### PR TITLE
Reskin reactor-sheet with Vellum design system & P0–P2 foundation

### DIFF
--- a/src/ReactorSheet/components/chrome/HeaderBand.stories.tsx
+++ b/src/ReactorSheet/components/chrome/HeaderBand.stories.tsx
@@ -5,6 +5,21 @@ export default { title: "Chrome / HeaderBand" };
 export const Default = () => (
   <HeaderBand
     identity={{ name: "Eldra Vey", img: "", classLabel: "Magic-User", level: 3, alignment: "Neutral", title: "Conjurer" }}
-    vitals={{ hp: { value: 8, max: 9 }, ac: { ascending: 12, descending: 7 }, initMod: 1, hd: "3d4", move: 120, moveBands: { encounter: 40, explore: 120, travel: 24 } }}
+    vitals={{
+      hp: { value: 8, max: 9 },
+      ac: {
+        ascending: 12,
+        descending: 7,
+        breakdown: [
+          { label: "Base (unarmored)", value: "+10" },
+          { label: "DEX modifier", value: "+1" },
+          { label: "Ring of protection +1", value: "+1" },
+        ],
+      },
+      initMod: 1,
+      hd: "3d4",
+      move: 120,
+      moveBands: { encounter: 40, explore: 120, travel: 24 },
+    }}
   />
 );

--- a/src/ReactorSheet/components/chrome/HeaderBand.tsx
+++ b/src/ReactorSheet/components/chrome/HeaderBand.tsx
@@ -2,6 +2,7 @@ import { useLayoutEffect, useRef } from "react";
 import type { IdentityVM, VitalsVM } from "../../viewModels/types";
 import { formatMod } from "../../viewModels/format";
 import { Stamp } from "../ui/Stamp";
+import { HoverCard } from "../ui/HoverCard";
 
 /** Shrink a single-line element's font to fit its box (down to `min`x) instead of
  *  truncating. Sets `--fit-scale`; CSS multiplies the base font-size by it. */
@@ -106,16 +107,21 @@ export function HeaderBand({ identity, vitals, onSetHp }: Props) {
             <span className="short">/{vitals.hp.max}</span>
           </div>
         </div>
-        <div className="rs-vital ac">
+        <HoverCard.Anchor className="rs-vital ac" focusable aria-describedby="rs-ac-pop">
           <Stamp className="vv-l">AC</Stamp>
           <div className="vv-row">
             <div className="vv-big">{vitals.ac.ascending}</div>
           </div>
           <div className="vv-sub">
-            <span className="full">Ascending</span>
+            <span className="full">AAC · DAC {vitals.ac.descending}</span>
             <span className="short">asc</span>
           </div>
-        </div>
+          <HoverCard id="rs-ac-pop" placement="bottom-end">
+            <HoverCard.Header title="Armor Class" badge="AAC" />
+            <HoverCard.Rows items={vitals.ac.breakdown} />
+            <HoverCard.Total label="Total" value={vitals.ac.ascending} unit="AAC" />
+          </HoverCard>
+        </HoverCard.Anchor>
       </div>
     </div>
   );

--- a/src/ReactorSheet/components/ui/HoverCard.stories.tsx
+++ b/src/ReactorSheet/components/ui/HoverCard.stories.tsx
@@ -1,0 +1,68 @@
+import { HoverCard } from "./HoverCard";
+
+export default { title: "Overlays / HoverCard" };
+
+/** The AC-breakdown case from the design handoff. Hover (or focus) the tile. */
+export const AcBreakdown = () => (
+  <div style={{ padding: 80, display: "flex", justifyContent: "center" }}>
+    <HoverCard.Anchor
+      focusable
+      aria-describedby="hc-ac"
+      style={{
+        position: "relative",
+        width: 96,
+        padding: "6px 10px 8px",
+        textAlign: "center",
+        background: "var(--surface)",
+        border: "1px solid color-mix(in srgb, var(--teal) 50%, transparent)",
+        borderRadius: "var(--r-md)",
+        cursor: "default",
+      }}
+    >
+      <span className="stamp sm" style={{ display: "block", width: "100%" }}>AC</span>
+      <div style={{ fontFamily: "var(--display)", fontSize: "var(--fs-4xl)", color: "var(--teal)" }}>12</div>
+      <HoverCard id="hc-ac" placement="bottom-end">
+        <HoverCard.Header title="Armor Class" badge="AAC" />
+        <HoverCard.Rows
+          items={[
+            { label: "Base (unarmored)", value: "+10" },
+            { label: "DEX modifier", value: "+1" },
+            { label: "Ring of protection +1", value: "+1" },
+          ]}
+        />
+        <HoverCard.Total label="Total" value="12" unit="AAC" />
+      </HoverCard>
+    </HoverCard.Anchor>
+  </div>
+);
+
+/** Placement variants — each reveals on hover. */
+export const Placements = () => {
+  const placements = ["bottom-end", "bottom-start", "top-end", "top-start"] as const;
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 100, padding: 100 }}>
+      {placements.map((p) => (
+        <HoverCard.Anchor
+          key={p}
+          focusable
+          style={{
+            position: "relative",
+            justifySelf: "center",
+            padding: "8px 12px",
+            background: "var(--surface)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--r-md)",
+            cursor: "default",
+          }}
+        >
+          <span style={{ fontFamily: "var(--mono)", fontSize: "var(--fs-xs)", color: "var(--text-dim)" }}>{p}</span>
+          <HoverCard placement={p}>
+            <HoverCard.Header title="Breakdown" badge="DEMO" />
+            <HoverCard.Rows items={[{ label: "Base", value: "+10" }, { label: "Bonus", value: "+2" }]} />
+            <HoverCard.Total label="Total" value="12" />
+          </HoverCard>
+        </HoverCard.Anchor>
+      ))}
+    </div>
+  );
+};

--- a/src/ReactorSheet/components/ui/HoverCard.tsx
+++ b/src/ReactorSheet/components/ui/HoverCard.tsx
@@ -1,0 +1,83 @@
+import { cx } from "./cx";
+import type { HTMLAttributes, ReactNode } from "react";
+
+/** Placement of the card relative to its anchor. `bottom-end` (under the anchor,
+ *  right-aligned) is the AC-breakdown default; the arrow repositions to match. */
+export type HoverCardPlacement = "bottom-end" | "bottom-start" | "top-end" | "top-start";
+
+type AnchorProps = HTMLAttributes<HTMLDivElement> & {
+  /** When set, the anchor becomes keyboard-focusable so the card reveals on focus too. */
+  focusable?: boolean;
+};
+
+/** Relative wrapper that drives the reveal on `:hover` / `:focus-within`.
+ *  Wrap the visible trigger and a <HoverCard> together inside this. */
+function Anchor({ focusable, className, tabIndex, ...rest }: AnchorProps) {
+  return (
+    <div
+      className={cx("hovercard-anchor", className)}
+      tabIndex={focusable ? (tabIndex ?? 0) : tabIndex}
+      {...rest}
+    />
+  );
+}
+
+type Props = Omit<HTMLAttributes<HTMLDivElement>, "role"> & {
+  placement?: HoverCardPlacement;
+  /** Read-only by default → `tooltip`. Use `dialog` only if it becomes interactive. */
+  role?: "tooltip" | "dialog";
+};
+
+/**
+ * Anchored hover-popover for showing a small stat breakdown next to the value it
+ * explains (e.g. the AC breakdown). Read-only: default `role="tooltip"`, revealed
+ * by the parent `.hovercard-anchor` on hover/focus-within. Token-only; themes via
+ * `--surface-2` / `--teal` / `--border` / `--text*`.
+ *
+ * @category Overlays
+ */
+export function HoverCard({ placement = "bottom-end", role = "tooltip", className, ...rest }: Props) {
+  return <div className={cx("hovercard", `po-${placement}`, className)} role={role} {...rest} />;
+}
+
+/** Title row + optional system badge (e.g. "Armor Class" · AAC). */
+function Header({ title, badge }: { title: ReactNode; badge?: ReactNode }) {
+  return (
+    <div className="hc-h">
+      <span>{title}</span>
+      {badge != null && <span className="hc-sys">{badge}</span>}
+    </div>
+  );
+}
+
+/** Key/value breakdown list — the common case (Base / DEX modifier / …). */
+function Rows({ items }: { items: { label: ReactNode; value: ReactNode }[] }) {
+  return (
+    <ul className="hc-rows">
+      {items.map((it, i) => (
+        <li key={i}>
+          <span className="hc-k">{it.label}</span>
+          <span className="hc-v">{it.value}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/** Footer total row, with an optional trailing unit (e.g. 12 AAC). */
+function Total({ label, value, unit }: { label: ReactNode; value: ReactNode; unit?: ReactNode }) {
+  return (
+    <div className="hc-total">
+      <span>{label}</span>
+      <span className="hc-tv">
+        {value}
+        {unit != null && <small> {unit}</small>}
+      </span>
+    </div>
+  );
+}
+
+HoverCard.Anchor = Anchor;
+HoverCard.Header = Header;
+HoverCard.Rows = Rows;
+HoverCard.Total = Total;

--- a/src/ReactorSheet/components/ui/index.ts
+++ b/src/ReactorSheet/components/ui/index.ts
@@ -21,5 +21,7 @@ export { Die } from "./Die";
 export { Modal } from "./Modal";
 export { Toast } from "./Toast";
 export { Menu, MenuLabel, MenuSep, MenuItem } from "./Menu";
+export { HoverCard } from "./HoverCard";
+export type { HoverCardPlacement } from "./HoverCard";
 export { Empty } from "./Empty";
 export { Skeleton } from "./Skeleton";

--- a/src/ReactorSheet/styles/vellum/components.css
+++ b/src/ReactorSheet/styles/vellum/components.css
@@ -439,6 +439,141 @@
   z-index: 3;
 }
 
+/* ─── HoverCard — anchored read-only stat-breakdown popover ─────────────
+   Promoted from the prototype's one-off AC popover (.fvtt-acpop). A small
+   card anchored under the value it explains (e.g. the AC breakdown), revealed
+   on the anchor's :hover / :focus-within. Read-only → role="tooltip". Distinct
+   from .menu.is-popover, which is the interactive click-driven menu popover.
+   Token-only; themes via --surface-2 / --teal / --border / --text*. */
+
+/* Relative wrapper that drives the reveal. */
+.hovercard-anchor { position: relative; }
+
+.hovercard {
+  position: absolute;
+  z-index: 60;
+  width: 210px;
+  padding: 10px 11px 9px;
+  background: var(--surface-2);
+  border: 1px solid var(--teal);
+  border-radius: var(--r-lg);
+  box-shadow: 0 12px 30px oklch(0 0 0 / 0.45);
+  text-align: left;
+  cursor: default;
+  /* Hidden until the anchor is hovered/focused; lifts in from the placement edge. */
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-4px);
+  transition: opacity 0.13s, transform 0.13s;
+}
+/* Top placements lift up from below instead of down from above. */
+.hovercard.po-top-end,
+.hovercard.po-top-start { transform: translateY(4px); }
+
+.hovercard-anchor:hover > .hovercard,
+.hovercard-anchor:focus-within > .hovercard {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+/* Placement — vertical edge + horizontal alignment, with the arrow to match. */
+.hovercard.po-bottom-end   { top: calc(100% + 7px); right: 0; }
+.hovercard.po-bottom-start { top: calc(100% + 7px); left: 0; }
+.hovercard.po-top-end      { bottom: calc(100% + 7px); right: 0; }
+.hovercard.po-top-start    { bottom: calc(100% + 7px); left: 0; }
+
+/* Arrow — a small square rotated 45° with two teal borders, pinned under/over
+   the card's aligned edge. */
+.hovercard::before {
+  content: "";
+  position: absolute;
+  width: 9px;
+  height: 9px;
+  background: var(--surface-2);
+  transform: rotate(45deg);
+}
+.hovercard.po-bottom-end::before,
+.hovercard.po-bottom-start::before {
+  top: -5px;
+  border-left: 1px solid var(--teal);
+  border-top: 1px solid var(--teal);
+}
+.hovercard.po-top-end::before,
+.hovercard.po-top-start::before {
+  bottom: -5px;
+  border-right: 1px solid var(--teal);
+  border-bottom: 1px solid var(--teal);
+}
+.hovercard.po-bottom-end::before,
+.hovercard.po-top-end::before { right: 26px; }
+.hovercard.po-bottom-start::before,
+.hovercard.po-top-start::before { left: 26px; }
+
+/* Header — display title + optional mono system badge. */
+.hovercard .hc-h {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  font-family: var(--display);
+  font-size: var(--fs-md);
+  color: var(--text);
+  padding-bottom: 6px;
+  margin-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+.hovercard .hc-sys {
+  font-family: var(--mono);
+  font-size: var(--fs-3xs);
+  letter-spacing: 0.08em;
+  color: var(--teal);
+  border: 1px solid color-mix(in srgb, var(--teal) 45%, transparent);
+  border-radius: var(--r-sm);
+  padding: 1px 5px;
+}
+
+/* Rows — key/value breakdown list. */
+.hovercard .hc-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacer-1);
+}
+.hovercard .hc-rows li {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--spacer-2);
+}
+.hovercard .hc-k { font-family: var(--sans); font-size: var(--fs-xs); color: var(--text-dim); }
+.hovercard .hc-v { font-family: var(--mono); font-size: var(--fs-xs); color: var(--text); }
+
+/* Total — uppercase label + emphasized serif value with a small unit. */
+.hovercard .hc-total {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-top: 7px;
+  padding-top: 7px;
+  border-top: 1px solid var(--border);
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: var(--fs-2xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+}
+.hovercard .hc-tv {
+  font-family: var(--display);
+  font-size: var(--fs-xl);
+  color: var(--teal);
+  letter-spacing: 0;
+  text-transform: none;
+}
+.hovercard .hc-tv small { font-family: var(--mono); font-size: var(--fs-3xs); color: var(--text-mute); }
+
 /* ─── Tag / Badge ───────────────────────────────────────────────────── */
 
 .tag {

--- a/src/ReactorSheet/viewModels/types.ts
+++ b/src/ReactorSheet/viewModels/types.ts
@@ -9,9 +9,21 @@ export interface IdentityVM {
   title: string;
 }
 
+/** One line of the AC breakdown popover (e.g. "DEX modifier" → +1). */
+export interface AcBreakdownRow {
+  label: string;
+  /** Signed contribution to the ascending (AAC) total, e.g. "+10", "+1". */
+  value: string;
+}
+
 export interface VitalsVM {
   hp: { value: number; max: number };
-  ac: { ascending: number; descending: number };
+  ac: {
+    ascending: number;
+    descending: number;
+    /** Itemized AAC breakdown for the HoverCard (sums to `ascending`). */
+    breakdown: AcBreakdownRow[];
+  };
   initMod: number;
   hd: string;
   move: number;

--- a/src/ReactorSheet/viewModels/vitals.test.ts
+++ b/src/ReactorSheet/viewModels/vitals.test.ts
@@ -7,7 +7,15 @@ describe("selectVitals", () => {
     const vm = selectVitals(raistlin);
     expect(vm).toEqual({
       hp: { value: 8, max: 9 },
-      ac: { ascending: 12, descending: 7 },
+      ac: {
+        ascending: 12,
+        descending: 7,
+        breakdown: [
+          { label: "Base (unarmored)", value: "+10" },
+          { label: "DEX modifier", value: "+1" },
+          { label: "Misc modifier", value: "+1" },
+        ],
+      },
       initMod: 1,
       hd: "3d4",
       move: 120,

--- a/src/ReactorSheet/viewModels/vitals.ts
+++ b/src/ReactorSheet/viewModels/vitals.ts
@@ -1,11 +1,36 @@
 import type { OSEActor } from "../types/types";
-import type { VitalsVM } from "./types";
+import type { AcBreakdownRow, VitalsVM } from "./types";
+import { formatMod } from "./format";
+
+/** Build the itemized AAC (ascending) breakdown shown in the AC HoverCard.
+ *  Reads the exposed AC getters so the rows always sum to `aac.value`:
+ *  Base (or Armor when worn) + DEX modifier + Shield + Misc modifier. */
+function acBreakdown(aac: OSEActor["system"]["aac"]): AcBreakdownRow[] {
+  const rows: AcBreakdownRow[] = [];
+  const dex = aac.naked - aac.base; // dex contribution to ascending AC
+  const shield = aac.shield;
+  const misc = aac.mod;
+  // Armour overrides the unarmored base (per the data model); the delta from base
+  // is whatever the total isn't accounted for by dex/shield/misc.
+  const armorDelta = aac.value - (aac.base + dex + shield + misc);
+
+  rows.push({ label: "Base (unarmored)", value: formatMod(aac.base) });
+  if (armorDelta !== 0) rows.push({ label: "Armor", value: formatMod(armorDelta) });
+  if (dex !== 0) rows.push({ label: "DEX modifier", value: formatMod(dex) });
+  if (shield !== 0) rows.push({ label: "Shield", value: formatMod(shield) });
+  if (misc !== 0) rows.push({ label: "Misc modifier", value: formatMod(misc) });
+  return rows;
+}
 
 export function selectVitals(actor: OSEActor): VitalsVM {
   const { hp, aac, ac, scores, movement } = actor.system;
   return {
     hp: { value: hp.value, max: hp.max },
-    ac: { ascending: aac.value, descending: ac.value },
+    ac: {
+      ascending: aac.value,
+      descending: ac.value,
+      breakdown: acBreakdown(aac),
+    },
     initMod: scores.dex.init,
     hd: hp.hd,
     move: movement.base,


### PR DESCRIPTION
## Summary

Complete reskin of the reactor-sheet character sheet with the Vellum design system (tokens, typography, components) and implementation of P0–P2 foundation layers: style isolation, typed view-models, presentational UI kit, and responsive app shell.

## Key Changes

### Design System & Styles
- Vendor Vellum CSS (`styles.css`, `design-system.css`, fonts) into `src/ReactorSheet/styles/vellum/`, scoped to `.reactor-sheet` via PostCSS prefix plugin
- Add theme tokens (dark/cream), typography (IM Fell English, Inter, JetBrains Mono), spacing rhythm, and component classes
- Replace old styled-components shell with token-driven, container-query responsive layout (two-pane ⇄ stacked grid, vertical tab rail ↔ horizontal tab bar)

### View-Models & Data Layer
- Introduce pure `select*` functions mapping `actor.system.*` → typed display structs:
  - `identity`, `vitals`, `topbar`, `abilities`, `attacks`, `saves`, `exploration`, `features`, `inventory`, `spells`, `wealthMovement`, `format`
- Unit-tested against Raistlin fixture; no Foundry/actor/`game` access in view-models
- Typed `types.ts` for all display structs

### Presentational Components (P2 UI Kit)
- New `src/ReactorSheet/components/ui/` with 30+ Ladle-storied components:
  - Form controls: `Button`, `Field`, `Input`, `Select`, `Textarea`, `Toggle`, `Radio`, `Check`
  - Layout: `Card`, `Table`, `Tabs`, `Modal`, `Menu`, `HoverCard`
  - Display: `Stamp`, `Tag`, `Badge`, `ProgressBar`, `Skeleton`, `Empty`, `Toast`, `Die`, `SectionTitle`
  - All consume Vellum tokens, work in both themes, no business logic

### App Shell & Responsive Layout (P3)
- `Shell` component: two-pane grid with optional slot props (topbar, header, left rail, body, right rail, bottom bar)
- `TabRail` (vertical, collapses to `TabBar` horizontal on wide screens) with working tab routing
- `Placeholder` regions for future chrome (Minibar, HeaderBand, etc.)
- Container-query responsive: mobile-first base, progressive enhancement as window grows

### Page Components
- `ActionsView`: composes Actions sections (Abilities, Attacks, Saves/Exploration, Wealth/Movement)
- `AbilityPlaques`, `AttacksTable`, `SavesExploration`, `WealthMovement`: read-only, bound to view-models
- `InventoryViewDnd`: drag-reorder grid (no edit yet)
- `SpellLevel`: spell list by level (no cast/prepare yet)
- `Abilities` (Features): feature cards with descriptions

### Removed
- Old styled-components shell (`Layout`, `Nav`, `TabContent`, `Footer`)
- Old component tree (`ActorScores`, `Header/*`, `SheetPages/Actions/*`, `SheetPages/InventoryPage/*`, etc.)
- Inline roll buttons, context menus, edit-in-place (deferred to interactive pass)

### Build & Tooling
- Add Ladle (component explorer) with `vite.ladle.config.ts`, `.ladle/config.mjs`, `.ladle/components.tsx`
- Add Vitest (`vitest.config.ts`, `node` env) for view-model unit tests
- Add PostCSS plugin (`tools/postcss/scope-vellum.mjs`) to prefix Vellum tokens to `.reactor-sheet`
- Add design-sync config (`.design-sync/`) for Figma ↔ code sync
- Update `package.json`, `vite.config.ts`, `eslint.config.js`

### Documentation
- Design handoff specs: `docs/design-handoff/`, `docs/design_handoff_foundry_sheet/`

https://claude.ai/code/session_01FZ2grBRe6e93GBmg7vUoMg