### PR TITLE
design-sync: subtle section-header guidance

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -61,6 +61,14 @@ library under `src/ReactorSheet/components/ui/`.
   (Controls/Display/Layout/Overlays/Navigation/Data). Adding a primitive → add its
   `@category`. KvCard needs its OWN `@category` (it's the 2nd export in Card.tsx).
 
+## Parallel story set (Ladle)
+
+- The repo ALSO has Ladle stories at `src/ReactorSheet/components/ui/*.stories.tsx` — a
+  separate catalog from the synced `.design-sync/previews/*.tsx`. The sync (package shape)
+  reads ONLY `previews/`, never the stories. They're independent files: when you change a
+  component's authored preview, mirror the same exports into its `*.stories.tsx` so the two
+  catalogs don't drift (e.g. SectionTitle's `Sub`/`Bare` variants live in both).
+
 ## Re-sync risks (what can silently go stale)
 
 - **`build-css.mjs` mirrors the app pipeline by hand.** If the repo changes how Vellum CSS

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -41,6 +41,24 @@ attribute on a `.reactor-sheet` ancestor.
   <div style={{ display: "flex", gap: "var(--spacer-3)", color: "var(--text-dim)" }}>…</div>
   ```
 
+## Section headers — use `<SectionTitle>`, never a bold white underline
+
+Section/group headings are a defining part of the Vellum look and they are **subtle**:
+display serif (`--display`) at normal weight in `--text` ink, over a thin **2px
+`var(--section-rule)`** hairline (= `--border`, a muted parchment/ink line — NOT white,
+NOT thick/heavy). Always render them with the `<SectionTitle>` component:
+
+```jsx
+<SectionTitle hint="3 prepared">Spells</SectionTitle>   {/* main head: serif + hairline rule */}
+<SectionTitle variant="sub">Equipped</SectionTitle>     {/* small uppercase sans label, no rule */}
+<SectionTitle variant="bare">Modal title</SectionTitle> {/* serif, no rule/margins (embedded heads) */}
+```
+
+**Do not** hand-roll a heading as bold white text with a heavy or white underline — that
+reads as a different design system. If you must style a heading yourself, match the
+component: `font-family: var(--display)`, normal weight, `color: var(--text)`, and a
+`2px solid var(--section-rule)` bottom border (none for `sub`/`bare`).
+
 ## Where the truth lives
 
 - `styles.css` is the whole styling closure (it `@import`s `_ds_bundle.css` — the scoped

--- a/.design-sync/previews/SectionTitle.tsx
+++ b/.design-sync/previews/SectionTitle.tsx
@@ -5,3 +5,9 @@ export const WithHint = () => (
 );
 
 export const WithoutHint = () => <SectionTitle>Inventory</SectionTitle>;
+
+// `sub` — small uppercase sans label for sub-section heads, no rule.
+export const Sub = () => <SectionTitle variant="sub">Equipped</SectionTitle>;
+
+// `bare` — display serif, rule + margins dropped (embedded heads like a modal title).
+export const Bare = () => <SectionTitle variant="bare">Character Details</SectionTitle>;

--- a/src/ReactorSheet/components/ui/SectionTitle.stories.tsx
+++ b/src/ReactorSheet/components/ui/SectionTitle.stories.tsx
@@ -7,3 +7,9 @@ export const WithHint = () => (
 );
 
 export const WithoutHint = () => <SectionTitle>Inventory</SectionTitle>;
+
+// `sub` — small uppercase sans label for sub-section heads, no rule.
+export const Sub = () => <SectionTitle variant="sub">Equipped</SectionTitle>;
+
+// `bare` — display serif, rule + margins dropped (embedded heads like a modal title).
+export const Bare = () => <SectionTitle variant="bare">Character Details</SectionTitle>;


### PR DESCRIPTION
Re-syncs the Vellum DS to claude.ai/design from latest `main` and fixes the recurring issue where the Claude Design agent renders section headers as **bold white underlines** instead of the subtle Vellum rule.

## Changes (sync inputs only)
- **conventions.md** (inlined into the design agent's prompt): new `Section headers` section — always use `<SectionTitle>`; the rule is a subtle 2px `var(--section-rule)` hairline (= `--border`), display serif at `--text` ink; explicitly forbids hand-rolled bold/white underlines.
- **SectionTitle preview + Ladle story**: added `Sub` and `Bare` variant exports so both catalogs demonstrate the subtle treatment. Kept the two parallel sets (`.design-sync/previews/` and `*.stories.tsx`) in sync.
- **NOTES.md**: documented that previews/ and Ladle stories are parallel catalogs to keep consistent.

The design project itself was re-uploaded (24 components, render check clean, SectionTitle re-graded good).

https://claude.ai/code/session_016vbVynnB3SDg7hWCVxsJdg