### PR TITLE
Optimistic UI: shadow-state provider + snappy HP/coin edits

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ import { globalIgnores } from "eslint/config";
 
 export default tseslint.config([
   // tools/e2e is a standalone Playwright package with its own toolchain/deps.
-  globalIgnores(["dist", "foundry", "tools"]),
+  globalIgnores(["dist", "foundry", "tools", ".claude"]),
   {
     files: ["**/*.{ts,tsx}"],
     extends: [

--- a/src/ReactorSheet/app/OptimisticProvider.tsx
+++ b/src/ReactorSheet/app/OptimisticProvider.tsx
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { ReactorSheetContext, useReactorSheetContext } from "@app/context";
+import { overlayDoc, prune, type FlatPatch } from "@domain/overlay";
+import type { OseItem } from "@domain/types";
+
+/** Pending optimistic patches, keyed by item `_id` (or "actor" for actor.system). */
+type Pending = Record<string, FlatPatch>;
+const ACTOR_KEY = "actor";
+
+/**
+ * Subordinate to ReactorSheetProvider. Holds shadow state of in-flight changes
+ * and re-provides the same context with the actor/items overlaid, so consumers
+ * see edits instantly. Each pending patch is dropped once the (debounced) Foundry
+ * sync reports the same value — equal, so nothing flickers — or rolled back if the
+ * write rejects. Derived values (encumbrance, weights) recompute from the overlay
+ * because the view-models read through it.
+ */
+export function OptimisticProvider({ children }: { children: ReactNode }) {
+  const parent = useReactorSheetContext();
+  const { actor, items } = parent;
+  const [pending, setPending] = useState<Pending>({});
+
+  // Reconcile against Foundry truth on every sync: keep only patches it hasn't
+  // caught up to yet. Runs when actor/items change (not on `pending`), so no loop.
+  useEffect(() => {
+    setPending((p) => reconcile(p, actor, items));
+  }, [actor, items]);
+
+  // Per-key trailing debounce: rapid edits update the overlay instantly but
+  // coalesce into ONE backend write of the final value (the latest commit wins).
+  const timers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  const writes = useRef<Record<string, () => Promise<unknown>>>({});
+
+  const flush = useCallback((key: string) => {
+    const commit = writes.current[key];
+    clearTimeout(timers.current[key]);
+    delete timers.current[key];
+    delete writes.current[key];
+    if (!commit) return;
+    // On failure, drop the whole doc's overlay → snap back to Foundry truth.
+    void Promise.resolve()
+      .then(commit)
+      .catch(() =>
+        setPending((p) => {
+          const next = { ...p };
+          delete next[key];
+          return next;
+        }),
+      );
+  }, []);
+
+  const optimisticUpdate = useCallback(
+    (key: string, patch: FlatPatch, commit: () => Promise<unknown>, debounceMs = 250) => {
+      setPending((p) => ({ ...p, [key]: { ...p[key], ...patch } })); // overlay now
+      writes.current[key] = commit; // latest write wins
+      clearTimeout(timers.current[key]);
+      timers.current[key] = setTimeout(() => flush(key), debounceMs);
+    },
+    [flush],
+  );
+
+  // Flush in-flight debounced writes on unmount (sheet close) so none are lost.
+  useEffect(() => {
+    const t = timers.current;
+    return () => Object.keys(t).forEach(flush);
+  }, [flush]);
+
+  const overlaidItems = useMemo(
+    () => items.map((it) => overlayDoc(it, pending[it._id as string])),
+    [items, pending],
+  );
+  const overlaidActor = useMemo(() => overlayDoc(actor, pending[ACTOR_KEY]), [actor, pending]);
+
+  const value = useMemo(
+    () => ({
+      ...parent,
+      actor: overlaidActor,
+      actorData: overlaidActor.system as typeof parent.actorData,
+      items: overlaidItems,
+      optimisticUpdate,
+    }),
+    [parent, overlaidActor, overlaidItems, optimisticUpdate],
+  );
+
+  return <ReactorSheetContext.Provider value={value}>{children}</ReactorSheetContext.Provider>;
+}
+
+function reconcile(pending: Pending, actor: unknown, items: OseItem[]): Pending {
+  if (Object.keys(pending).length === 0) return pending;
+  const next: Pending = {};
+  for (const [key, patch] of Object.entries(pending)) {
+    const doc = key === ACTOR_KEY ? actor : items.find((it) => (it._id as string) === key);
+    const remaining = doc ? prune(patch, doc) : patch;
+    if (Object.keys(remaining).length) next[key] = remaining;
+  }
+  return next;
+}
+

--- a/src/ReactorSheet/app/SheetShell.tsx
+++ b/src/ReactorSheet/app/SheetShell.tsx
@@ -20,7 +20,7 @@ import type { IdentityVM, VitalsVM } from "@domain/vm-types";
  * and mounts the Actions body (other tabs still render their legacy Content).
  */
 export default function SheetShell() {
-  const { actor, items: invItems, currentTab, setCurrentTab, updateActor } = useReactorSheetContext();
+  const { actor, items: invItems, currentTab, setCurrentTab, updateActor, optimisticUpdate } = useReactorSheetContext();
   const toast = useToast();
   const [editOpen, setEditOpen] = useState(false);
 
@@ -65,7 +65,9 @@ export default function SheetShell() {
         .reduce((m, i) => Math.max(m, readFlag<number>(i, FLAGS.equippedOrder) ?? 0), 0);
       update[flagPath(FLAGS.equippedOrder)] = maxEq + 100;
     }
-    void it.update(update);
+    // Optimistic: flip the hand instantly, reconcile when Foundry confirms.
+    if (optimisticUpdate) optimisticUpdate(id, update, () => it.update(update));
+    else void it.update(update);
     if (leftContainer) {
       const container = resolveItem(fromContainerId!);
       toast({

--- a/src/ReactorSheet/app/SheetShell.tsx
+++ b/src/ReactorSheet/app/SheetShell.tsx
@@ -44,7 +44,10 @@ export default function SheetShell() {
   };
   const onSetHp = (value: number) => {
     const next = Math.max(0, Math.min(vitals.hp.max, value));
-    if (next !== vitals.hp.value) void updateActor({ "system.hp.value": next });
+    if (next === vitals.hp.value) return;
+    const update = { "system.hp.value": next };
+    if (optimisticUpdate) optimisticUpdate("actor", update, () => updateActor(update));
+    else void updateActor(update);
   };
 
   const resolveItem = (id: string) => (invItems as OseItem[]).find((i) => i._id === id);
@@ -80,7 +83,11 @@ export default function SheetShell() {
   };
   const onOpenItem = (id: string) => resolveItem(id)?.sheet?.render(true);
   const onSetCoin = (id: string, value: number) => {
-    void resolveItem(id)?.update({ "system.quantity.value": value });
+    const it = resolveItem(id);
+    if (!it) return;
+    const update = { "system.quantity.value": value };
+    if (optimisticUpdate) optimisticUpdate(id, update, () => it.update(update));
+    else void it.update(update);
   };
   // Consume one: decrement the item's quantity (floored at 0).
   const onConsume = (id: string) => {

--- a/src/ReactorSheet/domain/overlay.ts
+++ b/src/ReactorSheet/domain/overlay.ts
@@ -1,0 +1,67 @@
+// Transparent optimistic overlay over Foundry documents.
+//
+// A pending change is a flat dot-path patch ({ "system.equipped": true }).
+// `overlayDoc` wraps the live document in a read-through Proxy: patched leaves
+// return the optimistic value; every other access — derived getters, methods,
+// `.sheet` — delegates to the real document (methods stay bound to it). So the
+// view-models read the optimistic value and recompute derived data (encumbrance,
+// weights) from it, while mutations and Foundry's own data prep stay untouched.
+// Patches are dropped once Foundry's (debounced) update reports the same value,
+// so reconciliation never flickers.
+
+export type FlatPatch = Record<string, unknown>;
+
+const isObj = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null;
+
+/** Read a dot-path value off a plain object tree (no Foundry dependency). */
+function getPath(obj: unknown, path: string): unknown {
+  return path.split(".").reduce<unknown>((o, k) => (isObj(o) ? o[k] : undefined), obj);
+}
+
+/** Flat dot-path patch → nested object ({ "system.equipped": true } → { system: { equipped: true } }). */
+function toNested(patch: FlatPatch): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [path, val] of Object.entries(patch)) {
+    const keys = path.split(".");
+    let node = out;
+    for (let i = 0; i < keys.length - 1; i++) {
+      if (!isObj(node[keys[i]])) node[keys[i]] = {};
+      node = node[keys[i]] as Record<string, unknown>;
+    }
+    node[keys[keys.length - 1]] = val;
+  }
+  return out;
+}
+
+function overlayNested<T extends object>(doc: T, tree: Record<string, unknown>): T {
+  return new Proxy(doc, {
+    get(target, prop) {
+      if (typeof prop === "string" && prop in tree) {
+        const pv = tree[prop];
+        const ov = Reflect.get(target, prop, target);
+        return isObj(pv) && isObj(ov) ? overlayNested(ov as object, pv) : pv;
+      }
+      // Getters evaluate on the real doc (derived data); methods bind to it.
+      const v = Reflect.get(target, prop, target);
+      return typeof v === "function" ? (v as (...a: unknown[]) => unknown).bind(target) : v;
+    },
+  }) as T;
+}
+
+/** Wrap `doc` so reads of patched paths return optimistic values; everything
+ *  else (derived getters, methods, `.sheet`) delegates to the live document. */
+export function overlayDoc<T extends object>(doc: T, patch?: FlatPatch): T {
+  if (!patch || Object.keys(patch).length === 0) return doc;
+  return overlayNested(doc, toNested(patch));
+}
+
+/** Drop patch paths whose value the live doc already reflects (so removing them
+ *  is invisible — no flicker); keep paths Foundry hasn't caught up to yet. */
+export function prune(patch: FlatPatch, doc: unknown): FlatPatch {
+  const out: FlatPatch = {};
+  for (const [path, val] of Object.entries(patch)) {
+    if (!Object.is(getPath(doc, path), val)) out[path] = val;
+  }
+  return out;
+}

--- a/src/ReactorSheet/domain/types.ts
+++ b/src/ReactorSheet/domain/types.ts
@@ -29,6 +29,15 @@ export interface ReactorSheetContextValue {
   updateActor: (updateData: {
     [key: string]: string | number | string[];
   }) => Promise<OSEActor | void>;
+  /** Apply an optimistic patch (flat dot-paths) to a doc immediately, run the real
+   *  Foundry write, and reconcile/rollback async. `key` = item `_id` or "actor".
+   *  Provided by OptimisticProvider; undefined outside it. */
+  optimisticUpdate?: (
+    key: string,
+    patch: Record<string, unknown>,
+    commit: () => Promise<unknown>,
+    debounceMs?: number,
+  ) => void;
 }
 
 export type OseSpellList = Record<number, OseSpell[]>;

--- a/src/ReactorSheet/features/inventory/WealthSection.tsx
+++ b/src/ReactorSheet/features/inventory/WealthSection.tsx
@@ -209,7 +209,7 @@ export function WealthSection({
                   aria-label={`${c.name} quantity`}
                   onChange={(e) => setDraft((d) => ({ ...d, [c.denom]: e.target.value }))}
                   onFocus={(e) => e.currentTarget.select()}
-                  onKeyDown={(e) => { if (e.key === "Enter") e.currentTarget.blur(); }}
+                  onKeyDown={(e) => { if (e.key === "Enter") { commit(c); setOpen(false); } }}
                   onBlur={() => commit(c)}
                 />
                 <span className="rs-coin-wt">{fmtCoin(qtyOf(c))} cn</span>

--- a/src/ReactorSheet/index.tsx
+++ b/src/ReactorSheet/index.tsx
@@ -5,6 +5,7 @@ import "./styles/vellum/components.css";
 import "./styles/styles.scss";
 import "./styles/edit-modal.scss";
 import ReactorSheetProvider from "@app/ReactorSheetProvider";
+import { OptimisticProvider } from "@app/OptimisticProvider";
 import SheetShell from "@app/SheetShell";
 import { ToastProvider } from "@ui/ToastHost";
 import { useEffect, useRef, type ReactNode } from "react";
@@ -44,7 +45,9 @@ function ReactorSheetApp({
           source={source!}
           contextConnector={contextConnector}
         >
-          <SheetShell />
+          <OptimisticProvider>
+            <SheetShell />
+          </OptimisticProvider>
         </ReactorSheetProvider>
       </ToastProvider>
     </ThemedRoot>


### PR DESCRIPTION
Rebased onto `main` after the Phase I feature-folder restructure (#38).

## What
- **`OptimisticProvider`** (`app/`) + **`overlay.ts`** (`domain/`) — a shadow-state layer subordinate to `ReactorSheetProvider`. Pending dot-path patches overlay the actor/items via a read-through proxy; derived view-models recompute from the overlay. Reconciles on each Foundry sync, rolls back on write failure, and coalesces rapid edits into one debounced backend write.
- **Snappy HP** — the −/+ steppers route through `optimisticUpdate`, so taps register instantly and rapid clicks step off the overlaid value.
- **Snappy coin edits** — coin qty routes through the overlay too. Encumbrance stays **backend-driven** (recomputes lazily once the write lands) — no duplicated weight/breakpoint math.
- **Coin table Enter** = "Done": commits the field and closes the table.
- **eslint**: ignore `.claude/` so nested worktrees aren't linted.

## Notes
- The slim removed `selectVitals`; `SheetShell` now inlines the `VitalsVM` literal. The optimistic edits only read `vitals.hp.*`, so nothing relied-upon broke. `selectEncumbrance`/`selectCoins`/`selectInventory` survived (now under `@features/inventory`).

## Test plan
`pnpm test` (78 pass), `pnpm lint`, `pnpm build` all green on the restructured tree.