### PR TITLE
Vellum audit — Phase 1: SCSS token cleanup (paused before Phase 2 for visual review)

### DIFF
--- a/src/ReactorSheet/styles/actions.scss
+++ b/src/ReactorSheet/styles/actions.scss
@@ -56,13 +56,13 @@
 // Buttons qualified with .rs-topbar to beat the `.reactor-sheet-app button`
 // reset (0,1,1) — same fix as .rs-tabrail .rs-tab (see shell.scss).
 .rs-topbar .rs-tb-btn {
-  display: inline-flex; align-items: center; gap: 6px;
+  display: inline-flex; align-items: center; gap: var(--spacer-2);
   background: transparent;
   border: 1px solid rgba(229, 222, 200, 0.18);
   color: var(--stamp-text-dim, #b5ad97);
   font-family: var(--sans); font-weight: 500;
   font-size: var(--fs-3xs, 10px); letter-spacing: 0.08em; text-transform: uppercase;
-  padding: 6px 11px 5px; border-radius: 5px; cursor: pointer;
+  padding: 6px 11px 5px; border-radius: var(--r-sm, 4px); cursor: pointer;
   white-space: nowrap; transition: color 0.12s, border-color 0.12s, background 0.12s;
 }
 .rs-topbar .rs-tb-btn:hover:not(:disabled) { color: var(--stamp-text, #e5dec8); border-color: rgba(229, 222, 200, 0.4); }
@@ -70,7 +70,7 @@
 .rs-topbar .rs-tb-btn.up { background: var(--gold); border-color: var(--gold); color: var(--on-accent, #070605); }
 .rs-topbar .rs-tb-btn.up:hover:not(:disabled) { background: var(--gold-dim, var(--gold)); }
 .rs-topbar .rs-tb-btn.icon { padding: 6px 8px; }
-.rs-topbar .rs-tb-btn .i { font-size: 12px; line-height: 1; }
+.rs-topbar .rs-tb-btn .i { font-size: var(--fs-xs, 12px); line-height: 1; }
 
 // --- header band ---
 // Grid areas let medium and rail arrange the same markup differently:
@@ -96,7 +96,7 @@
   inset: 0;
   width: 100%;
   height: 100%;
-  border-radius: 6px;
+  border-radius: var(--r-md, 6px);
   object-fit: cover;
   background: radial-gradient(circle at 50% 35%, #2c281f, #15130e);
   border: 2px solid var(--gold-dim);
@@ -141,7 +141,7 @@
   position: relative;
   background: var(--surface);
   border: 1px solid var(--border-soft, #2c2823);
-  border-radius: 7px;
+  border-radius: var(--r-md, 6px);
   padding: 6px 10px 8px;
   text-align: center;
 }
@@ -169,9 +169,9 @@
 .rs-vital .vv-step {
   display: inline-flex; align-items: center; justify-content: center;
   width: 18px; height: 18px;
-  border: 1px solid var(--border, #3a342c); border-radius: 4px;
+  border: 1px solid var(--border, #3a342c); border-radius: var(--r-sm, 4px);
   color: var(--text-dim, #b5ad97); cursor: pointer;
-  font-family: var(--sans); font-size: 13px; line-height: 1;
+  font-family: var(--sans); font-size: var(--fs-sm, 13px); line-height: 1;
   opacity: 0; transition: opacity 0.12s, border-color 0.12s, color 0.12s;
 }
 .rs-vital.hp:hover .vv-step,
@@ -185,7 +185,7 @@
   text-align: center;
   cursor: text;
   border: 1px solid transparent; // plain value until focused
-  border-radius: 4px;
+  border-radius: var(--r-sm, 4px);
   padding: 1px 0;
 }
 // active/edit: full crimson box + darker sunken bg around the value (prototype)
@@ -200,7 +200,7 @@
   grid-area: subs;
   align-self: start;
   display: flex;
-  gap: 6px;
+  gap: var(--spacer-2);
 }
 // borderless: just the stamp label + value, so HP/AC stay the only "boxes"
 .rs-tile {
@@ -232,7 +232,7 @@
   padding: var(--spacer-2) var(--spacer-2);
   background: var(--bg-2, #1f1c17);
   border: 1px solid var(--gold-soft);
-  border-radius: 8px;
+  border-radius: var(--r-lg, 10px);
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
   opacity: 0;
   visibility: hidden;
@@ -353,7 +353,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: var(--spacer-2);
   background: transparent;
   border: none;
   border-bottom: 2px solid transparent;
@@ -376,7 +376,7 @@
 .fvtt-save {
   background: var(--surface, #23201a);
   border: 1px solid var(--border-soft, #2c2823);
-  border-radius: 7px;
+  border-radius: var(--r-md, 6px);
   padding: var(--spacer-2) var(--spacer-1) 7px;
   text-align: center;
   transition: border-color 0.12s, background 0.12s;
@@ -387,7 +387,7 @@
 .fvtt-save .sk {
   width: 22px; height: 22px; margin: 0 auto var(--spacer-1);
   background: var(--ink, #070605); color: var(--stamp-text, #e5dec8);
-  border-radius: 4px; display: grid; place-items: center;
+  border-radius: var(--r-sm, 4px); display: grid; place-items: center;
   font-family: var(--display, serif); font-size: var(--fs-xs, 12px);
 }
 .fvtt-save .sv {
@@ -406,14 +406,14 @@
   display: flex; align-items: center; gap: var(--spacer-2);
   background: var(--surface, #23201a);
   border: 1px solid var(--border-soft, #2c2823);
-  border-radius: 7px;
+  border-radius: var(--r-md, 6px);
   padding: var(--spacer-2) var(--spacer-2) var(--spacer-2) var(--spacer-3);
   transition: border-color 0.12s, background 0.12s;
 }
 .fvtt-skill.rollable { cursor: pointer; }
 .fvtt-skill.rollable:hover { border-color: var(--gold); background: var(--surface-2, #2e2a23); }
 .fvtt-skill.rollable:focus-visible { outline: 2px solid var(--gold); outline-offset: -2px; }
-.fvtt-skill .skic { color: var(--gold-dim); font-size: 14px; width: 18px; text-align: center; flex: none; }
+.fvtt-skill .skic { color: var(--gold-dim); font-size: var(--fs-md, 14px); width: 18px; text-align: center; flex: none; }
 .fvtt-skill .skn {
   font-family: var(--sans); font-size: var(--fs-sm, 13px);
   color: var(--text-dim, #b5ad97); flex: 1; min-width: 0;
@@ -424,7 +424,7 @@
   font-family: var(--mono, monospace); font-size: var(--fs-xs, 12px);
   color: var(--text-mute, #8a8270);
   white-space: nowrap; flex: none;
-  i { color: var(--gold-dim); font-size: 12px; }
+  i { color: var(--gold-dim); font-size: var(--fs-xs, 12px); }
 }
 
 // --- memorized spells quick-cast (ported from .fvtt-castlist/.fvtt-spell) ---
@@ -439,9 +439,9 @@
 }
 // name + cast dots on one line (dots to the right of the name)
 .fvtt-spell .spn-row { display: inline-flex; align-items: baseline; gap: var(--spacer-2); }
-.fvtt-castlist .fvtt-spell:first-of-type { border-top: 1px solid var(--border-soft, #2c2823); border-radius: 7px 7px 0 0; }
+.fvtt-castlist .fvtt-spell:first-of-type { border-top: 1px solid var(--border-soft, #2c2823); border-radius: var(--r-md, 6px) var(--r-md, 6px) 0 0; }
 .fvtt-castlist .fvtt-spell:last-of-type { border-radius: 0 0 7px 7px; }
-.fvtt-castlist .fvtt-spell:only-of-type { border-radius: 7px; }
+.fvtt-castlist .fvtt-spell:only-of-type { border-radius: var(--r-md, 6px); }
 // cast dots — one per memorised slot (shared by Actions + Spells). Gold = a cast
 // remaining; light/soft = a used (spent) cast — used dots stay, they don't vanish.
 .sp-dots { display: inline-flex; align-items: center; gap: var(--spacer-1); }
@@ -502,18 +502,18 @@
 .rs-weapon {
   background: var(--surface, #23201a);
   border: 1px solid var(--border-soft, #2c2823);
-  border-radius: 8px;
+  border-radius: var(--r-lg, 10px);
   padding: 9px 10px;
 }
 .rs-weapon .winfo { display: flex; align-items: center; gap: var(--spacer-3); min-width: 0; }
 // ink-stamp monogram (or weapon art)
 .rs-weapon .wic {
   width: 34px; height: 34px; flex: 0 0 auto;
-  border-radius: 6px;
+  border-radius: var(--r-md, 6px);
   background: var(--ink, #070605);
   color: var(--gold);
   display: grid; place-items: center;
-  font-family: var(--display); font-size: 16px;
+  font-family: var(--display); font-size: var(--fs-lg, 16px);
   border: 1px solid var(--border, #3a342c);
 }
 .rs-weapon .wic-img { object-fit: cover; }
@@ -630,7 +630,7 @@
   padding: var(--spacer-1) var(--spacer-3);
   background: transparent;
   border: 1px solid var(--gold-soft);
-  border-radius: 6px;
+  border-radius: var(--r-md, 6px);
   color: var(--gold);
   font-family: var(--sans); font-size: var(--fs-3xs, 10px); font-weight: 600;
   letter-spacing: 0.08em; text-transform: uppercase;
@@ -682,7 +682,7 @@
   padding: 6px;
   background: var(--bg-2, #1f1c17);
   border: 1px solid var(--border, #3a342c);
-  border-radius: 7px;
+  border-radius: var(--r-md, 6px);
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.5);
   min-width: 130px;
 }
@@ -712,7 +712,7 @@
     gap: 1px;
     min-height: 76px;
     padding: 5px 4px 6px;
-    border-radius: 6px;
+    border-radius: var(--r-md, 6px);
   }
   .rs-vital .vv-l { font-size: var(--fs-2xs, 11px); padding: 4px 6px 3px; }
   .rs-vital .vv-big { font-size: var(--fs-3xl, 24px); }
@@ -724,7 +724,7 @@
   .rs-vital .vv-value { display: none; }
   .rs-vital .vv-input { display: inline-block; }
   // Init/HD/Move: borderless + small, three across (inherit the compact base)
-  .rs-substats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; }
+  .rs-substats { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--spacer-2); }
   .rs-tile { width: auto; }
   // attacks: keep the weapon card but tighten — icon-only tags, snug stat cells.
   .fvtt-tag .lbl { display: none; }

--- a/src/ReactorSheet/styles/inventory.scss
+++ b/src/ReactorSheet/styles/inventory.scss
@@ -95,7 +95,7 @@
 .rs-inv-img {
   display: inline-flex; align-items: center; justify-content: center;
   width: 30px; height: 30px;
-  border-radius: 4px; overflow: hidden;
+  border-radius: var(--r-sm, 4px); overflow: hidden;
   background: var(--ink, #070605);
   border: 1px solid var(--border, #3a342c);
   img { width: 100%; height: 100%; object-fit: cover; }
@@ -109,7 +109,7 @@
 .rs-inv .rs-inv-drag {
   display: inline-flex; align-items: center; justify-content: center;
   color: var(--text-faint, #6a6354);
-  cursor: grab; font-size: 12px; line-height: 1;
+  cursor: grab; font-size: var(--fs-xs, 12px); line-height: 1;
   padding: var(--spacer-1); border-radius: 3px;
   transition: color 0.12s;
   &:active { cursor: grabbing; }
@@ -121,9 +121,9 @@
 .rs-inv .rs-inv-equip {
   justify-self: center;
   display: inline-flex; align-items: center; justify-content: center;
-  width: 22px; height: 22px; padding: 0; border-radius: 4px;
+  width: 22px; height: 22px; padding: 0; border-radius: var(--r-sm, 4px);
   background: transparent; border: none; cursor: pointer;
-  color: var(--text-faint, #6a6354); font-size: 13px;
+  color: var(--text-faint, #6a6354); font-size: var(--fs-sm, 13px);
   transition: color 0.12s, background 0.12s;
   &:hover { color: var(--text-dim, #b5ad97); background: var(--surface-2, #2c2823); }
   &.is-on { color: var(--teal); }
@@ -185,7 +185,7 @@
   display: inline-flex; align-items: center; justify-content: center;
   background: transparent; border: none;
   color: var(--text-mute, #8a8270);
-  cursor: pointer; padding: 0 4px; font-size: 13px; line-height: 1;
+  cursor: pointer; padding: 0 4px; font-size: var(--fs-sm, 13px); line-height: 1;
   transition: color 0.12s;
 
   svg, i { transition: transform 0.18s; display: block; }
@@ -235,7 +235,7 @@
 }
 .rs-inv .rs-inv-qtyin {
   width: 100%; text-align: center;
-  padding: 2px 0; border-radius: 4px;
+  padding: 2px 0; border-radius: var(--r-sm, 4px);
   background: var(--surface, #23201a);
   border: 1px solid var(--border-soft, #2c2823); // always visible so it reads as a field
   color: var(--text-dim, #b5ad97);
@@ -276,7 +276,7 @@
 // The whole (collapsed) container is the nest drop target — dotted brass
 // outline (container = brass).
 .rs-inv-container.is-drop-target {
-  border-radius: 4px;
+  border-radius: var(--r-sm, 4px);
   outline: 2px dotted var(--accent-alt);
   outline-offset: -2px;
   background: color-mix(in oklab, var(--accent-alt) 9%, transparent);
@@ -317,7 +317,7 @@
   padding: var(--spacer-2) var(--spacer-2);
   background: var(--surface, #23201a);
   border: 1px solid var(--border, #3a342c);
-  border-radius: 6px;
+  border-radius: var(--r-md, 6px);
   color: var(--text, #e5dec8);
   font-family: var(--mono); font-size: var(--fs-md, 15px);
   transition: border-color 0.12s;
@@ -363,7 +363,7 @@
 
 // --- Equipped tray: dashed-bordered row of large ink-stamp tiles ---
 .rs-equip-tray {
-  display: flex; flex-wrap: wrap; gap: 9px; align-items: flex-start;
+  display: flex; flex-wrap: wrap; gap: var(--spacer-2); align-items: flex-start;
   padding: var(--spacer-3);
   border: 1.5px dashed var(--border-soft, #2c2823); border-radius: var(--r-md, 6px);
   transition: border-color 0.12s, background 0.12s;
@@ -455,7 +455,7 @@
   position: fixed; z-index: 1000; min-width: 168px;
   padding: var(--spacer-1);
   background: var(--surface, #23201a);
-  border: 1px solid var(--border, #3a342c); border-radius: 6px;
+  border: 1px solid var(--border, #3a342c); border-radius: var(--r-md, 6px);
   box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45);
 }
 .rs-ctx-title {
@@ -467,7 +467,7 @@
 }
 .rs-inv .rs-ctx-item {
   display: flex; align-items: center; gap: var(--spacer-2); width: 100%;
-  padding: var(--spacer-2); border-radius: 4px;
+  padding: var(--spacer-2); border-radius: var(--r-sm, 4px);
   background: transparent; border: none; cursor: pointer; text-align: left;
   font-family: var(--sans); font-size: var(--fs-sm, 13px);
   color: var(--text, #e5dec8);

--- a/src/ReactorSheet/styles/minibar.scss
+++ b/src/ReactorSheet/styles/minibar.scss
@@ -46,7 +46,7 @@
   flex: 0 0 auto;
   width: 32px;
   height: 32px;
-  border-radius: 4px;
+  border-radius: var(--r-sm, 4px);
   object-fit: cover;
   border: 1px solid var(--border-soft, #2c2823);
 }
@@ -87,7 +87,7 @@
   gap: var(--spacer-1);
   padding: 3px var(--spacer-2);
   border: 1px solid var(--border-soft, #2c2823);
-  border-radius: 6px;
+  border-radius: var(--r-md, 6px);
   background: var(--surface);
 }
 .rs-mb-hp { border-color: color-mix(in srgb, var(--crimson) 55%, transparent); }
@@ -109,7 +109,7 @@
   font-size: var(--fs-md, 15px);
   color: var(--crimson);
   border: 1px solid transparent;
-  border-radius: 4px;
+  border-radius: var(--r-sm, 4px);
   padding: 0 1px;
 }
 .rs-mb-hp-input:focus { border-color: var(--crimson); background: var(--bg, #181612); }

--- a/src/ReactorSheet/styles/shell.scss
+++ b/src/ReactorSheet/styles/shell.scss
@@ -82,7 +82,7 @@
 }
 .rs-tab .rs-tab-ic {
   writing-mode: horizontal-tb;
-  font-size: 14px;
+  font-size: var(--fs-md, 14px);
   color: var(--gold-dim, var(--gold));
   transform: rotate(180deg);
 }
@@ -127,7 +127,7 @@
   transition: color 0.12s;
 }
 .rs-bottombar .rs-botbtn-ic {
-  font-size: 16px;
+  font-size: var(--fs-lg, 16px);
   color: var(--gold-dim, var(--gold));
   line-height: 1;
 }
@@ -214,7 +214,7 @@
     width: auto;
     background: var(--surface);
     border: 1px solid var(--border-soft, #2c2823);
-    border-radius: 6px;
+    border-radius: var(--r-md, 6px);
     padding: 5px 6px var(--spacer-1); // 5px optical top, 6px optical sides, 4px bottom
   }
   .rs-twopane .rs-tile .stamp { font-size: var(--fs-2xs, 11px); padding: 5px 8px 3px; }
@@ -249,7 +249,7 @@
     cursor: pointer;
     transition: color 0.12s, border-color 0.12s;
   }
-  .rs-htab .rs-htab-ic { color: var(--gold-dim, var(--gold)); font-size: 13px; }
+  .rs-htab .rs-htab-ic { color: var(--gold-dim, var(--gold)); font-size: var(--fs-sm, 13px); }
   .rs-htab .rs-htab-ct {
     font-family: var(--mono);
     font-size: var(--fs-3xs, 10px);

--- a/src/ReactorSheet/styles/styles.scss
+++ b/src/ReactorSheet/styles/styles.scss
@@ -22,7 +22,7 @@
   // --- titlebar: near-black to match the top-bar, design-system font ---
   .window-header {
     background: var(--ink, #070605);
-    border-bottom: 1px solid #000;
+    border-bottom: 1px solid var(--ink, #070605);
   }
   .window-title {
     font-family: var(--display); // IM Fell English SC — chiseled small-caps

--- a/src/ReactorSheet/styles/vellum/components.css
+++ b/src/ReactorSheet/styles/vellum/components.css
@@ -15,7 +15,7 @@
 .field-label {
   font-family: var(--sans);
   font-weight: 500;
-  font-size: 11px;
+  font-size: var(--fs-2xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-dim);
@@ -23,13 +23,13 @@
 .field-hint {
   font-family: var(--serif);
   font-style: italic;
-  font-size: 12px;
+  font-size: var(--fs-xs);
   color: var(--text-mute);
   line-height: 1.4;
 }
 .field-error {
   font-family: var(--sans);
-  font-size: 11.5px;
+  font-size: var(--fs-2xs);
   color: var(--crimson);
 }
 
@@ -40,7 +40,7 @@
   border: 1px solid var(--border);
   color: var(--text);
   font-family: var(--sans);
-  font-size: 13.5px;
+  font-size: var(--fs-sm);
   padding: 8px 10px;
   border-radius: var(--r-sm);
   outline: none;
@@ -73,7 +73,7 @@
 
 .textarea {
   font-family: var(--serif);
-  font-size: 14px;
+  font-size: var(--fs-md);
   line-height: 1.55;
   min-height: 110px;
   resize: vertical;
@@ -108,7 +108,7 @@
   border: none;
   color: var(--text-dim);
   font-family: var(--mono);
-  font-size: 14px;
+  font-size: var(--fs-md);
   width: 28px;
   cursor: pointer;
   padding: 0;
@@ -121,7 +121,7 @@
   border-right: 1px solid var(--border);
   color: var(--text);
   font-family: var(--mono);
-  font-size: 13px;
+  font-size: var(--fs-sm);
   text-align: center;
   width: 52px;
   outline: none;
@@ -137,7 +137,7 @@
   cursor: pointer;
   user-select: none;
   font-family: var(--sans);
-  font-size: 13px;
+  font-size: var(--fs-sm);
   color: var(--text);
 }
 .toggle input { position: absolute; opacity: 0; pointer-events: none; }
@@ -177,7 +177,7 @@
   cursor: pointer;
   user-select: none;
   font-family: var(--sans);
-  font-size: 13px;
+  font-size: var(--fs-sm);
   color: var(--text);
 }
 .check input, .radio input { position: absolute; opacity: 0; pointer-events: none; }
@@ -196,7 +196,7 @@
 .check input:checked + .box::after {
   content: "✓";
   color: var(--on-accent);
-  font-size: 11px;
+  font-size: var(--fs-2xs);
   font-weight: 700;
   line-height: 1;
 }
@@ -233,7 +233,7 @@
   color: var(--text-mute);
   font-family: var(--sans);
   font-weight: 500;
-  font-size: 11px;
+  font-size: var(--fs-2xs);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   padding: 6px 12px;
@@ -263,7 +263,7 @@
   gap: 10px;
   padding: 8px 12px;
   font-family: var(--sans);
-  font-size: 13px;
+  font-size: var(--fs-sm);
   color: var(--text);
   cursor: pointer;
   transition: background 0.1s;
@@ -274,13 +274,13 @@
   width: 14px;
   color: var(--text-mute);
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: var(--fs-xs);
   text-align: center;
 }
 .menu-item .shortcut {
   margin-left: auto;
   font-family: var(--mono);
-  font-size: 10.5px;
+  font-size: var(--fs-3xs);
   color: var(--text-faint);
   letter-spacing: 0.04em;
 }
@@ -293,7 +293,7 @@
   padding: 6px 12px 3px;
   font-family: var(--sans);
   font-weight: 600;
-  font-size: 10px;
+  font-size: var(--fs-3xs);
   text-transform: uppercase;
   letter-spacing: 0.1em;
   color: var(--text-faint);
@@ -349,7 +349,7 @@
   background: oklch(0 0 0 / 0.4);
   color: var(--stamp-text);
   font-family: var(--display);
-  font-size: 18px;
+  font-size: var(--fs-xl);
   line-height: 1;
   border: 0;
   outline: 0;
@@ -407,7 +407,7 @@
   border: 1px solid var(--border-soft);
   border-radius: 999px;
   font-family: var(--mono);
-  font-size: 10.5px;
+  font-size: var(--fs-3xs);
   color: var(--text-dim);
   letter-spacing: 0.02em;
   line-height: 1.3;
@@ -416,7 +416,7 @@
 .tag.crimson { color: var(--crimson); border-color: var(--crimson); background: color-mix(in oklab, var(--crimson) 10%, transparent); }
 .tag.forest  { color: var(--forest);  border-color: var(--forest);  background: color-mix(in oklab, var(--forest) 12%, transparent); }
 .tag.mustard { color: var(--mustard); border-color: var(--mustard); background: color-mix(in oklab, var(--mustard) 12%, transparent); }
-.tag.solid   { background: var(--ink); color: var(--stamp-text); border-color: var(--ink); font-family: var(--display); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; padding: 4px 10px 2px; }
+.tag.solid   { background: var(--ink); color: var(--stamp-text); border-color: var(--ink); font-family: var(--display); font-size: var(--fs-2xs); letter-spacing: 0.08em; text-transform: uppercase; padding: 4px 10px 2px; }
 
 /* ─── Modal / Dialog ────────────────────────────────────────────────── */
 
@@ -452,7 +452,7 @@
 }
 .modal-head .ttl {
   font-family: var(--display);
-  font-size: 22px;
+  font-size: var(--fs-2xl);
   letter-spacing: 0.02em;
   color: var(--text);
   flex: 1;
@@ -461,7 +461,7 @@
   background: transparent;
   border: none;
   color: var(--text-mute);
-  font-size: 18px;
+  font-size: var(--fs-xl);
   cursor: pointer;
   padding: 0;
   width: 24px;
@@ -474,7 +474,7 @@
   padding: 18px 22px;
   overflow-y: auto;
   font-family: var(--serif);
-  font-size: 14px;
+  font-size: var(--fs-md);
   color: var(--text-dim);
   line-height: 1.55;
 }
@@ -537,14 +537,14 @@
 .toast .x { flex: none; }
 .toast .ttl {
   font-family: var(--display);
-  font-size: 14px;
+  font-size: var(--fs-md);
   letter-spacing: 0.02em;
   color: var(--text);
   line-height: 1.2;
 }
 .toast .msg {
   font-family: var(--serif);
-  font-size: 12.5px;
+  font-size: var(--fs-xs);
   color: var(--text-dim);
   margin-top: 2px;
   line-height: 1.4;
@@ -553,7 +553,7 @@
   background: transparent;
   border: none;
   color: var(--text-faint);
-  font-size: 14px;
+  font-size: var(--fs-md);
   cursor: pointer;
   padding: 0;
   line-height: 1;
@@ -582,14 +582,14 @@
 }
 .empty .ttl {
   font-family: var(--display);
-  font-size: 17px;
+  font-size: var(--fs-lg);
   color: var(--text-dim);
   margin-bottom: 4px;
 }
 .empty .msg {
   font-family: var(--serif);
   font-style: italic;
-  font-size: 13px;
+  font-size: var(--fs-sm);
   color: var(--text-mute);
   max-width: 36ch;
   margin: 0 auto 12px;
@@ -626,7 +626,7 @@
   background: var(--ink);
   color: var(--stamp-text);
   font-family: var(--display);
-  font-size: 11px;
+  font-size: var(--fs-2xs);
   letter-spacing: 0.10em;
   text-transform: uppercase;
   padding: 9px 12px;
@@ -636,12 +636,12 @@
 .table tbody td {
   padding: 9px 12px;
   font-family: var(--serif);
-  font-size: 13.5px;
+  font-size: var(--fs-sm);
   color: var(--text);
   border-top: 1px solid var(--border-soft);
 }
 .table tbody tr:first-child td { border-top: none; }
 .table tbody tr:nth-child(even) td { background: color-mix(in oklab, var(--surface-2) 60%, transparent); }
 .table tbody tr:hover td { background: var(--surface-2); }
-.table td.num, .table th.num { font-family: var(--mono); font-size: 12px; text-align: right; }
+.table td.num, .table th.num { font-family: var(--mono); font-size: var(--fs-xs); text-align: right; }
 .table td.dim { color: var(--text-mute); }


### PR DESCRIPTION
Implements **Phase 1** of `docs/vellum-system-audit.md`. Phases 2–3 are intentionally **not** in this PR — see "Paused for visual review" below.

## What's in here (Phase 1 — mechanical, low-risk)

Verified green: `pnpm build` ✓ · `pnpm lint` ✓ · `pnpm test` (58) ✓

**`vellum/components.css`** — replaced every hardcoded px `font-size` with the nearest `--fs-*` token (the file's own rule is "always use `--fs-*`", which it was contradicting). Ties round **down** (e.g. `17px → --fs-lg`, `12.5px → --fs-xs`). Most are exact equivalents at the 16px root (`14px == --fs-md`, etc.), so rendering is unchanged.

**`actions.scss` / `inventory.scss` / `minibar.scss` / `shell.scss`**
- Radius literals → `--r-*` per the locked mapping (`5→sm`, `7→md`, `8→lg`, bare `4→sm`, `6→md`). Pill/circle radii (`99px`/`999px`) and sub-scale radii (`2px`/`3px`) left as-is — they're below the `--r-*` floor.
- Exact-equivalent px `font-size`s → `var(--fs-*, Npx)` (matches the file's existing token-with-fallback convention; **no** render change).
- Ad-hoc `6/8/9px` gaps → `--spacer-2`.

**`styles.scss`** — `#000` titlebar border → `--ink` (preserves the near-black hairline; `#000 ≈ --ink` `#070605`).

### Two notes / deviations from the literal plan
- **`--gold-bright` dedupe (Phase 1.3): already satisfied.** There's no live duplicate — `tokens.css` defines the base and `styles.scss` overrides it for the hireling kind; that's a base + theme override, not a redefinition. Nothing to remove.
- **Three sub-10px glyph sizes left as px** (`actions.scss` `8px`, `inventory.scss` `8px` caret / `9px` icon). The `--fs-*` scale floors at `10px`, so snapping them would be a visible ~+25% size change on decorative carets/icons rather than a no-op. Deferred to the Phase 3 stylelint work (they'll get a scoped exemption rather than a wrong rounding).

## Paused for visual review (Phases 2–3)

Per the plan, **Phase 2 (component-vocabulary convergence) is the "look-and-feel win" that needs local visual QA** — and this cloud session has no browser/Foundry to verify against. I had an architect review pressure-test whether a "faithful, no-visual-change subset" of Phase 2 could land safely here. Conclusion: **no**, and carving one off would *add* risk. Reasons:

1. **Most "hand-rolled buttons" are composite domain widgets, not buttons-in-disguise** — `.wstat` (two-line label/value + tooltip), `.fvtt-atk`/`.kind-seg` (segmented attack switch), `.sp-cast` (aria-busy spinner + "spent" state), and the tab rails (vertical writing-mode navigation). Flattening these into the generic `.btn` primitive would break their layout, not converge them. They should stay bespoke.
2. **The heading + tag convergence is genuinely visual** — e.g. routing the tiny uppercase `.rs-inv-sec-title`/`.rs-spellhead` labels through the big IM Fell `<SectionTitle>` is a real restyle, not a refactor. Needs eyes.
3. **⚠️ Latent correctness finding (worth a look regardless of Phase 2):** the `ui/Button`/`Tag` primitives emit a bare `.btn`/`.tag` (specificity `0,1,0`), but `.reactor-sheet-app button { all: unset }` (`0,1,1`, and imported **last**) out-specifies them. Every working live button dodges this with a qualified `.reactor-sheet-app .x` selector. The `ui/` primitives are currently **only used in Storybook** (no `.reactor-sheet-app` ancestor there), so they've never actually rendered in-app and would be stripped by the reset if used as-is. **Phase 2 should start by qualifying the primitives above the reset** — otherwise the convergence lands broken in ways `pnpm build` can't catch.

### Suggested next step
I'll implement Phase 2 as a single coherent branch (sequenced buttons → headings → tags, starting with the primitive/reset fix), then push it for you to `pnpm dev` and eyeball before it merges. Phase 3 guardrails (stylelint/eslint/CLAUDE.md) follow once the converged vocabulary is settled — and they need new tooling (stylelint) plus care around the heavy `var(--token, #hexfallback)` convention, so they're better designed against the final state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FGrGmaj67NfFeLPnbmSHC

---
_Generated by [Claude Code](https://claude.ai/code/session_019FGrGmaj67NfFeLPnbmSHC)_