### PR TITLE
feat(classes): adapt Advanced Fantasy classes into CONFIG.OSE.classes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import ReactorSheet from "./applications/reactor-sheet";
+import { installAdvancedClasses } from "./util/adaptAdvancedClasses";
 import logger from "./util/logger";
 
 export function initialize() {
@@ -9,6 +10,7 @@ export function initialize() {
 
   foundry.helpers.Hooks.once("ready", async () => {
     logger("Initializing React application");
+    installAdvancedClasses();
     foundry.documents.collections.Actors.registerSheet(
       game.system?.id,
       ReactorSheet,

--- a/src/util/adaptAdvancedClasses.test.ts
+++ b/src/util/adaptAdvancedClasses.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { adaptAdvancedClass } from "./adaptAdvancedClasses";
+
+// Trimmed real data from OSE.data.classes.advanced (maxLvl shortened to 5 so
+// breakpoint expansion crosses exactly one boundary at level 5).
+const acrobat = {
+  name: "acrobat",
+  menu: "Acrobat",
+  pack: "ose-advancedfantasytome.abilities",
+  hdArr: ["1d4", "2d4", "3d4", "4d4", "5d4"],
+  saves: { "1": [13, 14, 13, 16, 15], "5": [12, 13, 11, 14, 13] },
+  thac0: { "1": [19, 0], "5": [17, 2] },
+  xp: [1200, 2400, 4800, 9600],
+  req: "None",
+  spellCaster: false,
+  maxLvl: 5,
+};
+
+const bard = {
+  name: "bard",
+  menu: "Bard",
+  pack: "ose-advancedfantasytome.abilities",
+  hdArr: ["1d6", "2d6", "3d6"],
+  saves: { "1": [13, 14, 13, 16, 15] },
+  thac0: { "1": [19, 0] },
+  xp: [2000, 4000],
+  req: "Minimum DEX 9, minimum INT 9",
+  spellCaster: true,
+  spellPackName: "old-school-essentials.ose spells",
+  // slot levels 4-6 never exceed 0 → trimmed to a length-3 spells array.
+  spellSlot: {
+    "1": { "1": { max: 0 }, "2": { max: 0 }, "3": { max: 0 }, "4": { max: 0 } },
+    "2": { "1": { max: 1 }, "2": { max: 0 }, "3": { max: 0 }, "4": { max: 0 } },
+    "3": { "1": { max: 2 }, "2": { max: 1 }, "3": { max: 1 }, "4": { max: 0 } },
+  },
+  maxLvl: 3,
+};
+
+describe("adaptAdvancedClass", () => {
+  it("maps a non-caster, expanding breakpoint tables to per-level", () => {
+    const def = adaptAdvancedClass(acrobat);
+
+    expect(def.name).toBe("Acrobat");
+    expect(def.source).toBe("Advanced Fantasy");
+    expect(def.abilitiesPack).toBe("ose-advancedfantasytome.abilities");
+    expect(def.requirements).toEqual({});
+    expect(def.spellsPack).toBeUndefined();
+    expect(def.levels).toHaveLength(5);
+
+    // level 1: xp 0, first breakpoint (thac0 single value, not the pair).
+    expect(def.levels[0]).toEqual({
+      xp: 0,
+      hd: "1d4",
+      thac0: 19,
+      saves: [13, 14, 13, 16, 15],
+    });
+    // level 4 still on the "1" breakpoint; xp from raw.xp[2].
+    expect(def.levels[3].thac0).toBe(19);
+    expect(def.levels[3].xp).toBe(4800);
+    // level 5 crosses to the "5" breakpoint.
+    expect(def.levels[4].thac0).toBe(17);
+    expect(def.levels[4].saves).toEqual([12, 13, 11, 14, 13]);
+    expect(def.levels[4].xp).toBe(9600);
+    // non-casters carry no spells array.
+    expect(def.levels[0].spells).toBeUndefined();
+  });
+
+  it("maps a caster: parses multi requirements, trims trailing empty spell levels", () => {
+    const def = adaptAdvancedClass(bard);
+
+    expect(def.requirements).toEqual({ dex: 9, int: 9 });
+    expect(def.spellsPack).toBe("old-school-essentials.ose spells");
+    // highest non-zero slot is spell level 3 → length-3 arrays.
+    expect(def.levels[0].spells).toEqual([0, 0, 0]);
+    expect(def.levels[1].spells).toEqual([1, 0, 0]);
+    expect(def.levels[2].spells).toEqual([2, 1, 1]);
+  });
+});

--- a/src/util/adaptAdvancedClasses.ts
+++ b/src/util/adaptAdvancedClasses.ts
@@ -1,0 +1,137 @@
+import type { Attribute, OseClass } from "@ose-foundry-core/types";
+import logger from "./logger";
+
+/**
+ * Adapts the OSE Advanced Fantasy tome's class data into the canonical
+ * `OseClass` shape and stores it at `CONFIG.OSE.classes.advanced`.
+ *
+ * The classic-fantasy module publishes canonical defs at
+ * `CONFIG.OSE.classes.classic`, but the advanced tome only exposes a different
+ * raw shape on the `OSE.data.classes.advanced` global. This bridges the two so
+ * reactor-sheet can read every class from one canonical place.
+ */
+
+/** The advanced tome's raw per-class shape (only the fields we consume). */
+interface RawAdvancedClass {
+  /** Display name, e.g. "Bard". */
+  menu: string;
+  /** Slug, e.g. "bard" — fallback when `menu` is missing. */
+  name: string;
+  /** Abilities compendium pack id. */
+  pack: string;
+  /** HD formula per level (index 0 = level 1). */
+  hdArr: string[];
+  /** Saves keyed by level breakpoint ("1","5","9","13") → 5-tuple. */
+  saves: Record<string, number[]>;
+  /** THAC0 keyed by level breakpoint → [thac0, attackBonus]. */
+  thac0: Record<string, number[]>;
+  /** XP thresholds for levels 2..maxLvl (index 0 = level 2). */
+  xp: number[];
+  /** Free-text requirement string, e.g. "Minimum DEX 9, minimum INT 9". */
+  req: string;
+  spellCaster: boolean;
+  /** spellSlot[level][spellLevel] = { max }. */
+  spellSlot?: Record<string, Record<string, { max: number }>>;
+  spellPackName?: string;
+  maxLvl: number;
+}
+
+const ABILITIES = ["str", "dex", "con", "int", "wis", "cha"] as const;
+const REQ_RE = new RegExp(`(${ABILITIES.join("|")})\\s+(\\d+)`, "gi");
+
+/** Parse "Minimum DEX 9, minimum INT 9" → { dex: 9, int: 9 }; "None"/"" → {}. */
+function parseRequirements(req: string): Partial<Record<Attribute, number>> {
+  const out: Partial<Record<Attribute, number>> = {};
+  if (!req) return out;
+  for (const [, ability, value] of req.matchAll(REQ_RE)) {
+    out[ability.toLowerCase() as Attribute] = Number(value);
+  }
+  return out;
+}
+
+/** Value from a breakpoint table (keys "1","5",…) for the given level. */
+function atBreakpoint<T>(table: Record<string, T>, level: number): T {
+  const keys = Object.keys(table)
+    .map(Number)
+    .sort((a, b) => a - b);
+  let chosen = keys[0];
+  for (const k of keys) if (k <= level) chosen = k;
+  return table[String(chosen)];
+}
+
+/** Highest spell level (1..n) with any non-zero slot; 0 if non-caster. */
+function maxSpellLevel(slots: RawAdvancedClass["spellSlot"]): number {
+  let max = 0;
+  if (!slots) return max;
+  for (const perLevel of Object.values(slots)) {
+    for (const [spellLevel, { max: m }] of Object.entries(perLevel)) {
+      if (m > 0) max = Math.max(max, Number(spellLevel));
+    }
+  }
+  return max;
+}
+
+/** Adapt one raw advanced class to the canonical `OseClass` shape. */
+export function adaptAdvancedClass(raw: RawAdvancedClass): OseClass {
+  const levelCount = raw.maxLvl ?? raw.hdArr.length;
+  const spellLevels = raw.spellCaster ? maxSpellLevel(raw.spellSlot) : 0;
+
+  const levels: OseClass["levels"] = [];
+  for (let level = 1; level <= levelCount; level++) {
+    const entry: OseClass["levels"][number] = {
+      // level 1 starts at 0 XP; raw.xp[0] is the level-2 threshold.
+      xp: level === 1 ? 0 : (raw.xp[level - 2] ?? 0),
+      hd: raw.hdArr[level - 1],
+      thac0: atBreakpoint(raw.thac0, level)[0],
+      saves: atBreakpoint(raw.saves, level),
+    };
+    if (spellLevels > 0) {
+      const perLevel = raw.spellSlot?.[String(level)] ?? {};
+      entry.spells = Array.from(
+        { length: spellLevels },
+        (_, i) => perLevel[String(i + 1)]?.max ?? 0,
+      );
+    }
+    levels.push(entry);
+  }
+
+  const def: OseClass = {
+    name: raw.menu ?? raw.name,
+    abilitiesPack: raw.pack,
+    requirements: parseRequirements(raw.req),
+    source: "Advanced Fantasy",
+    levels,
+  };
+  if (raw.spellCaster && raw.spellPackName) def.spellsPack = raw.spellPackName;
+  return def;
+}
+
+/** `CONFIG.OSE.classes` widened to allow the `advanced` group we add. */
+type ClassesWithAdvanced = (typeof CONFIG.OSE)["classes"] & {
+  advanced: Record<string, OseClass>;
+};
+
+/**
+ * Boot-time adapter: if the advanced tome's raw class data is present, adapt
+ * every class and store the result at `CONFIG.OSE.classes.advanced`. No-op when
+ * the global is absent (tome not installed). Returns the count adapted.
+ */
+export function installAdvancedClasses(): number {
+  const advanced = (globalThis as { OSE?: { data?: { classes?: { advanced?: Record<string, RawAdvancedClass> } } } })
+    .OSE?.data?.classes?.advanced;
+  if (!advanced || typeof advanced !== "object") {
+    logger("No OSE.data.classes.advanced found; skipping advanced class adapter");
+    return 0;
+  }
+
+  const classes = CONFIG.OSE.classes as ClassesWithAdvanced;
+  const target: Record<string, OseClass> = (classes.advanced ??= {});
+  for (const raw of Object.values(advanced)) {
+    const def = adaptAdvancedClass(raw);
+    target[def.name] = def;
+  }
+
+  const count = Object.keys(target).length;
+  logger(`Adapted ${count} advanced classes into CONFIG.OSE.classes.advanced`);
+  return count;
+}


### PR DESCRIPTION
## What

The OSE Advanced Fantasy tome exposes its 15 class definitions on the `OSE.data.classes.advanced` global in a **different shape** than the canonical `OseClass` defs the classic-fantasy module publishes at `CONFIG.OSE.classes.classic`. This adds a boot-time adapter that maps the advanced classes into the canonical shape and stores them at `CONFIG.OSE.classes.advanced`, so reactor-sheet can read every class from one place.

## How

- `src/util/adaptAdvancedClasses.ts`
  - `adaptAdvancedClass()` — pure transform. Expands breakpoint-keyed `saves`/`thac0` tables to per-level, offsets XP (level 1 = 0; raw `xp[0]` is the level-2 threshold), parses the free-text `req` string into `requirements` (`{dex:9,…}`), and trims trailing all-zero spell levels so each caster's `spells` array is its true length (Paladin/Ranger 3 → Illusionist 6). Non-casters omit `spells`/`spellsPack`.
  - `installAdvancedClasses()` — boot entry, called from the `ready` hook (after both the advanced tome and classic module have populated their data). No-op when the tome isn't installed.
- `src/main.ts` — wires `installAdvancedClasses()` into `ready`.
- Reuses the published `OseClass` / `Attribute` types as the output contract; casts `CONFIG.OSE.classes` to a widened type to add the `advanced` group (the type only declares `classic`).

## Verification

- `tsc -b`, `vite build`, `pnpm lint`, `pnpm test` (60 tests) all green.
- New unit tests cover the non-caster (breakpoint expansion) and caster (multi-requirement parse + spell-level trimming) paths.
- Ran the transform live against all 15 real advanced classes: output is structurally identical to the canonical `classic` defs (same 6 keys), with variable level counts (8/10/12/14), requirements, spell-array lengths, and THAC0 progression all correct.

## Known gaps (source data, not adapter)

- **`skillChecks` unavailable** — the source `classTables` field is empty (`""`) for **all 15** classes, so skill-based classes (Acrobat, Assassin, Ranger) get no per-level thief-skill table. Canonical `OseClass.skillChecks` is optional, so it's omitted.
- **`spellType` dropped** — source carries a `spellType` (arcane/divine list: cleric/druid/magic-user/illusionist) that the canonical `OseClass` shape has no field for. All advanced casters' `spellsPack` resolves to the same base `old-school-essentials.ose spells` pack, so `spellType` was the only discriminator between lists — lost in adaptation. Worth revisiting if the sheet needs to filter spell lists by class.
- **`requirements` is a heuristic parse** of free text — robust for these 15 (all use "Minimum XXX 9"/"None"/""), but brittle to other phrasings.
- No structural/numeric gaps: every class has full HD, XP, saves, THAC0, and spell-slot coverage.