### PR TITLE
feat(types): consume @ose-foundry-core/types for OSE data-model types

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@eslint/js": "^9.33.0",
     "@ladle/react": "^5.1.1",
+    "@ose-foundry-core/types": "github:tasandberg/ose-foundry-core#types-v0.1.0",
     "@pixi/compressed-textures": "github:foundry-vtt-types/pixi-compressed-textures#main",
     "@types/node": "^24.3.0",
     "@types/react": "^19.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@ladle/react':
         specifier: ^5.1.1
         version: 5.1.1(@types/node@24.3.0)(@types/react@19.2.17)(lightningcss@1.32.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass-embedded@1.91.0)(sass@1.91.0)(typescript@5.8.3)
+      '@ose-foundry-core/types':
+        specifier: github:tasandberg/ose-foundry-core#types-v0.1.0
+        version: https://codeload.github.com/tasandberg/ose-foundry-core/tar.gz/0ec7583b74f40cc7d343de59ae5991be34ed047c(@league-of-foundry-developers/foundry-vtt-types@13.346.0-beta.20251209192131(63ed09af4cea38bed3b96d997d05ee5d))
       '@pixi/compressed-textures':
         specifier: github:foundry-vtt-types/pixi-compressed-textures#main
         version: https://codeload.github.com/foundry-vtt-types/pixi-compressed-textures/tar.gz/890bd5cf9f92d6e48103b733513ccb603e5d1a36(@pixi/assets@7.4.3(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e))(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e)
@@ -720,6 +723,17 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
+  '@league-of-foundry-developers/foundry-vtt-types@13.346.0-beta.20251209192131':
+    resolution: {integrity: sha512-fmDGZibARZ2Qjz9xO2GlU42XkUXM8pTp0vWQwyTurZBnpUw6tiPfkIInGHPdbD5WRiaQ7GKauZYCRCaoQRxC0w==}
+    peerDependencies:
+      '@typescript/native-preview': '*'
+      typescript: ^5.4
+    peerDependenciesMeta:
+      '@typescript/native-preview':
+        optional: true
+      typescript:
+        optional: true
+
   '@league-of-foundry-developers/foundry-vtt-types@https://codeload.github.com/League-of-Foundry-Developers/foundry-vtt-types/tar.gz/7e0fa2d3c649fb23e721476e62916290808f23b7':
     resolution: {tarball: https://codeload.github.com/League-of-Foundry-Developers/foundry-vtt-types/tar.gz/7e0fa2d3c649fb23e721476e62916290808f23b7}
     version: 13.346.0
@@ -801,6 +815,12 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@ose-foundry-core/types@https://codeload.github.com/tasandberg/ose-foundry-core/tar.gz/0ec7583b74f40cc7d343de59ae5991be34ed047c':
+    resolution: {tarball: https://codeload.github.com/tasandberg/ose-foundry-core/tar.gz/0ec7583b74f40cc7d343de59ae5991be34ed047c}
+    version: 0.1.0
+    peerDependencies:
+      '@league-of-foundry-developers/foundry-vtt-types': 13.346.0-beta.20251209192131
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
@@ -4912,6 +4932,63 @@ snapshots:
       - typescript
       - yaml
 
+  '@league-of-foundry-developers/foundry-vtt-types@13.346.0-beta.20251209192131(63ed09af4cea38bed3b96d997d05ee5d)':
+    dependencies:
+      '@codemirror/lang-html': 6.4.9
+      '@codemirror/lang-javascript': 6.2.4
+      '@codemirror/lang-json': 6.0.2
+      '@codemirror/lang-markdown': 6.3.4
+      '@pixi/basis': https://codeload.github.com/foundry-vtt-types/pixi-basis/tar.gz/d0956799d7c23f59e12b7b2ec4dc21c041180b0e(@pixi/assets@7.4.3(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e))(@pixi/compressed-textures@https://codeload.github.com/foundry-vtt-types/pixi-compressed-textures/tar.gz/890bd5cf9f92d6e48103b733513ccb603e5d1a36(@pixi/assets@7.4.3(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e))(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e))(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e)
+      '@pixi/graphics-smooth': 1.1.1(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e)(@pixi/display@7.4.3(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e))(@pixi/graphics@7.4.3(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e)(@pixi/display@7.4.3(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e))(@pixi/sprite@7.4.3(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e)(@pixi/display@7.4.3(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e))))
+      '@pixi/particle-emitter': https://codeload.github.com/foundry-vtt-types/pixi-particle-emitter/tar.gz/9bd3cb53826b2c7d4c407db183f4dd93edd50aae(@pixi/constants@7.4.3)(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e)(@pixi/display@7.4.3(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e))(@pixi/math@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e)(@pixi/display@7.4.3(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e)))(@pixi/ticker@7.4.3)
+      '@types/jquery': 3.5.33
+      '@types/showdown': 2.0.6
+      '@types/simple-peer': 9.11.8
+      '@types/youtube': 0.0.50
+      codemirror: 6.0.2
+      handlebars: 4.7.8
+      handlebars-intl: 1.1.2
+      jquery: 3.7.1
+      mime-types: 3.0.1
+      peggy: 4.2.0
+      pixi-basis-ktx2: 0.0.22(pixi.js@https://codeload.github.com/foundry-vtt-types/pixi.js/tar.gz/a8414afd3a1141c3ef94e62079e7861723029c2c)
+      pixi.js: https://codeload.github.com/foundry-vtt-types/pixi.js/tar.gz/a8414afd3a1141c3ef94e62079e7861723029c2c
+      prosemirror-collab: 1.3.1
+      prosemirror-commands: 1.7.1
+      prosemirror-dropcursor: 1.8.2
+      prosemirror-gapcursor: 1.3.2
+      prosemirror-history: 1.4.1
+      prosemirror-inputrules: 1.5.0
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.3
+      prosemirror-schema-list: 1.5.1
+      prosemirror-state: 1.4.3
+      prosemirror-tables: 1.8.1
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.40.1
+      sanitize-html: 2.17.0
+      showdown: 2.1.0
+      simple-peer: 9.11.1
+      socket.io: 4.8.1
+      socket.io-client: 4.8.1
+      spark-md5: 3.0.2
+      tinymce: 6.8.6
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - '@pixi/assets'
+      - '@pixi/compressed-textures'
+      - '@pixi/constants'
+      - '@pixi/core'
+      - '@pixi/display'
+      - '@pixi/graphics'
+      - '@pixi/math'
+      - '@pixi/sprite'
+      - '@pixi/ticker'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@league-of-foundry-developers/foundry-vtt-types@https://codeload.github.com/League-of-Foundry-Developers/foundry-vtt-types/tar.gz/7e0fa2d3c649fb23e721476e62916290808f23b7(63ed09af4cea38bed3b96d997d05ee5d)':
     dependencies:
       '@codemirror/lang-html': 6.4.9
@@ -5084,6 +5161,10 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@ose-foundry-core/types@https://codeload.github.com/tasandberg/ose-foundry-core/tar.gz/0ec7583b74f40cc7d343de59ae5991be34ed047c(@league-of-foundry-developers/foundry-vtt-types@13.346.0-beta.20251209192131(63ed09af4cea38bed3b96d997d05ee5d))':
+    dependencies:
+      '@league-of-foundry-developers/foundry-vtt-types': 13.346.0-beta.20251209192131(63ed09af4cea38bed3b96d997d05ee5d)
 
   '@oxc-project/types@0.133.0': {}
 

--- a/src/ReactorSheet/components/SheetPages/Abilities/LanguagesSection.tsx
+++ b/src/ReactorSheet/components/SheetPages/Abilities/LanguagesSection.tsx
@@ -33,8 +33,7 @@ export function LanguagesSection({ editing: forced }: { editing?: boolean }) {
   const flavour = useFlavour();
 
   const choices = useMemo(() => {
-    // @ts-expect-error CONFIG.OSE is untyped
-    const all = (CONFIG.OSE.languages as string[]) ?? [];
+    const all = CONFIG.OSE?.languages ?? [];
     return all.filter((l) => !current.includes(l));
   }, [current]);
 

--- a/src/ReactorSheet/types/data-model-character-ac.ts
+++ b/src/ReactorSheet/types/data-model-character-ac.ts
@@ -2,13 +2,7 @@
  * @file A class to handle the nested AC/AAC props on OseDataModelCharacter.
  */
 
-interface CharacterAC {
-  base: number;
-  naked: number;
-  shield: number;
-  value: number;
-  mod: number;
-}
+import type { CharacterAC } from "@ose-foundry-core/types";
 
 export default class OseDataModelCharacterAC implements CharacterAC {
   static baseAscending = 10;

--- a/src/ReactorSheet/types/data-model-character-scores.ts
+++ b/src/ReactorSheet/types/data-model-character-scores.ts
@@ -1,10 +1,16 @@
 /**
  * @file A class representing a Character's ability scores.
  */
+import type { CharacterScores } from "@ose-foundry-core/types";
+
+export type { CharacterScores };
+
 type IncomingScore = {
   value: number;
   bonus: number;
 };
+
+export type BaseScore = IncomingScore & { mod: number };
 
 export type Scores = {
   str: BaseScore;
@@ -15,17 +21,6 @@ export type Scores = {
   cha: BaseScore;
 };
 type OptionalScores = Partial<Scores>;
-
-export type BaseScore = IncomingScore & { mod: number };
-
-export interface CharacterScores {
-  str: BaseScore & { od: number };
-  int: BaseScore & { literacy: string; spoken: string };
-  wis: BaseScore;
-  dex: BaseScore & { init: number };
-  con: BaseScore;
-  cha: BaseScore & { loyalty: number; retain: number; npc: number };
-}
 
 /**
  * A class representing a character's ability scores

--- a/src/ReactorSheet/types/types.ts
+++ b/src/ReactorSheet/types/types.ts
@@ -1,7 +1,11 @@
+import type { RollType, Save } from "@ose-foundry-core/types";
 import type OseDataModelCharacterAC from "./data-model-character-ac";
 import type OseDataModelCharacterScores from "./data-model-character-scores";
 import type { TabIds } from "../components/shared/tabs";
 import type { ContextConnector } from "foundry-vtt-react";
+
+/** Saving-throw category key, sourced from the OSE system's CONFIG (`saves_long`). */
+export type OSESave = Save;
 
 // Add props as needed
 export type ReactorContext = {
@@ -26,8 +30,6 @@ export interface ReactorSheetContextValue {
     [key: string]: string | number | string[];
   }) => Promise<OSEActor | void>;
 }
-
-export type OSESave = "breath" | "death" | "paralysis" | "spell" | "wand";
 
 export type OseSpellList = Record<number, OseSpell[]>;
 
@@ -155,7 +157,8 @@ export type OseWeapon = OseItem & {
   bonus: number;
 };
 
-export type OseRollType = "result" | "above" | "below";
+/** Roll-comparison key, sourced from the OSE system's CONFIG (`roll_type`). */
+export type OseRollType = RollType;
 
 export type OseAbility = OseItem & {
   system: {

--- a/src/ReactorSheet/viewModels/features.ts
+++ b/src/ReactorSheet/viewModels/features.ts
@@ -25,7 +25,7 @@ export interface FeatureVM {
 
 /** Symbol for the roll comparison (= / ≥ / ≤) from CONFIG.OSE. Falls back to "=". */
 function rollSymbol(rollType?: OseRollType): string {
-  const map = (CONFIG as { OSE?: { roll_type?: Record<string, string> } }).OSE?.roll_type;
+  const map = CONFIG.OSE?.roll_type;
   return (rollType && map?.[rollType]) || "=";
 }
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,3 +1,5 @@
+import type { OseConfig } from "@ose-foundry-core/types";
+
 declare global {
   interface LenientGlobalVariableTypes {
     game: never;
@@ -7,4 +9,9 @@ declare global {
   class Hooks extends foundry.helpers.Hooks {}
   const fromUuid = foundry.utils.fromUuid;
   const fromUuidSync = foundry.utils.fromUuidSync;
+
+  // The OSE system's CONFIG.OSE block, typed from the published fork types.
+  interface CONFIG {
+    OSE: OseConfig;
+  }
 }


### PR DESCRIPTION
Swaps reactor-sheet's hand-maintained OSE type defs for the published fork package `@ose-foundry-core/types` (`github:tasandberg/ose-foundry-core#types-v0.1.0`).

## What
- Add `@ose-foundry-core/types` dev dep.
- Replace local `CharacterAC` / `CharacterScores` interfaces with package imports.
- Type `CONFIG.OSE` globally (`OseConfig`) — drops the `@ts-expect-error` / inline `CONFIG.OSE` casts in `LanguagesSection` and `features.ts`.
- Source `OSESave` from `Save`, `OseRollType` from `RollType`.

## Why
Single source of truth for OSE data shapes, owned by the fork. Notably exposes typed `CONFIG.OSE.classes.classic` (per-level `{ xp, hd, saves, thac0 }` tables) — the rule-default source the upcoming Edit Character modal needs.

## Verification
- `pnpm build` ✓
- `pnpm lint` ✓
- `pnpm test` ✓ (58 tests)

https://claude.ai/code/session_01Y3b5TePpyiNxuQ3sCwFf9H