### PR TITLE
Vellum audit — Phase 2: component-vocabulary convergence (buttons · headings · tags)

### DIFF
--- a/src/ReactorSheet/components/SheetPages/Abilities/FeatureCard.tsx
+++ b/src/ReactorSheet/components/SheetPages/Abilities/FeatureCard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import type { FeatureVM } from "../../../viewModels/features";
 import { useReactorSheetContext } from "../../context";
 import { cx } from "../../ui/cx";
+import { IconButton } from "../../ui/IconButton";
 
 /** Enrich raw HTML once via Foundry's TextEditor (links, inline rolls, embeds). */
 function useEnriched(html: string): string {
@@ -79,9 +80,7 @@ export function FeatureCard({ feature }: { feature: FeatureVM }) {
             </div>
           )}
         </div>
-        <button
-          type="button"
-          className="ft-chev"
+        <IconButton
           aria-expanded={open}
           aria-label={open ? "Collapse" : "Expand"}
           onClick={(e) => {
@@ -90,7 +89,7 @@ export function FeatureCard({ feature }: { feature: FeatureVM }) {
           }}
         >
           {open ? "▾" : "▸"}
-        </button>
+        </IconButton>
       </div>
       {open && (
         <div className="ft-body">
@@ -99,14 +98,14 @@ export function FeatureCard({ feature }: { feature: FeatureVM }) {
             dangerouslySetInnerHTML={{ __html: desc }}
           />
           <div className="ft-actions">
-            <button
-              type="button"
-              className="ft-del"
+            <IconButton
+              variant="danger"
               title="Delete ability"
+              aria-label="Delete ability"
               onClick={feature.onDelete}
             >
               <i className="fas fa-trash" aria-hidden="true" />
-            </button>
+            </IconButton>
           </div>
         </div>
       )}

--- a/src/ReactorSheet/components/SheetPages/Abilities/LanguagesSection.tsx
+++ b/src/ReactorSheet/components/SheetPages/Abilities/LanguagesSection.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { useReactorSheetContext } from "../../context";
 import { SectionTitle } from "../../ui/SectionTitle";
+import { IconButton } from "../../ui/IconButton";
 import { cx } from "../../ui/cx";
 
 /** INT literacy/spoken mods resolve to localized labels on the actor; compose a flavour line. */
@@ -54,9 +55,9 @@ export function LanguagesSection({ editing: forced }: { editing?: boolean }) {
       <div className="rs-feat-head">
         <SectionTitle>Languages</SectionTitle>
         {!forced && (
-          <button
-            type="button"
-            className={cx("rs-feat-add", editing && "on")}
+          <IconButton
+            variant="accent"
+            on={editing}
             title={editing ? "Done editing languages" : "Edit languages"}
             aria-label={editing ? "Done editing languages" : "Edit languages"}
             aria-pressed={editing}
@@ -66,7 +67,7 @@ export function LanguagesSection({ editing: forced }: { editing?: boolean }) {
               className={cx("fas", editing ? "fa-check" : "fa-pen")}
               aria-hidden="true"
             />
-          </button>
+          </IconButton>
         )}
       </div>
 
@@ -113,16 +114,15 @@ export function LanguagesSection({ editing: forced }: { editing?: boolean }) {
               <option key={l} value={l} />
             ))}
           </datalist>
-          <button
-            type="button"
-            className="rs-lang-go"
+          <IconButton
+            variant="round"
             title="Add language"
             aria-label="Add language"
             disabled={!draft.trim()}
             onClick={() => add(draft)}
           >
             <i className="fas fa-plus" aria-hidden="true" />
-          </button>
+          </IconButton>
         </div>
       )}
 

--- a/src/ReactorSheet/components/SheetPages/Abilities/LanguagesSection.tsx
+++ b/src/ReactorSheet/components/SheetPages/Abilities/LanguagesSection.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { useReactorSheetContext } from "../../context";
 import { SectionTitle } from "../../ui/SectionTitle";
 import { IconButton } from "../../ui/IconButton";
+import { Tag } from "../../ui/Tag";
 import { cx } from "../../ui/cx";
 
 /** INT literacy/spoken mods resolve to localized labels on the actor; compose a flavour line. */
@@ -76,7 +77,7 @@ export function LanguagesSection({ editing: forced }: { editing?: boolean }) {
           <span className="rs-langs-empty">None</span>
         )}
         {current.map((lang) => (
-          <span key={lang} className="rs-lang">
+          <Tag key={lang}>
             {lang}
             {editing && (
               <button
@@ -89,7 +90,7 @@ export function LanguagesSection({ editing: forced }: { editing?: boolean }) {
                 <i className="fas fa-xmark" aria-hidden="true" />
               </button>
             )}
-          </span>
+          </Tag>
         ))}
       </div>
 

--- a/src/ReactorSheet/components/SheetPages/Abilities/index.tsx
+++ b/src/ReactorSheet/components/SheetPages/Abilities/index.tsx
@@ -1,6 +1,7 @@
 import { useReactorSheetContext } from "../../context";
 import { selectFeatures } from "../../../viewModels/features";
 import { SectionTitle } from "../../ui/SectionTitle";
+import { IconButton } from "../../ui/IconButton";
 import { createAbility } from "./createAbility";
 import { FeatureCard } from "./FeatureCard";
 import { LanguagesSection } from "./LanguagesSection";
@@ -18,15 +19,14 @@ export default function Abilities() {
       <section className="rs-section rs-feat-sec">
         <div className="rs-feat-head">
           <SectionTitle>Abilities</SectionTitle>
-          <button
-            type="button"
-            className="rs-feat-add"
+          <IconButton
+            variant="accent"
             title="Add ability"
             aria-label="Add ability"
             onClick={onAdd}
           >
             <i className="fas fa-plus" aria-hidden="true" />
-          </button>
+          </IconButton>
         </div>
         {features.length === 0 ? (
           <p className="rs-flavour">No abilities yet.</p>

--- a/src/ReactorSheet/components/chrome/Minibar.tsx
+++ b/src/ReactorSheet/components/chrome/Minibar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import type { IdentityVM, VitalsVM } from "../../viewModels/types";
+import { Stamp } from "../ui/Stamp";
 
 type Props = {
   identity: IdentityVM;
@@ -51,7 +52,21 @@ export function Minibar({ identity, vitals, onSetHp }: Props) {
       </div>
       <div className="rs-mb-vitals">
         <div className="rs-mb-hp">
-          <span className="rs-mb-stamp">HP</span>
+          {/* hover swaps label/max → −/+ steppers; grid-stacked so width never shifts */}
+          <span className="rs-mb-hp-slot">
+            <Stamp className="rs-mb-stamp">HP</Stamp>
+            {onSetHp && (
+              <button
+                type="button"
+                className="rs-mb-hp-btn"
+                aria-label="Decrease HP"
+                tabIndex={-1}
+                onClick={() => onSetHp(Math.max(0, vitals.hp.value - 1))}
+              >
+                −
+              </button>
+            )}
+          </span>
           {onSetHp ? (
             <input
               className="rs-mb-hp-input"
@@ -77,10 +92,23 @@ export function Minibar({ identity, vitals, onSetHp }: Props) {
           ) : (
             <span className="rs-mb-hp-input rs-mb-hp-static">{vitals.hp.value}</span>
           )}
-          <span className="rs-mb-hp-max">/{vitals.hp.max}</span>
+          <span className="rs-mb-hp-slot">
+            <span className="rs-mb-hp-max">/{vitals.hp.max}</span>
+            {onSetHp && (
+              <button
+                type="button"
+                className="rs-mb-hp-btn"
+                aria-label="Increase HP"
+                tabIndex={-1}
+                onClick={() => onSetHp(Math.min(vitals.hp.max, vitals.hp.value + 1))}
+              >
+                +
+              </button>
+            )}
+          </span>
         </div>
         <div className="rs-mb-ac">
-          <span className="rs-mb-stamp">AC</span>
+          <Stamp className="rs-mb-stamp">AC</Stamp>
           <span className="rs-mb-ac-v">{vitals.ac.ascending}</span>
         </div>
       </div>

--- a/src/ReactorSheet/components/inventory/InventoryViewDnd.tsx
+++ b/src/ReactorSheet/components/inventory/InventoryViewDnd.tsx
@@ -20,6 +20,7 @@ import type {
 import { sortInventory, SORT_DEFAULT_DIR } from "../../viewModels/inventory";
 import { useDragReorder } from "./useDragReorder";
 import { SectionTitle } from "../ui/SectionTitle";
+import { Tag } from "../ui/Tag";
 import { cx } from "../ui/cx";
 
 type Dnd = ReturnType<typeof useDragReorder>;
@@ -268,7 +269,7 @@ function ContainerRow({
           <i className="fa-solid fa-grip-lines" />
         </span>
         <ItemImage item={item} />
-        <NameCell item={item} onOpen={onOpen} badge={<span className="rs-inv-count">{count}</span>} trailing={caret} />
+        <NameCell item={item} onOpen={onOpen} badge={<Tag intent="count">{count}</Tag>} trailing={caret} />
         <span className="rs-inv-rowcat">{item.category}</span>
         <span className="rs-inv-wt">{weightLabel(item.weight)}</span>
         <RowEquip item={item} onEquip={onEquip} />
@@ -393,7 +394,7 @@ function EncumbranceBar({ e }: { e: EncumbranceVM }) {
 function SectionCount({ title, items }: { title: string; items: InventoryItemVM[] }) {
   return (
     <div className="rs-inv-sec-head">
-      <span className="rs-inv-sec-title">{title}</span>
+      <SectionTitle variant="sub">{title}</SectionTitle>
       <span className="rs-inv-sec-count">{sectionCountLabel(items)}</span>
     </div>
   );

--- a/src/ReactorSheet/components/spells/SpellCastRow.tsx
+++ b/src/ReactorSheet/components/spells/SpellCastRow.tsx
@@ -1,6 +1,7 @@
 import { useState, type ReactNode } from "react";
 import type { OseSpell } from "../../types/types";
 import { cx } from "../ui/cx";
+import { IconButton } from "../ui/IconButton";
 
 type Props = {
   spell: OseSpell;
@@ -55,15 +56,15 @@ export function SpellCastRow({ spell, meta, onCast, onUnprepare, onOpenName, row
             ))}
           </span>
           {onUnprepare && (
-            <button
-              type="button"
-              className="sp-trash"
+            <IconButton
+              variant="danger"
+              size="sm"
               onClick={onUnprepare}
               title={`Remove ${spell.name}`}
               aria-label={`Remove ${spell.name}`}
             >
               <i className="fa-solid fa-trash-can" aria-hidden="true" />
-            </button>
+            </IconButton>
           )}
         </span>
         <span className="spm">{meta}</span>

--- a/src/ReactorSheet/components/ui/IconButton.stories.tsx
+++ b/src/ReactorSheet/components/ui/IconButton.stories.tsx
@@ -1,0 +1,29 @@
+import { IconButton } from "./IconButton";
+
+export default { title: "Controls / IconButton" };
+
+export const Variants = () => (
+  <div style={{ display: "flex", gap: 12, alignItems: "center", flexWrap: "wrap" }}>
+    <IconButton title="Default" aria-label="Default">
+      <i className="fa-solid fa-pen" aria-hidden="true" />
+    </IconButton>
+    <IconButton variant="danger" title="Delete" aria-label="Delete">
+      <i className="fa-solid fa-trash" aria-hidden="true" />
+    </IconButton>
+    <IconButton variant="accent" title="Add" aria-label="Add">
+      <i className="fa-solid fa-plus" aria-hidden="true" />
+    </IconButton>
+    <IconButton variant="accent" on title="Editing" aria-label="Editing">
+      <i className="fa-solid fa-check" aria-hidden="true" />
+    </IconButton>
+    <IconButton variant="round" title="Add language" aria-label="Add language">
+      <i className="fa-solid fa-plus" aria-hidden="true" />
+    </IconButton>
+    <IconButton size="sm" variant="danger" title="Remove" aria-label="Remove">
+      <i className="fa-solid fa-xmark" aria-hidden="true" />
+    </IconButton>
+    <IconButton disabled title="Disabled" aria-label="Disabled">
+      <i className="fa-solid fa-plus" aria-hidden="true" />
+    </IconButton>
+  </div>
+);

--- a/src/ReactorSheet/components/ui/IconButton.tsx
+++ b/src/ReactorSheet/components/ui/IconButton.tsx
@@ -1,0 +1,24 @@
+import { cx } from "./cx";
+import type { ButtonHTMLAttributes } from "react";
+
+type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
+  /** Hover/intent treatment. Default = neutral (faint → text-dim). */
+  variant?: "danger" | "accent" | "round";
+  /** Compact 18px box for inline carets / × / trash glyphs. */
+  size?: "sm";
+  /** Toggled/active state (e.g. an edit-mode pen). */
+  on?: boolean;
+};
+
+/**
+ * Icon-only button — a transparent square wrapping a single glyph (FontAwesome
+ * `<i>` or a character). The canonical replacement for the hand-rolled
+ * `.ft-chev` / `.ft-del` / `.rs-feat-add` / `.rs-lang-go` / `.sp-trash` one-offs.
+ * Styling lives in `.icon-btn` (components.css), which is auto-scoped under
+ * `.reactor-sheet` so it beats the `.reactor-sheet-app button` reset.
+ */
+export function IconButton({ variant, size, on, className, type = "button", ...rest }: Props) {
+  return (
+    <button type={type} className={cx("icon-btn", variant, size, on && "on", className)} {...rest} />
+  );
+}

--- a/src/ReactorSheet/components/ui/Modal.tsx
+++ b/src/ReactorSheet/components/ui/Modal.tsx
@@ -1,4 +1,5 @@
 import { cx } from "./cx";
+import { SectionTitle } from "./SectionTitle";
 import type { ReactNode } from "react";
 
 type Props = {
@@ -16,7 +17,7 @@ export function Modal({ open, title, onClose, children, footer, className }: Pro
     <div className="modal-scrim" onClick={onClose}>
       <div className={cx("modal", className)} onClick={(e) => e.stopPropagation()}>
         <div className="modal-head">
-          <span className="ttl">{title}</span>
+          <SectionTitle variant="bare" className="ttl">{title}</SectionTitle>
           <button type="button" className="x" aria-label="Close" onClick={onClose}>
             ×
           </button>

--- a/src/ReactorSheet/components/ui/SectionTitle.tsx
+++ b/src/ReactorSheet/components/ui/SectionTitle.tsx
@@ -1,11 +1,19 @@
 import { cx } from "./cx";
 import type { HTMLAttributes, ReactNode } from "react";
 
-type Props = HTMLAttributes<HTMLHeadingElement> & { hint?: ReactNode };
+type Props = HTMLAttributes<HTMLHeadingElement> & {
+  hint?: ReactNode;
+  /**
+   * `sub` — small uppercase sans label for sub-section heads (e.g. inventory
+   * "Equipped" / "All Items"). `bare` — keeps the display type but drops the
+   * rule + margins, for embedded heads like a modal title.
+   */
+  variant?: "sub" | "bare";
+};
 
-export function SectionTitle({ hint, children, className, ...rest }: Props) {
+export function SectionTitle({ hint, variant, children, className, ...rest }: Props) {
   return (
-    <h3 className={cx("section-title", className)} {...rest}>
+    <h3 className={cx("section-title", variant, className)} {...rest}>
       {children}
       {hint != null && <span className="hint">{hint}</span>}
     </h3>

--- a/src/ReactorSheet/components/ui/Tag.tsx
+++ b/src/ReactorSheet/components/ui/Tag.tsx
@@ -2,7 +2,7 @@ import { cx } from "./cx";
 import type { HTMLAttributes } from "react";
 
 type Props = HTMLAttributes<HTMLSpanElement> & {
-  intent?: "teal" | "crimson" | "forest" | "mustard" | "solid";
+  intent?: "teal" | "crimson" | "forest" | "mustard" | "solid" | "count";
 };
 
 export function Tag({ intent, className, ...rest }: Props) {

--- a/src/ReactorSheet/components/ui/index.ts
+++ b/src/ReactorSheet/components/ui/index.ts
@@ -1,6 +1,7 @@
 export { cx } from "./cx";
 export { Stamp } from "./Stamp";
 export { Button } from "./Button";
+export { IconButton } from "./IconButton";
 export { Tag } from "./Tag";
 export { SectionTitle } from "./SectionTitle";
 export { Card, KvCard } from "./Card";

--- a/src/ReactorSheet/styles/actions.scss
+++ b/src/ReactorSheet/styles/actions.scss
@@ -134,7 +134,9 @@
   align-self: start;
   width: 184px;
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  // minmax(0,…) so a wide value can't auto-expand a track past its share and
+  // shove the sibling card out of the container.
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: var(--spacer-2);
 }
 .rs-vital {
@@ -165,6 +167,9 @@
 }
 .rs-vital .vv-sub .short { display: none; } // full label by default; short shows at XS
 .rs-vital .vv-row { display: flex; align-items: center; justify-content: center; gap: var(--spacer-2); }
+// Reserve width for up to 3 digits so the value's digit count never shifts the
+// flanking − / + steppers as HP changes. tabular-nums keeps digit widths uniform.
+.rs-vital .vv-value { min-width: 1.2em; text-align: center; font-variant-numeric: tabular-nums; }
 // medium+: − / + steppers revealed on hover
 .rs-vital .vv-step {
   display: inline-flex; align-items: center; justify-content: center;

--- a/src/ReactorSheet/styles/features.scss
+++ b/src/ReactorSheet/styles/features.scss
@@ -62,13 +62,7 @@
   &:focus-visible { outline: 2px solid var(--gold); outline-offset: 1px; }
 }
 
-.reactor-sheet-app .ft-chev {
-  flex: none; width: 16px; text-align: center; cursor: pointer;
-  background: none; border: none;
-  color: var(--text-faint, #6a6354); font-size: var(--fs-2xs, 11px);
-  &:hover { color: var(--text-dim, #b5ad97); }
-  &:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
-}
+// (chevron is now <IconButton>; see .icon-btn in components.css)
 
 // Body indented under the title (past the 40px stamp + gap).
 .ft-body { padding: 0 var(--spacer-3) var(--spacer-3) 62px; }
@@ -84,13 +78,7 @@
   gap: var(--spacer-3);
   margin-top: var(--spacer-2);
 }
-.reactor-sheet-app .ft-del {
-  background: none; border: none; cursor: pointer;
-  color: var(--text-mute, #8a8270);
-  font-size: var(--fs-sm, 13px);
-  transition: color 0.12s;
-  &:hover { color: var(--crimson, #c75044); }
-}
+// (delete is now <IconButton variant="danger">; see .icon-btn in components.css)
 
 // --- Section header: title + hint on the left, + / edit button on the right ---
 // Mirrors .rs-inv-head so the rule spans the full width and the title flexes.
@@ -102,37 +90,8 @@
 }
 .rs-feat-head .section-title { flex: 1; }
 
-// Language "go" button keeps the round brass-outline affordance.
-.reactor-sheet-app .rs-lang-go {
-  flex: none;
-  display: grid; place-items: center;
-  width: 26px; height: 26px;
-  border-radius: 999px;
-  background: none;
-  border: 1px solid var(--accent-alt);
-  color: var(--accent-alt);
-  cursor: pointer;
-  font-size: var(--fs-2xs, 11px);
-  transition: background 0.12s, color 0.12s, border-color 0.12s;
-  &:hover:not(:disabled) { background: var(--accent-alt); color: var(--on-accent); }
-  &:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
-  &:disabled { opacity: 0.4; cursor: not-allowed; }
-}
-
-// Add-ability "+" — deliberately subtle (seldom used): a faint ghost icon that
-// only gains colour on hover. No outline/fill at rest.
-.reactor-sheet-app .rs-feat-add {
-  flex: none;
-  display: grid; place-items: center;
-  width: 22px; height: 22px;
-  background: none; border: none; cursor: pointer;
-  color: var(--text-faint, #6a6354);
-  font-size: var(--fs-2xs, 11px);
-  transition: color 0.12s;
-  &:hover:not(:disabled) { color: var(--accent-alt); }
-  &:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
-  &:disabled { opacity: 0.4; cursor: not-allowed; }
-}
+// Language "go" (round brass add) + Add-ability/edit "+" are now <IconButton>
+// (variant="round" / variant="accent"); see .icon-btn in components.css.
 
 // --- Languages: ink-stamp chips ---
 .rs-langs { display: flex; flex-wrap: wrap; gap: var(--spacer-1); align-items: center; }

--- a/src/ReactorSheet/styles/features.scss
+++ b/src/ReactorSheet/styles/features.scss
@@ -99,14 +99,8 @@
   font-family: "IM Fell English", Georgia, serif; font-style: italic;
   font-size: var(--fs-sm, 13px); color: var(--text-faint, #6a6354);
 }
-.rs-lang {
-  display: inline-flex; align-items: center; gap: var(--spacer-1);
-  font-family: var(--mono, monospace); font-size: var(--fs-xs, 12px);
-  color: var(--text-dim, #b5ad97);
-  background: var(--surface, #23201a);
-  border: 1px solid var(--border-soft, #2c2823);
-  padding: 3px 9px 2px; border-radius: 99px;
-}
+// language chips are now <Tag>; .tag provides the pill. The × stays bespoke
+// (it tucks inside the chip — an .icon-btn box would inflate the chip height).
 .reactor-sheet-app .rs-lang-x {
   display: grid; place-items: center;
   background: none; border: none; cursor: pointer; padding: 0;

--- a/src/ReactorSheet/styles/inventory.scss
+++ b/src/ReactorSheet/styles/inventory.scss
@@ -157,17 +157,7 @@
   color: var(--text-mute, #8a8270); white-space: nowrap; flex: none;
 }
 
-// container count pill (brass) — sits after the container name
-.rs-inv-count {
-  font-family: var(--mono); font-size: var(--fs-2xs, 11px);
-  color: var(--on-accent, #070605);
-  background: var(--accent-alt-dim);
-  border-radius: 999px;
-  padding: 1px 7px;
-  min-width: 16px;
-  text-align: center;
-  white-space: nowrap;
-}
+// container count pill (brass) — now <Tag intent="count">; see .tag.count
 
 // name column (col 3): name (+count) row on top, tags beneath, all left-justified
 .rs-inv-name-c {
@@ -352,10 +342,7 @@
   background: var(--bg);
   color: var(--text-mute, #8a8270);
 }
-.rs-inv-sec-title {
-  font-family: var(--sans); font-size: var(--fs-2xs, 11px); font-weight: 600;
-  letter-spacing: 0.09em; text-transform: uppercase;
-}
+// section title is now <SectionTitle variant="sub">; see .section-title.sub
 .rs-inv-sec-count {
   font-family: var(--mono); font-size: var(--fs-2xs, 11px);
   color: var(--text-faint, #6a6354); margin-left: auto; white-space: nowrap;

--- a/src/ReactorSheet/styles/minibar.scss
+++ b/src/ReactorSheet/styles/minibar.scss
@@ -85,7 +85,8 @@
   display: flex;
   align-items: center;
   gap: var(--spacer-1);
-  padding: 3px var(--spacer-2);
+  height: 30px; // locked: focused input border must not grow the box
+  padding: 0 var(--spacer-2);
   border: 1px solid var(--border-soft, #2c2823);
   border-radius: var(--r-md, 6px);
   background: var(--surface);
@@ -93,27 +94,29 @@
 .rs-mb-hp { border-color: color-mix(in srgb, var(--crimson) 55%, transparent); }
 .rs-mb-ac { border-color: color-mix(in srgb, var(--teal) 50%, transparent); }
 
-.rs-mb-stamp {
-  font-family: var(--display, serif);
-  font-size: var(--fs-sm, 13px);
-  letter-spacing: 0.08em;
-  color: var(--text-mute, #8a8270);
-}
+// Label uses the shared ink-stamp <Stamp size="sm"> (black bar, cream caps);
+// this class is just a hover hook for the −/+ swap. Keep styling on .stamp.
 
 // Qualified with .reactor-sheet-app so font/colour/size beat the
 // `.reactor-sheet-app input { all: unset }` reset (0,1,1) — otherwise the
 // editable HP number renders in the inherited sans/text colour, not crimson.
 .reactor-sheet-app .rs-mb-hp-input {
-  width: 2.2em;
+  width: 1.4em;
   min-width: 0;
   text-align: center;
   cursor: text;
   font-family: var(--display);
-  font-size: var(--fs-xl, 18px);
+  font-size: var(--fs-3xl, 24px);
+  line-height: 1;
+  // Clamp to the box height so the focus border never overflows the parent.
+  // IM Fell numerals sit low, so lift the glyph with bottom padding (not a
+  // transform, which would carry the border up out of the box).
+  height: 100%;
+  box-sizing: border-box;
   color: var(--crimson);
   border: 1px solid transparent;
   border-radius: var(--r-sm, 4px);
-  padding: 0 1px;
+  padding: 0 0 var(--spacer-1);
   -moz-appearance: textfield;
   appearance: textfield;
 }
@@ -128,9 +131,48 @@
   color: var(--text-mute);
 }
 
+// The label sits in normal flow (flex-centered by .rs-mb-hp); the −/+ stepper
+// overlays it absolutely so hover-swapping the two never shifts the layout.
+.rs-mb-hp-slot {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  .rs-mb-stamp,
+  .rs-mb-hp-max { transition: opacity 0.12s ease; }
+}
+.reactor-sheet-app .rs-mb-hp-btn {
+  // boxed stepper matching the header .vv-step; beats `button { all: unset }` (0,1,1)
+  position: absolute;
+  inset: 0;
+  margin: auto; // center the fixed-size box over the label
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border: 1px solid var(--border, #3a342c);
+  border-radius: var(--r-sm, 4px);
+  cursor: pointer;
+  font-family: var(--sans);
+  font-size: var(--fs-sm, 13px);
+  line-height: 1;
+  color: var(--text-dim, #b5ad97);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+  &:hover { border-color: var(--gold); color: var(--text, #e5dec8); }
+}
+// hover the HP box: fade labels out, steppers in
+.rs-mb-hp:hover {
+  .rs-mb-stamp,
+  .rs-mb-hp-max { opacity: 0; }
+  .rs-mb-hp-btn { opacity: 1; pointer-events: auto; }
+}
+
 .rs-mb-ac-v {
   font-family: var(--display);
-  font-size: var(--fs-xl, 18px);
+  font-size: var(--fs-2xl, 21px);
+  line-height: 1; // bigger glyph, box height unchanged
   color: var(--teal);
 }
 

--- a/src/ReactorSheet/styles/minibar.scss
+++ b/src/ReactorSheet/styles/minibar.scss
@@ -109,7 +109,7 @@
   text-align: center;
   cursor: text;
   font-family: var(--display);
-  font-size: var(--fs-lg, 16px);
+  font-size: var(--fs-xl, 18px);
   color: var(--crimson);
   border: 1px solid transparent;
   border-radius: var(--r-sm, 4px);
@@ -130,7 +130,7 @@
 
 .rs-mb-ac-v {
   font-family: var(--display);
-  font-size: var(--fs-lg, 16px);
+  font-size: var(--fs-xl, 18px);
   color: var(--teal);
 }
 

--- a/src/ReactorSheet/styles/minibar.scss
+++ b/src/ReactorSheet/styles/minibar.scss
@@ -94,29 +94,33 @@
 .rs-mb-ac { border-color: color-mix(in srgb, var(--teal) 50%, transparent); }
 
 .rs-mb-stamp {
-  font-family: var(--mono);
-  font-size: var(--fs-3xs, 10px);
-  letter-spacing: 0.06em;
-  color: var(--text-faint, #6a6354);
+  font-family: var(--display, serif);
+  font-size: var(--fs-sm, 13px);
+  letter-spacing: 0.08em;
+  color: var(--text-mute, #8a8270);
 }
 
-.rs-mb-hp-input {
+// Qualified with .reactor-sheet-app so font/colour/size beat the
+// `.reactor-sheet-app input { all: unset }` reset (0,1,1) — otherwise the
+// editable HP number renders in the inherited sans/text colour, not crimson.
+.reactor-sheet-app .rs-mb-hp-input {
   width: 2.2em;
   min-width: 0;
   text-align: center;
   cursor: text;
   font-family: var(--display);
-  font-size: var(--fs-md, 15px);
+  font-size: var(--fs-lg, 16px);
   color: var(--crimson);
   border: 1px solid transparent;
   border-radius: var(--r-sm, 4px);
   padding: 0 1px;
+  -moz-appearance: textfield;
+  appearance: textfield;
 }
-.rs-mb-hp-input:focus { border-color: var(--crimson); background: var(--bg, #181612); }
+.reactor-sheet-app .rs-mb-hp-input:focus { border-color: var(--crimson); background: var(--bg, #181612); }
 .rs-mb-hp-input::-webkit-inner-spin-button,
 .rs-mb-hp-input::-webkit-outer-spin-button { appearance: none; margin: 0; }
-.rs-mb-hp-input { -moz-appearance: textfield; appearance: textfield; }
-.rs-mb-hp-static { cursor: default; }
+.reactor-sheet-app .rs-mb-hp-static { cursor: default; }
 
 .rs-mb-hp-max {
   font-family: var(--mono);
@@ -126,7 +130,7 @@
 
 .rs-mb-ac-v {
   font-family: var(--display);
-  font-size: var(--fs-md, 15px);
+  font-size: var(--fs-lg, 16px);
   color: var(--teal);
 }
 

--- a/src/ReactorSheet/styles/spells.scss
+++ b/src/ReactorSheet/styles/spells.scss
@@ -92,16 +92,8 @@
 // name + cast dots on one line (dots to the right of the name)
 .rs-spell .spn-row { display: inline-flex; align-items: baseline; gap: var(--spacer-2); min-width: 0; }
 .rs-spell .sp-actions { display: inline-flex; align-items: center; gap: var(--spacer-2); }
-// remove (free a slot) — small trashcan sitting just after the cast dots
-.reactor-sheet-app .rs-spell .sp-trash {
-  display: inline-flex; align-items: center; justify-content: center;
-  width: 18px; height: 18px; padding: 0;
-  background: transparent; border: none;
-  color: var(--text-faint, #6a6354); cursor: pointer;
-  font-size: 11px; line-height: 1;
-  transition: color 0.12s;
-  &:hover { color: var(--crimson, #c75044); }
-}
+// remove (free a slot) — small trashcan after the cast dots — is now
+// <IconButton variant="danger" size="sm">; see .icon-btn in components.css.
 .rs-spell.spent .spn { text-decoration: line-through; color: var(--text-mute, #8a8270); }
 
 // --- spellbook toggle (dashed divider with caret) ---

--- a/src/ReactorSheet/styles/vellum/components.css
+++ b/src/ReactorSheet/styles/vellum/components.css
@@ -247,6 +247,49 @@
 }
 .segmented button:hover:not(.on) { color: var(--text-dim); }
 
+/* ─── Icon button — transparent square wrapping a single glyph ───────────
+   Canonical replacement for the hand-rolled .ft-chev/.ft-del/.rs-feat-add/
+   .rs-lang-go/.sp-trash one-offs. Neutral by default; intents via variants. */
+
+.icon-btn {
+  flex: none;
+  display: inline-grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  background: none;
+  border: none;
+  border-radius: var(--r-sm);
+  color: var(--text-faint);
+  font-size: var(--fs-2xs);
+  line-height: 1;
+  cursor: pointer;
+  transition: color 0.12s, background 0.12s, border-color 0.12s;
+}
+.icon-btn:hover:not(:disabled) { color: var(--text-dim); }
+.icon-btn:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+.icon-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* compact box for inline carets / × / trash glyphs */
+.icon-btn.sm { width: 18px; height: 18px; font-size: var(--fs-3xs); }
+
+/* danger — delete / remove / × (faint → crimson) */
+.icon-btn.danger:hover:not(:disabled) { color: var(--crimson); }
+/* accent — add / edit affordances (faint → brass); `.on` = toggled active */
+.icon-btn.accent:hover:not(:disabled) { color: var(--accent-alt); }
+.icon-btn.on { color: var(--accent-alt); }
+/* round — brass-outline add affordance that fills on hover */
+.icon-btn.round {
+  border-radius: 999px;
+  border: 1px solid var(--accent-alt);
+  color: var(--accent-alt);
+}
+.icon-btn.round:hover:not(:disabled) {
+  background: var(--accent-alt);
+  color: var(--on-accent);
+}
+
 /* ─── Dropdown menu ─────────────────────────────────────────────────── */
 
 .menu {

--- a/src/ReactorSheet/styles/vellum/components.css
+++ b/src/ReactorSheet/styles/vellum/components.css
@@ -460,6 +460,8 @@
 .tag.forest  { color: var(--forest);  border-color: var(--forest);  background: color-mix(in oklab, var(--forest) 12%, transparent); }
 .tag.mustard { color: var(--mustard); border-color: var(--mustard); background: color-mix(in oklab, var(--mustard) 12%, transparent); }
 .tag.solid   { background: var(--ink); color: var(--stamp-text); border-color: var(--ink); font-family: var(--display); font-size: var(--fs-2xs); letter-spacing: 0.08em; text-transform: uppercase; padding: 4px 10px 2px; }
+/* count — brass-solid numeric pill (container item counts, etc.) */
+.tag.count   { background: var(--accent-alt-dim); border-color: var(--accent-alt-dim); color: var(--on-accent); font-size: var(--fs-2xs); padding: 1px 7px; min-width: 16px; justify-content: center; }
 
 /* ─── Modal / Dialog ────────────────────────────────────────────────── */
 
@@ -493,11 +495,8 @@
   align-items: baseline;
   gap: 10px;
 }
+/* title is a <SectionTitle variant="bare">; just stretch it in the head row */
 .modal-head .ttl {
-  font-family: var(--display);
-  font-size: var(--fs-2xl);
-  letter-spacing: 0.02em;
-  color: var(--text);
   flex: 1;
 }
 .modal-head .x {

--- a/src/ReactorSheet/styles/vellum/tokens.css
+++ b/src/ReactorSheet/styles/vellum/tokens.css
@@ -234,6 +234,29 @@ body {
   min-width: 0;
 }
 
+/* bare — embedded head (e.g. a modal title): keep the display type, drop the
+   rule + margins so it sits inside another framed container. */
+.section-title.bare {
+  border-bottom: none;
+  margin: 0;
+  padding-bottom: 0;
+}
+
+/* sub — small uppercase sans label for sub-section heads (inventory
+   "Equipped" / "All Items", etc.). */
+.section-title.sub {
+  font-family: var(--sans);
+  font-size: var(--fs-2xs);
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  border-bottom: none;
+  margin: 0;
+  padding-bottom: 0;
+  line-height: var(--lh-normal);
+}
+
 /* Rule callout — italic serif explanatory line, like the print sheet */
 .rule {
   font-family: var(--serif);


### PR DESCRIPTION
All of **Phase 2** of `docs/vellum-system-audit.md` in one branch. This is the visual phase — please `pnpm dev` and eyeball before merge. `build` + `lint` + `test` (58) green throughout.

## Correction to the PR #19 "latent bug" note
I flagged that `ui/Button`/`Tag` looked out-specified by the `all: unset` reset. **That was wrong** — I'd missed `tools/postcss/scope-vellum.mjs`, which prefixes every `styles/vellum/*` selector with `.reactor-sheet`. So `.btn`/`.tag`/`.icon-btn`/`.section-title` ship as e.g. `.reactor-sheet .icon-btn` (**0,2,0**) and beat the reset (**0,1,1**) regardless of load order. The primitives work in-app; they just had no live consumer yet. Convergence is mechanically safe — the open questions are purely aesthetic, which is what this review covers.

---

## 1 · Buttons — new `IconButton` primitive
`.icon-btn` (components.css) with `danger`/`accent`/`round` variants, `sm` size, `on` state; Ladle story under *Controls / IconButton*. Folded the standalone icon-only one-offs onto it and deleted their bespoke CSS:

| was | now |
|---|---|
| `.ft-chev` (collapse caret) | `IconButton` |
| `.ft-del` (delete ability) | `IconButton variant="danger"` |
| `.rs-feat-add` (add ability) | `IconButton variant="accent"` |
| `.rs-feat-add.on` (Languages edit toggle) | `IconButton variant="accent" on` |
| `.rs-lang-go` (round brass add) | `IconButton variant="round"` |
| `.sp-trash` (free a slot) | `IconButton variant="danger" size="sm"` |

Box sizes converge to 24px (sm 18px) — `.ft-chev` 16→24, `.ft-del` inline→boxed, `.rs-feat-add` 22→24, `.rs-lang-go` 26→24, `.sp-trash` unchanged (18).

## 2 · Headings — through `<SectionTitle>` (new `bare` + `sub` variants)
- **Modal head** → `<SectionTitle variant="bare">` (the distinct 3rd heading system; `<Modal>` is stories-only so this is safe to verify in Ladle). `.modal-head .ttl` trimmed to layout-only.
- **Inventory "Equipped" / "All Items"** → `<SectionTitle variant="sub">`; `.rs-inv-sec-title` deleted. `sub` reproduces the small uppercase-sans label, so ~no visual change.

## 3 · Tags — through `<Tag>` (new `count` variant)
- **Container count pill** → `<Tag intent="count">`; `.rs-inv-count` deleted.
- **Language chips** → `<Tag>`; `.rs-lang` pill CSS deleted. ⚠️ Visible change to eyeball: the chip text drops `fs-xs (12px) → fs-3xs (10px)` to match every other `.tag`. If you'd rather keep them larger, say so and I'll add a size to `<Tag>`.

---

## Deliberately left bespoke (with reasons)
Same judgment call you OK'd for the composite buttons — these aren't vocabulary items and folding them would break layout/semantics:
- `.rs-spellhead .lv` — an ink **Stamp** badge (+ interactive slot pips), not a heading. (Could move to the `<Stamp>` primitive later if you want; it's a different vocabulary than `SectionTitle`.)
- `.fvtt-tag` — icon chip with a hover `.tag-pop` popover + melee/missile accent.
- `.ft-tag` / `.ft-tag-roll` — the roll tag is a `<button>`; a `<Tag>` span can't carry it.
- `.am` — the ability mod-pill is absolutely positioned on the plaque.
- The topbar `.rs-tb-btn` group, tab rails, `.rs-inv-equip` toggle, and `.wstat`/`.fvtt-atk`/`.kind-seg`/`.sp-cast` widgets (carried over from Phase 2a).

If you want any of these pulled in too, point me at them after QA and I'll add the matching primitive variant.

## After Phase 2 merges
Phase 3 (guardrails: stylelint/eslint/CLAUDE.md note) is the remaining plan item — best designed against this converged state, and it needs new tooling (stylelint) plus care around the `var(--token, #hexfallback)` convention. I'll pick it up once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FGrGmaj67NfFeLPnbmSHC