### PR TITLE
SCSS dedup: surface-card + rollable-card mixins (output-preserving)

### DIFF
--- a/src/ReactorSheet/styles/_mixins.scss
+++ b/src/ReactorSheet/styles/_mixins.scss
@@ -1,0 +1,20 @@
+// Shared declaration groups, extracted verbatim from repeated rule bodies.
+// These are dedup, not restyle: each @include expands to the exact declarations
+// it replaced, so the compiled CSS is byte-identical (verified by diffing the
+// built main.css). Restyle/consolidation that *changes* output is done separately
+// with live-sheet visual checks — keep this file output-preserving.
+
+// Inked panel surface: dark fill + soft hairline border. The radius/padding that
+// vary per card stay at the call site.
+@mixin surface-card {
+  background: var(--surface, #23201a);
+  border: 1px solid var(--border-soft, #2c2823);
+}
+
+// Click-to-roll affordance for a bordered card (gold border + surface lift on
+// hover, gold focus ring). Include inside the card's own rule.
+@mixin rollable-card {
+  &.rollable { cursor: pointer; }
+  &.rollable:hover { border-color: var(--gold); background: var(--surface-2, #2e2a23); }
+  &.rollable:focus-visible { outline: 2px solid var(--gold); outline-offset: -2px; }
+}

--- a/src/ReactorSheet/styles/actions.scss
+++ b/src/ReactorSheet/styles/actions.scss
@@ -1,3 +1,4 @@
+@use "mixins" as *;
 // Display-layout helpers for the Actions tab + chrome (pass 1).
 // Pure layout on top of the Vellum component classes; colors come from tokens.
 
@@ -399,16 +400,13 @@
 // In the narrow left rail (large view), 5-up overflows — drop to 3+2.
 .rs-rail-extra .fvtt-saves { grid-template-columns: repeat(3, 1fr); }
 .fvtt-save {
-  background: var(--surface, #23201a);
-  border: 1px solid var(--border-soft, #2c2823);
+  @include surface-card;
   border-radius: var(--r-md, 6px);
   padding: var(--spacer-2) var(--spacer-1) 7px;
   text-align: center;
   transition: border-color 0.12s, background 0.12s;
+  @include rollable-card;
 }
-.fvtt-save.rollable { cursor: pointer; }
-.fvtt-save.rollable:hover { border-color: var(--gold); background: var(--surface-2, #2e2a23); }
-.fvtt-save.rollable:focus-visible { outline: 2px solid var(--gold); outline-offset: -2px; }
 .fvtt-save .sk {
   width: 22px; height: 22px; margin: 0 auto var(--spacer-1);
   background: var(--ink, #070605); color: var(--stamp-text, #e5dec8);
@@ -432,15 +430,12 @@
 .rs-rail-extra .fvtt-explore { grid-template-columns: 1fr; }
 .fvtt-skill {
   display: flex; align-items: center; gap: var(--spacer-2);
-  background: var(--surface, #23201a);
-  border: 1px solid var(--border-soft, #2c2823);
+  @include surface-card;
   border-radius: var(--r-md, 6px);
   padding: var(--spacer-2) var(--spacer-2) var(--spacer-2) var(--spacer-3);
   transition: border-color 0.12s, background 0.12s;
+  @include rollable-card;
 }
-.fvtt-skill.rollable { cursor: pointer; }
-.fvtt-skill.rollable:hover { border-color: var(--gold); background: var(--surface-2, #2e2a23); }
-.fvtt-skill.rollable:focus-visible { outline: 2px solid var(--gold); outline-offset: -2px; }
 .fvtt-skill .skic { color: var(--gold-dim); font-size: var(--fs-md, 14px); width: 18px; text-align: center; flex: none; }
 .fvtt-skill .skn {
   font-family: var(--sans); font-size: var(--fs-sm, 13px);
@@ -504,8 +499,7 @@
 .rs-whdr > span:nth-child(n + 2) { text-align: center; }
 
 .rs-weapon {
-  background: var(--surface, #23201a);
-  border: 1px solid var(--border-soft, #2c2823);
+  @include surface-card;
   border-radius: var(--r-lg, 10px);
   padding: 9px 10px;
 }

--- a/src/ReactorSheet/styles/spells.scss
+++ b/src/ReactorSheet/styles/spells.scss
@@ -1,3 +1,4 @@
+@use "mixins" as *;
 // Spells tab — per-level panels (ink-stamp badge + slot pips), prepared cast
 // rows, and the expandable spellbook grid. Ported from the prototype
 // .fvtt-spell* classes onto rs- names + tokens (see foundry-styles.css SPELLS).
@@ -55,8 +56,7 @@
   display: grid; grid-template-columns: 1fr auto;
   align-items: center; gap: var(--spacer-2);
   padding: var(--spacer-2) var(--spacer-3);
-  background: var(--surface, #23201a);
-  border: 1px solid var(--border-soft, #2c2823);
+  @include surface-card;
   border-top: none;
 }
 // In the Spells tab `.rs-spellhead` supplies the top edge/radius; the Actions


### PR DESCRIPTION
## SCSS dedup — surface-card + rollable-card mixins

First pass of the deferred SCSS partials work. **Output-preserving**: the compiled
`dist/main.css` is byte-identical before/after (verified by diff) — pure dedup, no restyle.

- New `styles/_mixins.scss` with two extracted declaration groups:
  - `surface-card` (dark fill + soft hairline border) — used ×4 (saves, skills, weapons, spells)
  - `rollable-card` (gold hover/focus affordance) — used ×2 (saves, skills)
- Replaced the literal repeated blocks with `@include`s at the same positions.

### Verification
`pnpm build` ✓ · `pnpm lint` ✓ · compiled CSS **byte-identical** to baseline.

### Deliberately NOT here (needs live-sheet visual check)
The output-*changing* consolidations — merging the near-duplicate popovers / tag pills /
input fields, and the ink-stamp/monogram unification — are going to a separate
style/component-consolidation branch where appearance changes get screenshot-verified.

Stacked on #38 (Phase I restructure); rebase to main once that merges.
