### PR TITLE
Inventory: drag items onto the macro hotbar to create attack macros

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Run Playwright E2E suite
         working-directory: tools/e2e
-        run: npx playwright test
+        run: npx playwright test --forbid-only --workers=1
 
       - name: Upload Playwright report
         if: always()

--- a/README.md
+++ b/README.md
@@ -1,32 +1,67 @@
-# Re-Actor Sheet
+# OSE Re-Actor Sheet
 
-An alternative Old School Essentials character sheet, built with React.
+A fresh, responsive character sheet for **[Old School Essentials](https://necroticgnome.com/)** in Foundry VTT — rebuilt in React for a faster, cleaner play experience.
 
-## Release Process
+> **Requires the [Old School Essentials](https://foundryvtt.com/packages/ose) game system.** Re-Actor replaces the character sheet; your actors, items, and data are untouched.
 
-1. Build the code `pnpm build`
-2. Run the release script `pnpm release --type=<patch|minor|major> (--dry-run optional)`
+![Foundry v13](https://img.shields.io/badge/Foundry-v13%E2%80%93v14-informational) ![System: OSE](https://img.shields.io/badge/system-OSE-orange)
 
-Release script will:
+---
 
-- Build the package to dist/
-- Update the version in module.json based on type argument
-- Commit the changes and push to origin
-- Create a relase (and tag) on GitHub for the new version
+## Install
 
-## Foundry React Application Framework
+Re-Actor will be on the official Foundry package listing soon. Until then, install by manifest:
 
-Components
+1. In Foundry, open **Add-on Modules → Install Module**.
+2. Paste this **Manifest URL** into the bottom field:
 
-- ReactApplication - mounts a React app to a Foundry Application window
-- ContextConnector - event emitter to allow React app to receive lifecycle events from Foundry Application (aka document changes).
+   ```
+   https://raw.githubusercontent.com/tasandberg/reactor-sheet/main/module.json
+   ```
 
-Development Tools:
+3. Click **Install**.
+4. Launch your OSE world, then enable **OSE Re-Actor Sheet** under **Game Settings → Manage Modules**.
 
-- main.js - contains a development-only adapter to enable React fast refresh and HMR in Foundry.
-- \_main.js - the actual module entry point.
-- Vite config:
-  - Dev server and proxy to local foundry instance
-  - Build config for building app to dist/
-  - Uses main.js as entry point for dev and \_main.js for production build
-- tools/release.mjs - release script to automate module versioning and GitHub releases/tags
+Open any character actor — Re-Actor takes over as the sheet automatically.
+
+## Why Re-Actor
+
+### Responsive by design — reclaim your screen
+
+The sheet adapts to whatever space you give it. Drag the window narrow and tabs collapse to the bottom with a compact stat minibar; widen it and navigation moves to a roomy side rail. Run a tight one-window-among-many table without sacrificing legibility, or stretch out when you've got the room.
+
+### Pop out for the luxe experience
+
+Send the sheet to its own browser window and treat it like a proper play surface — full-size on a second monitor or tablet while your map and tokens own the main screen. Same sheet, all the elbow room.
+
+### Built for OSE
+
+Coins, encumbrance, weapon tags, attacks, and inventory are modeled on the OSE data system — drag an item to the macro hotbar to spin up an attack macro, equip from the inventory, and keep your numbers in sync with the actor.
+
+## Compatibility
+
+| | |
+|---|---|
+| **Foundry VTT** | v13 minimum · v14 verified |
+| **Game system** | Old School Essentials (`ose`) |
+
+## Feedback & issues
+
+Bug reports and feature requests are welcome on the [issue tracker](https://github.com/tasandberg/reactor-sheet/issues).
+
+---
+
+## Built with foundry-vtt-react
+
+Re-Actor is a React application mounted onto Foundry's ApplicationV2 via **[foundry-vtt-react](https://www.npmjs.com/package/foundry-vtt-react)** — a small framework for building React-powered sheets and apps that stay in sync with Foundry documents. If you're building your own React sheet, that's the place to start.
+
+## Development
+
+```bash
+pnpm dev      # Vite dev server, hot-reloaded into local Foundry
+pnpm build    # tsc -b && vite build → dist/
+pnpm lint
+pnpm test
+```
+
+**Release:** `pnpm build`, then `pnpm release --type=<patch|minor|major>` (add `--dry-run` to preview). The release script builds to `dist/`, bumps the version in `module.json`, commits, pushes, and cuts a tagged GitHub release.

--- a/src/ReactorSheet/features/actions/ActionsView.tsx
+++ b/src/ReactorSheet/features/actions/ActionsView.tsx
@@ -1,10 +1,11 @@
-import type { OSEActor, OSESave } from "@domain/types";
+import type { OSEActor, OSESave, OseItem } from "@domain/types";
 import type { RollSpec } from "@domain/vm-types";
 import { selectAbilities } from "@features/actions/abilities";
 import { selectAttacks } from "@features/actions/attacks";
 import { selectSaves } from "@features/actions/saves";
 import { selectExploration, rollExploration } from "@features/actions/exploration";
 import { postRollCard } from "@domain/chat/attackCard";
+import { buildItemMacroDragData } from "@features/inventory/dragToMacro";
 import { AbilityPlaques } from "@features/actions/AbilityPlaques";
 import { AttacksTable } from "@features/actions/AttacksTable";
 import { MemorizedSpells } from "@features/actions/MemorizedSpells";
@@ -27,13 +28,19 @@ export function ActionsView({ actor }: Props) {
     actor.system.weapons.find((w) => w._id === itemId)?.rollWeapon({ skipDialog: false });
   const onSave = (key: OSESave) => actor.rollSave(key, {});
   const onExploration = (key: string) => rollExploration(actor, key);
+  // Drag a weapon card onto the macro hotbar → OSE's hotbarDrop creates an attack
+  // macro, same as dragging the item's inventory row.
+  const dragData = (itemId: string) => {
+    const item = actor.items.get(itemId) as unknown as OseItem | undefined;
+    return item ? buildItemMacroDragData(actor, item) : undefined;
+  };
 
   const attacks = selectAttacks(actor);
 
   return (
     <>
       <AbilityPlaques abilities={selectAbilities(actor)} onRoll={onAbility} />
-      <AttacksTable attacks={attacks} onRoll={onRoll} onAttack={onAttack} />
+      <AttacksTable attacks={attacks} onRoll={onRoll} onAttack={onAttack} dragData={dragData} />
       <MemorizedSpells actor={actor} />
       {/* .actions-only: hidden at lg (Saves/Exploration live in the rail there). */}
       <section className="rs-section actions-only">

--- a/src/ReactorSheet/features/actions/AttacksTable.tsx
+++ b/src/ReactorSheet/features/actions/AttacksTable.tsx
@@ -53,7 +53,7 @@ function WeaponRow({ a, onRoll, onAttack, dragData }: { a: AttackVM; onRoll?: Pr
     <div className="rs-weapon" role="row" data-testid={`weapon-row-${a.itemId}`}>
       <div className="winfo">
         {a.img ? (
-          <img className="wic wic-img" src={a.img} alt="" {...macroDrag} />
+          <img className="wic wic-img" data-testid={`weapon-img-${a.itemId}`} src={a.img} alt="" {...macroDrag} />
         ) : (
           <span className="wic" aria-hidden="true" {...macroDrag}>{monogram(a.name)}</span>
         )}

--- a/src/ReactorSheet/features/actions/AttacksTable.tsx
+++ b/src/ReactorSheet/features/actions/AttacksTable.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type DragEvent } from "react";
 import type { AttackVM, RollSpec } from "@domain/vm-types";
 import { SectionTitle } from "@ui/SectionTitle";
 import { cx } from "@ui/cx";
@@ -9,6 +9,9 @@ type Props = {
   onRoll?: (spec: RollSpec) => void;
   /** Composite attack roll (OSE weapon dialog). */
   onAttack?: (itemId: string) => void;
+  /** Foundry item drag-data for a weapon, so its card drops onto the macro hotbar
+   *  to create an attack macro (same as an inventory row). undefined = not draggable. */
+  dragData?: (itemId: string) => string | undefined;
 };
 
 /** Monogram glyph for the ink-stamp weapon icon (first letter, Title-case). */
@@ -20,18 +23,39 @@ const kindIcon = (kind: "melee" | "missile") => (kind === "melee" ? "fa-sword" :
 
 /** One weapon card. A melee+missile weapon shows both kind tags as a toggle
  *  (melee active by default); the active mode drives Hit/Dmg. */
-function WeaponRow({ a, onRoll, onAttack }: { a: AttackVM; onRoll?: Props["onRoll"]; onAttack?: Props["onAttack"] }) {
+function WeaponRow({ a, onRoll, onAttack, dragData }: { a: AttackVM; onRoll?: Props["onRoll"]; onAttack?: Props["onAttack"]; dragData?: Props["dragData"] }) {
   const [active, setActive] = useState(0); // index into a.modes (melee = 0)
   const mode = a.modes[active] ?? a.modes[0];
   const dual = a.modes.length > 1;
+
+  // Drag the weapon image or the Attack button onto the macro hotbar → OSE's
+  // hotbarDrop creates an attack macro (same payload as the inventory row).
+  const macroDrag = dragData
+    ? {
+        draggable: true,
+        onDragStart: (e: DragEvent<HTMLElement>) => {
+          const payload = dragData(a.itemId);
+          if (!payload) {
+            e.preventDefault();
+            return;
+          }
+          e.dataTransfer.effectAllowed = "all";
+          try {
+            e.dataTransfer.setData("text/plain", payload);
+          } catch {
+            /* IE guard */
+          }
+        },
+      }
+    : {};
 
   return (
     <div className="rs-weapon" role="row" data-testid={`weapon-row-${a.itemId}`}>
       <div className="winfo">
         {a.img ? (
-          <img className="wic wic-img" src={a.img} alt="" />
+          <img className="wic wic-img" src={a.img} alt="" {...macroDrag} />
         ) : (
-          <span className="wic" aria-hidden="true">{monogram(a.name)}</span>
+          <span className="wic" aria-hidden="true" {...macroDrag}>{monogram(a.name)}</span>
         )}
         <div className="wmain">
           <div className="wname">
@@ -107,6 +131,7 @@ function WeaponRow({ a, onRoll, onAttack }: { a: AttackVM; onRoll?: Props["onRol
         type="button"
         className="fvtt-atk"
         data-testid={`weapon-attack-${a.itemId}`}
+        {...macroDrag}
         disabled={!onAttack}
         onClick={() => onAttack?.(a.itemId)}
         title="Attack roll (hit + damage)"
@@ -122,13 +147,13 @@ function WeaponRow({ a, onRoll, onAttack }: { a: AttackVM; onRoll?: Props["onRol
 /** Equipped-weapon attacks as woodcut weapon cards: ink-stamp monogram, name +
  *  melee/missile + quality tags, clickable HIT/DMG stat cells (FA dice), and a
  *  tall brass Attack button (full hit + damage via the OSE weapon dialog). */
-export function AttacksTable({ attacks, onRoll, onAttack }: Props) {
+export function AttacksTable({ attacks, onRoll, onAttack, dragData }: Props) {
   return (
     <section className="rs-section rs-atk">
       <SectionTitle hint="click to roll">Attacks</SectionTitle>
       <div className="rs-wtable">
         {attacks.map((a) => (
-          <WeaponRow key={a.id} a={a} onRoll={onRoll} onAttack={onAttack} />
+          <WeaponRow key={a.id} a={a} onRoll={onRoll} onAttack={onAttack} dragData={dragData} />
         ))}
       </div>
     </section>

--- a/src/ReactorSheet/features/inventory/InventoryViewDnd.tsx
+++ b/src/ReactorSheet/features/inventory/InventoryViewDnd.tsx
@@ -19,14 +19,21 @@ import type {
 } from "@domain/vm-types";
 import { sortInventory, SORT_DEFAULT_DIR } from "@features/inventory/inventory";
 import { useDragReorder } from "@features/inventory/useDragReorder";
+import { buildItemMacroDragData } from "@features/inventory/dragToMacro";
 import { WealthSection } from "@features/inventory/WealthSection";
 import { ItemImage } from "@features/inventory/ItemImage";
 import { SortHeader } from "@features/inventory/SortHeader";
+import { useReactorSheetContext } from "@app/context";
 import { SectionTitle } from "@ui/SectionTitle";
 import { Tag } from "@ui/Tag";
 import { cx } from "@ui/cx";
+import type { OseItem } from "@domain/types";
 
 type Dnd = ReturnType<typeof useDragReorder>;
+
+/** Per-row Foundry drag payload → drop onto the macro hotbar. undefined = row isn't
+ *  a draggable-to-macro item (default `<group>:<idx>` reorder payload is used). */
+type ItemDragData = (id: string) => string | undefined;
 
 type Ops = {
   onEquip: (id: string) => void;
@@ -208,6 +215,7 @@ function SortableRow({
   group,
   depth,
   dnd,
+  itemDragData,
   onEquip,
   onOpen,
   onContext,
@@ -217,6 +225,7 @@ function SortableRow({
   group: string;
   depth: number;
   dnd: Dnd;
+  itemDragData: ItemDragData;
   onEquip: (id: string) => void;
   onOpen: (id: string) => void;
   onContext: OnContext;
@@ -237,6 +246,7 @@ function SortableRow({
       {...dnd.rowProps(group, index, {
         ownZone: group,
         acceptCrossGroup: group === ROOT ? (from) => from !== EQUIPPED : false,
+        dragPayload: () => itemDragData(item.id),
       })}
     >
       <span className="rs-inv-drag" aria-hidden="true">
@@ -258,6 +268,7 @@ function ContainerRow({
   byId,
   collapsed,
   dnd,
+  itemDragData,
   onToggle,
   onEquip,
   onOpen,
@@ -269,6 +280,7 @@ function ContainerRow({
   byId: Map<string, InventoryItemVM>;
   collapsed: boolean;
   dnd: Dnd;
+  itemDragData: ItemDragData;
   onToggle: (id: string) => void;
   onEquip: (id: string) => void;
   onOpen: (id: string) => void;
@@ -306,6 +318,7 @@ function ContainerRow({
           containerZone: item.id,
           ownZone: ROOT,
           acceptCrossGroup: (from) => from !== EQUIPPED,
+          dragPayload: () => itemDragData(item.id),
         })}
       >
         <span className="rs-inv-drag" aria-hidden="true">
@@ -341,6 +354,7 @@ function ContainerRow({
                 group={group}
                 depth={1}
                 dnd={dnd}
+                itemDragData={itemDragData}
                 onEquip={onEquip}
                 onOpen={onOpen}
                 onContext={onContext}
@@ -456,6 +470,7 @@ function equippedStats(
 function EquippedTray({
   items,
   dnd,
+  itemDragData,
   onOpen,
   onContext,
   equipDropActive,
@@ -463,6 +478,7 @@ function EquippedTray({
 }: {
   items: InventoryItemVM[];
   dnd: Dnd;
+  itemDragData: ItemDragData;
   onOpen: (id: string) => void;
   onContext: OnContext;
   /** An All-Items row is mid-drag — the tray is a live equip drop target. */
@@ -506,7 +522,11 @@ function EquippedTray({
             dnd.rowClass(EQUIPPED, i),
           )}
           onContextMenu={(e) => onContext(e, item)}
-          {...dnd.rowProps(EQUIPPED, i, { ownZone: EQUIPPED, axis: "x" })}
+          {...dnd.rowProps(EQUIPPED, i, {
+            ownZone: EQUIPPED,
+            axis: "x",
+            dragPayload: () => itemDragData(item.id),
+          })}
         >
           <button
             type="button"
@@ -690,6 +710,15 @@ export function InventoryViewDnd({
   const [listOver, setListOver] = useState(false); // tray tile hovering the list → unequip
   const [menu, setMenu] = useState<MenuState | null>(null);
 
+  // Foundry items by id — source for the hotbar drag payload. Dragging a row onto
+  // the macro bar creates an item macro (OSE's hotbarDrop hook), like the stock sheet.
+  const { actor, items } = useReactorSheetContext();
+  const itemsById = new Map<string, OseItem>(items.map((it) => [it._id, it]));
+  const itemDragData: ItemDragData = (id) => {
+    const it = itemsById.get(id);
+    return it ? buildItemMacroDragData(actor, it) : undefined;
+  };
+
   const openMenu: OnContext = (e, item) => {
     e.preventDefault();
     setMenu({ item, x: e.clientX, y: e.clientY });
@@ -862,6 +891,7 @@ export function InventoryViewDnd({
             <EquippedTray
               items={trayItems}
               dnd={dnd}
+              itemDragData={itemDragData}
               onOpen={onOpen}
               onContext={openMenu}
               // Equip-by-drop only for an All-Items row drag (not a tray-internal reorder).
@@ -937,6 +967,7 @@ export function InventoryViewDnd({
                 byId={byId}
                 collapsed={!expanded.has(id)}
                 dnd={dnd}
+                itemDragData={itemDragData}
                 onToggle={toggleCollapse}
                 onEquip={onEquip}
                 onOpen={onOpen}
@@ -950,6 +981,7 @@ export function InventoryViewDnd({
                 group={ROOT}
                 depth={0}
                 dnd={dnd}
+                itemDragData={itemDragData}
                 onEquip={onEquip}
                 onOpen={onOpen}
                 onContext={openMenu}

--- a/src/ReactorSheet/features/inventory/dragToMacro.test.ts
+++ b/src/ReactorSheet/features/inventory/dragToMacro.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { buildItemMacroDragData } from "./dragToMacro";
+import type { OSEActor, OseItem } from "@domain/types";
+
+const actor = (over: Partial<OSEActor> = {}) =>
+  ({ id: "act1", isToken: false, token: null, pack: null, ...over }) as unknown as OSEActor;
+
+const item = (over: Record<string, unknown> = {}) =>
+  ({
+    name: "Sword",
+    img: "sword.png",
+    uuid: "Actor.act1.Item.itm1",
+    toDragData: () => ({ type: "Item", uuid: "Actor.act1.Item.itm1" }),
+    ...over,
+  }) as unknown as OseItem;
+
+describe("buildItemMacroDragData", () => {
+  it("produces an OSE-compatible Item payload (createOseMacro reads uuid + item)", () => {
+    const data = JSON.parse(buildItemMacroDragData(actor(), item()));
+    expect(data.type).toBe("Item");
+    expect(data.uuid).toContain("Item."); // createOseMacro rejects non-owned items
+    expect(data.actorId).toBe("act1");
+    expect(data.item.name).toBe("Sword"); // macro name + img come from here
+    expect(data.item.img).toBe("sword.png");
+  });
+
+  it("omits scene/token ids for a world actor", () => {
+    const data = JSON.parse(buildItemMacroDragData(actor(), item()));
+    expect(data.sceneId).toBeNull();
+    expect(data.tokenId).toBeNull();
+  });
+
+  it("carries scene/token ids for a token actor", () => {
+    const data = JSON.parse(
+      buildItemMacroDragData(
+        actor({ isToken: true, token: { id: "tok1", parent: { id: "scn1" } } } as Partial<OSEActor>),
+        item(),
+      ),
+    );
+    expect(data.tokenId).toBe("tok1");
+    expect(data.sceneId).toBe("scn1");
+  });
+});

--- a/src/ReactorSheet/features/inventory/dragToMacro.ts
+++ b/src/ReactorSheet/features/inventory/dragToMacro.ts
@@ -1,0 +1,26 @@
+// Build the Foundry drag payload for an owned item so dropping a row onto the
+// macro hotbar creates an item macro — exactly like the stock OSE actor sheet.
+//
+// Flow once dropped: OSE's `hotbarDrop` hook (already registered by the system) →
+// `createOseMacro` → a script macro running `game.ose.rollItemMacro(name)` →
+// `item.roll()` → the weapon-attack dialog. We just need to write OSE's drag-data
+// shape to `text/plain`; we register no hook of our own.
+import type { OSEActor, OseItem } from "@domain/types";
+
+/** Serialized `text/plain` payload mirroring OSE's actor-sheet `_onDragStart`, so
+ *  the hotbar (and any other drop target — another sheet, the canvas) treats a
+ *  dragged reactor-sheet item identically to one from the stock sheet. */
+export function buildItemMacroDragData(actor: OSEActor, item: OseItem): string {
+  // toDragData() → { type:"Item", uuid:"Actor.<id>.Item.<id>" } for owned items.
+  // createOseMacro keys off `uuid` (must contain "Item.") and reads name/img off `item`.
+  const dragData = item.toDragData() as Record<string, unknown>;
+  dragData.item = item;
+  dragData.type = "Item";
+  dragData.actorId = actor.id;
+  // Token actor: carry its scene/token for parity. rollItemMacro re-resolves the
+  // actor from the chat speaker at roll time, so these are non-critical extras.
+  dragData.sceneId = actor.isToken ? (actor.token?.parent?.id ?? null) : null;
+  dragData.tokenId = actor.isToken ? (actor.token?.id ?? null) : null;
+  dragData.pack = actor.pack ?? null;
+  return JSON.stringify(dragData);
+}

--- a/src/ReactorSheet/features/inventory/dragToMacro.ts
+++ b/src/ReactorSheet/features/inventory/dragToMacro.ts
@@ -1,24 +1,10 @@
-// Build the Foundry drag payload for an owned item so dropping a row onto the
-// macro hotbar creates an item macro — exactly like the stock OSE actor sheet.
-//
-// Flow once dropped: OSE's `hotbarDrop` hook (already registered by the system) →
-// `createOseMacro` → a script macro running `game.ose.rollItemMacro(name)` →
-// `item.roll()` → the weapon-attack dialog. We just need to write OSE's drag-data
-// shape to `text/plain`; we register no hook of our own.
 import type { OSEActor, OseItem } from "@domain/types";
 
-/** Serialized `text/plain` payload mirroring OSE's actor-sheet `_onDragStart`, so
- *  the hotbar (and any other drop target — another sheet, the canvas) treats a
- *  dragged reactor-sheet item identically to one from the stock sheet. */
 export function buildItemMacroDragData(actor: OSEActor, item: OseItem): string {
-  // toDragData() → { type:"Item", uuid:"Actor.<id>.Item.<id>" } for owned items.
-  // createOseMacro keys off `uuid` (must contain "Item.") and reads name/img off `item`.
   const dragData = item.toDragData() as Record<string, unknown>;
   dragData.item = item;
   dragData.type = "Item";
   dragData.actorId = actor.id;
-  // Token actor: carry its scene/token for parity. rollItemMacro re-resolves the
-  // actor from the chat speaker at roll time, so these are non-critical extras.
   dragData.sceneId = actor.isToken ? (actor.token?.parent?.id ?? null) : null;
   dragData.tokenId = actor.isToken ? (actor.token?.id ?? null) : null;
   dragData.pack = actor.pack ?? null;

--- a/src/ReactorSheet/features/inventory/useDragReorder.ts
+++ b/src/ReactorSheet/features/inventory/useDragReorder.ts
@@ -34,6 +34,10 @@ type RowOpts = {
   /** Edge-detection axis for before/after. 'y' (default) splits on clientY;
    *  'x' splits on clientX — for a horizontal (flex-wrap) row like the equipped tray. */
   axis?: "x" | "y";
+  /** Override the `text/plain` drag payload (default `"<group>:<idx>"`). Used to
+   *  write Foundry item drag-data so the row also drops onto the macro hotbar.
+   *  Internal reorder reads its source from React state, not this, so it's safe. */
+  dragPayload?: () => string | undefined;
   onStart?: () => void;
   onEnd?: () => void;
 };
@@ -73,7 +77,8 @@ export function useDragReorder(opts: {
     onDragStart: (e) => {
       setDrag({ group, idx });
       e.dataTransfer.effectAllowed = "move";
-      try { e.dataTransfer.setData("text/plain", `${group}:${idx}`); } catch { /* IE guard */ }
+      const payload = o.dragPayload?.() ?? `${group}:${idx}`;
+      try { e.dataTransfer.setData("text/plain", payload); } catch { /* IE guard */ }
       o.onStart?.();
     },
     onDragEnd: () => { clear(); o.onEnd?.(); },

--- a/src/ReactorSheet/styles/actions.scss
+++ b/src/ReactorSheet/styles/actions.scss
@@ -630,6 +630,9 @@
 // compact brass "Attack" button (composite hit + damage via OSE weapon dialog)
 .reactor-sheet-app .fvtt-atk {
   justify-self: stretch;
+  // Chromium won't start a drag from a <button> on draggable=true alone; this
+  // opts the button in (so it drags to the macro hotbar like the weapon image).
+  -webkit-user-drag: element;
   display: inline-flex; align-items: center; justify-content: center; gap: var(--spacer-1);
   padding: var(--spacer-1) var(--spacer-3);
   background: transparent;

--- a/tools/e2e/specs/drag-to-macro.spec.ts
+++ b/tools/e2e/specs/drag-to-macro.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect } from "../fixtures";
+import { openCharacterSheet, itemId, ACTOR_NAME } from "../helpers";
+
+declare const game: any;
+
+/**
+ * Drag-to-macro: dragging a draggable sheet element onto Foundry's macro hotbar
+ * runs OSE's `hotbarDrop` hook → `createOseMacro` → a script macro that calls
+ * `game.ose.rollItemMacro(name)` → `item.roll()` → the weapon-attack dialog.
+ *
+ * The three drag sources all write the same `buildItemMacroDragData` payload via
+ * `text/plain` (inventory `useDragReorder.rowProps`, and the AttacksTable image +
+ * Attack button `onDragStart`). We exercise that real component handler by firing
+ * a `dragstart` on the source to capture the payload it writes, then dispatch a
+ * `drop` carrying that payload onto a hotbar slot so Foundry parses it and fires
+ * `hotbarDrop` — i.e. the full feature path, not a direct `rollItemMacro` call.
+ *
+ * Playwright's native dragTo is unreliable for Foundry's HTML5 DnD + canvas
+ * hotbar, hence the deterministic event dispatch.
+ */
+
+const MACRO_NAME = "Dagger";
+
+/**
+ * In the page: fire a real `dragstart` on `sourceSel` (optionally resolved to its
+ * `.rs-inv-row` ancestor) to capture the component's `text/plain` payload, then
+ * dispatch dragenter/dragover/drop carrying it onto the first hotbar slot. Returns
+ * the captured payload so the test can assert the component wrote item drag-data.
+ */
+async function dragSourceToHotbar(
+  page: import("@playwright/test").Page,
+  sourceSel: string,
+  toRow = false,
+): Promise<string> {
+  return page.evaluate(
+    ({ sel, row }) => {
+      let src = document.querySelector(sel) as HTMLElement | null;
+      if (src && row) src = src.closest(".rs-inv-row");
+      if (!src) throw new Error(`drag source not found: ${sel}`);
+
+      // 1. capture the payload the component writes in its onDragStart.
+      const startDt = new DataTransfer();
+      src.dispatchEvent(
+        new DragEvent("dragstart", { bubbles: true, cancelable: true, dataTransfer: startDt }),
+      );
+      const payload = startDt.getData("text/plain");
+      src.dispatchEvent(
+        new DragEvent("dragend", { bubbles: true, cancelable: true, dataTransfer: startDt }),
+      );
+      if (!payload) throw new Error("drag source produced no text/plain payload");
+
+      // 2. drop it onto a hotbar slot → Foundry parses text/plain → hotbarDrop hook.
+      const slot = document.querySelector("#hotbar [data-slot]") as HTMLElement | null;
+      if (!slot) throw new Error("hotbar slot not found");
+      const dropDt = new DataTransfer();
+      dropDt.setData("text/plain", payload);
+      for (const type of ["dragenter", "dragover", "drop"]) {
+        slot.dispatchEvent(
+          new DragEvent(type, { bubbles: true, cancelable: true, dataTransfer: dropDt }),
+        );
+      }
+      return payload;
+    },
+    { sel: sourceSel, row: toRow },
+  );
+}
+
+test.describe("drag weapon to macro hotbar", () => {
+  test.beforeAll(async ({ gamePage }) => {
+    // rollItemMacro resolves the item off the speaker's actor; with no token
+    // selected, give the GM an assigned character so the macro finds the Dagger.
+    await gamePage.evaluate(async (name) => {
+      const actor = game.actors.getName(name);
+      await game.user.update({ character: actor.id });
+    }, ACTOR_NAME);
+  });
+
+  test.afterAll(async ({ gamePage }) => {
+    await gamePage.evaluate(() => game.user.update({ character: null })).catch(() => {});
+  });
+
+  // Keep reruns clean: drop the macro this spec created and clear hotbar slots.
+  test.afterEach(async ({ gamePage }) => {
+    await gamePage
+      .evaluate(async (name) => {
+        for (const m of [...game.macros].filter((x: any) => x.name === name)) await m.delete();
+        const slots = game.user.getHotbarMacros?.() ?? [];
+        for (const s of slots) if (s?.macro) await game.user.unassignHotbarMacro(s.slot);
+      }, MACRO_NAME)
+      .catch(() => {});
+  });
+
+  async function expectDropCreatesExecutableMacro(
+    gamePage: import("@playwright/test").Page,
+    sourceSel: string,
+    toRow = false,
+  ): Promise<void> {
+    const dagger = await itemId(gamePage, "Dagger");
+    const payload = await dragSourceToHotbar(gamePage, sourceSel.replace("{id}", dagger), toRow);
+
+    // The component wrote real item drag-data (not the reorder fallback payload).
+    const data = JSON.parse(payload);
+    expect(data.type).toBe("Item");
+
+    // OSE's hotbarDrop created the item macro.
+    await expect
+      .poll(() => gamePage.evaluate((n) => !!game.macros.getName(n), MACRO_NAME), {
+        timeout: 10_000,
+      })
+      .toBe(true);
+
+    // Executing it runs rollItemMacro → item.roll() → the weapon-attack dialog.
+    await gamePage.evaluate((n) => game.macros.getName(n).execute(), MACRO_NAME);
+    const dialog = gamePage.locator(".application.dialog").first();
+    await expect(dialog).toBeVisible({ timeout: 15_000 });
+
+    // Close it (fixtures' afterEach also sweeps stragglers).
+    const cancel = dialog.locator('button[data-action="cancel"], button[data-action="close"]').first();
+    if (await cancel.isVisible().catch(() => false)) await cancel.click().catch(() => {});
+    else await dialog.locator("button.header-control[data-action='close'], a.header-control").first().click().catch(() => {});
+  }
+
+  test("Attack button drops a macro that opens the weapon dialog", async ({ gamePage }) => {
+    const sheet = await openCharacterSheet(gamePage);
+    await sheet.locator('[data-testid="tab-actions"]').click();
+    await expectDropCreatesExecutableMacro(gamePage, '[data-testid="weapon-attack-{id}"]');
+  });
+
+  test("weapon image drops a macro that opens the weapon dialog", async ({ gamePage }) => {
+    const sheet = await openCharacterSheet(gamePage);
+    await sheet.locator('[data-testid="tab-actions"]').click();
+    await expectDropCreatesExecutableMacro(gamePage, '[data-testid="weapon-img-{id}"]');
+  });
+
+  test("inventory row drops a macro that opens the weapon dialog", async ({ gamePage }) => {
+    const sheet = await openCharacterSheet(gamePage);
+    await sheet.locator('[data-testid="tab-inventory"]').click();
+    // The whole row is draggable; resolve from the row's equip button to its root.
+    await expectDropCreatesExecutableMacro(gamePage, '[data-testid="equip-{id}"]', true);
+  });
+});


### PR DESCRIPTION
Dragging an inventory item from reactor-sheet onto Foundry's macro hotbar now creates an item macro — the same behavior as the stock OSE actor sheet (a weapon yields the attack-roll macro).

## How
reactor-sheet runs inside the OSE system, which already registers a `hotbarDrop` hook (`createOseMacro` → script macro running `game.ose.rollItemMacro(name)` → `item.roll()`). So no new Foundry hook is needed — item rows just need to write OSE's drag-data shape to `text/plain` on dragstart.

- `dragToMacro.ts` — `buildItemMacroDragData(actor, item)` mirrors the OSE sheet's `_onDragStart` payload (`{type:"Item", uuid, item, actorId, …}`). Unit-tested.
- `useDragReorder` — `rowProps` gains an optional `dragPayload()` override for the `text/plain` data. Internal reorder reads its drag source from React state (not `dataTransfer`), so the override doesn't affect reordering.
- `InventoryViewDnd` — list rows, nested rows, container headers, and equipped-tray tiles all supply the payload, resolving the Foundry item by id from context. Coins are left untouched.

## Test plan
- `pnpm test` (86 pass, incl. 3 new for the payload shape), `pnpm lint`, `pnpm build` all green.
- Manual: drag a weapon row onto the hotbar → macro created; clicking it opens the attack dialog. Drag-to-reorder and container nesting still work.