### PR TITLE
feat: open weapon item sheet from attack-card name

### DIFF
--- a/src/ReactorSheet/features/actions/ActionsView.tsx
+++ b/src/ReactorSheet/features/actions/ActionsView.tsx
@@ -26,6 +26,7 @@ export function ActionsView({ actor }: Props) {
   // The composite "Attack" uses OSE's own weapon roll dialog.
   const onAttack = (itemId: string) =>
     actor.system.weapons.find((w) => w._id === itemId)?.rollWeapon({ skipDialog: false });
+  const onOpenWeapon = (itemId: string) => actor.items.get(itemId)?.sheet?.render(true);
   const onSave = (key: OSESave) => actor.rollSave(key, {});
   const onExploration = (key: string) => rollExploration(actor, key);
   // Drag a weapon card onto the macro hotbar → OSE's hotbarDrop creates an attack
@@ -40,7 +41,7 @@ export function ActionsView({ actor }: Props) {
   return (
     <>
       <AbilityPlaques abilities={selectAbilities(actor)} onRoll={onAbility} />
-      <AttacksTable attacks={attacks} onRoll={onRoll} onAttack={onAttack} dragData={dragData} />
+      <AttacksTable attacks={attacks} onRoll={onRoll} onAttack={onAttack} onOpen={onOpenWeapon} dragData={dragData} />
       <MemorizedSpells actor={actor} />
       {/* .actions-only: hidden at lg (Saves/Exploration live in the rail there). */}
       <section className="rs-section actions-only">

--- a/src/ReactorSheet/features/actions/AttacksTable.tsx
+++ b/src/ReactorSheet/features/actions/AttacksTable.tsx
@@ -9,6 +9,8 @@ type Props = {
   onRoll?: (spec: RollSpec) => void;
   /** Composite attack roll (OSE weapon dialog). */
   onAttack?: (itemId: string) => void;
+  /** Open the weapon's item sheet (click the name). */
+  onOpen?: (itemId: string) => void;
   /** Foundry item drag-data for a weapon, so its card drops onto the macro hotbar
    *  to create an attack macro (same as an inventory row). undefined = not draggable. */
   dragData?: (itemId: string) => string | undefined;
@@ -23,7 +25,7 @@ const kindIcon = (kind: "melee" | "missile") => (kind === "melee" ? "fa-sword" :
 
 /** One weapon card. A melee+missile weapon shows both kind tags as a toggle
  *  (melee active by default); the active mode drives Hit/Dmg. */
-function WeaponRow({ a, onRoll, onAttack, dragData }: { a: AttackVM; onRoll?: Props["onRoll"]; onAttack?: Props["onAttack"]; dragData?: Props["dragData"] }) {
+function WeaponRow({ a, onRoll, onAttack, onOpen, dragData }: { a: AttackVM; onRoll?: Props["onRoll"]; onAttack?: Props["onAttack"]; onOpen?: Props["onOpen"]; dragData?: Props["dragData"] }) {
   const [active, setActive] = useState(0); // index into a.modes (melee = 0)
   const mode = a.modes[active] ?? a.modes[0];
   const dual = a.modes.length > 1;
@@ -59,7 +61,20 @@ function WeaponRow({ a, onRoll, onAttack, dragData }: { a: AttackVM; onRoll?: Pr
         )}
         <div className="wmain">
           <div className="wname">
-            {a.name} <span className="wkind">({mode.kindLabel.toLowerCase()})</span>
+            {onOpen ? (
+              <button
+                type="button"
+                className="wname-btn"
+                data-testid={`weapon-name-${a.itemId}`}
+                onClick={() => onOpen(a.itemId)}
+                title={`Open ${a.name}`}
+              >
+                {a.name}
+              </button>
+            ) : (
+              a.name
+            )}{" "}
+            <span className="wkind">({mode.kindLabel.toLowerCase()})</span>
           </div>
           <div className="wtags">
             {/* dual melee+missile → a segmented switch; single mode → a static tag */}
@@ -147,13 +162,13 @@ function WeaponRow({ a, onRoll, onAttack, dragData }: { a: AttackVM; onRoll?: Pr
 /** Equipped-weapon attacks as woodcut weapon cards: ink-stamp monogram, name +
  *  melee/missile + quality tags, clickable HIT/DMG stat cells (FA dice), and a
  *  tall brass Attack button (full hit + damage via the OSE weapon dialog). */
-export function AttacksTable({ attacks, onRoll, onAttack, dragData }: Props) {
+export function AttacksTable({ attacks, onRoll, onAttack, onOpen, dragData }: Props) {
   return (
     <section className="rs-section rs-atk">
       <SectionTitle hint="click to roll">Attacks</SectionTitle>
       <div className="rs-wtable">
         {attacks.map((a) => (
-          <WeaponRow key={a.id} a={a} onRoll={onRoll} onAttack={onAttack} dragData={dragData} />
+          <WeaponRow key={a.id} a={a} onRoll={onRoll} onAttack={onAttack} onOpen={onOpen} dragData={dragData} />
         ))}
       </div>
     </section>

--- a/src/ReactorSheet/styles/actions.scss
+++ b/src/ReactorSheet/styles/actions.scss
@@ -521,6 +521,13 @@
   color: var(--text, #e5dec8); line-height: 1.15;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
+// Weapon name as a button to open the item sheet — reset to inline text; brass on hover.
+.rs-weapon .wname-btn {
+  font: inherit; color: inherit;
+  background: none; border: 0; padding: 0;
+  cursor: pointer;
+}
+.rs-weapon .wname-btn:hover { color: var(--gold); text-decoration: underline; }
 .rs-weapon .wtags { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 3px; }
 
 // quality / mode tags — icon-only chips with a hover popover (+ native title)


### PR DESCRIPTION
## Open weapon item sheet from the attack-card name

The weapon name in Actions → attack cards was non-interactive. Now clicking it opens
the weapon's item sheet — the same affordance as ability/spell names.

- `AttacksTable` gains an `onOpen?(itemId)` prop, threaded to `WeaponRow`; the name
  renders as a `.wname-btn` button (brass on hover) when `onOpen` is provided.
- `ActionsView` supplies it: `actor.items.get(itemId)?.sheet?.render(true)` — the
  same open path used elsewhere in the sheet.
- `data-testid="weapon-name-<id>"` added for the e2e suite.

`pnpm build` ✓ · `pnpm lint` ✓ · `pnpm test` ✓ (81). Off current `main`.
