### PR TITLE
fix(ac): show descending AC when ascendingAC setting is off

### DIFF
--- a/src/ReactorSheet/app/SheetShell.tsx
+++ b/src/ReactorSheet/app/SheetShell.tsx
@@ -11,6 +11,8 @@ import { selectSaves } from "@features/actions/saves";
 import { selectExploration, rollExploration } from "@features/actions/exploration";
 import { selectInventory, selectEncumbrance, selectCoins } from "@features/inventory/inventory";
 import { flagPath, FLAGS, readFlag } from "@domain/flags";
+import { selectAc } from "@domain/vitals";
+import { usesAscendingAC } from "@domain/chat/targeting";
 import { useToast } from "@ui/toastContext";
 import type { OseItem } from "@domain/types";
 import type { IdentityVM, VitalsVM } from "@domain/vm-types";
@@ -36,7 +38,7 @@ export default function SheetShell() {
   };
   const vitals: VitalsVM = {
     hp: { value: hp.value, max: hp.max },
-    ac: { ascending: aac.value, descending: ac.value },
+    ac: selectAc(aac.value, ac.value, usesAscendingAC()),
     initMod: scores.dex.init + (initiative?.mod ?? 0),
     hd: hp.hd,
     move: movement.base,

--- a/src/ReactorSheet/domain/vitals.test.ts
+++ b/src/ReactorSheet/domain/vitals.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { selectAc } from "@domain/vitals";
+
+describe("selectAc", () => {
+  it("uses ascending AAC value when the setting is on", () => {
+    expect(selectAc(14, 5, true)).toEqual({ value: 14, ascending: true });
+  });
+
+  it("uses descending AC value when the setting is off", () => {
+    expect(selectAc(14, 5, false)).toEqual({ value: 5, ascending: false });
+  });
+});

--- a/src/ReactorSheet/domain/vitals.ts
+++ b/src/ReactorSheet/domain/vitals.ts
@@ -1,0 +1,12 @@
+/**
+ * @file Vitals view-model helpers.
+ */
+
+/** Resolved AC for display: the value matching the ascendingAC setting, plus the mode. */
+export function selectAc(
+  aacValue: number,
+  acValue: number,
+  isAscending: boolean
+): { value: number; ascending: boolean } {
+  return { value: isAscending ? aacValue : acValue, ascending: isAscending };
+}

--- a/src/ReactorSheet/domain/vm-types.ts
+++ b/src/ReactorSheet/domain/vm-types.ts
@@ -11,7 +11,8 @@ export interface IdentityVM {
 
 export interface VitalsVM {
   hp: { value: number; max: number };
-  ac: { ascending: number; descending: number };
+  /** Resolved AC for display: value matching the ascendingAC setting + the mode. */
+  ac: { value: number; ascending: boolean };
   initMod: number;
   hd: string;
   move: number;

--- a/src/ReactorSheet/layout/HeaderBand.stories.tsx
+++ b/src/ReactorSheet/layout/HeaderBand.stories.tsx
@@ -5,6 +5,6 @@ export default { title: "Chrome / HeaderBand" };
 export const Default = () => (
   <HeaderBand
     identity={{ name: "Eldra Vey", img: "", classLabel: "Magic-User", level: 3, alignment: "Neutral", title: "Conjurer" }}
-    vitals={{ hp: { value: 8, max: 9 }, ac: { ascending: 12, descending: 7 }, initMod: 1, hd: "3d4", move: 120, moveBands: { encounter: 40, explore: 120, travel: 24 } }}
+    vitals={{ hp: { value: 8, max: 9 }, ac: { value: 12, ascending: true }, initMod: 1, hd: "3d4", move: 120, moveBands: { encounter: 40, explore: 120, travel: 24 } }}
   />
 );

--- a/src/ReactorSheet/layout/HeaderBand.tsx
+++ b/src/ReactorSheet/layout/HeaderBand.tsx
@@ -117,11 +117,11 @@ export function HeaderBand({ identity, vitals, onSetHp }: Props) {
         <div className="rs-vital ac">
           <Stamp className="vv-l">AC</Stamp>
           <div className="vv-row">
-            <div className="vv-big">{vitals.ac.ascending}</div>
+            <div className="vv-big">{vitals.ac.value}</div>
           </div>
           <div className="vv-sub">
-            <span className="full">Ascending</span>
-            <span className="short">asc</span>
+            <span className="full">{vitals.ac.ascending ? "Ascending" : "Descending"}</span>
+            <span className="short">{vitals.ac.ascending ? "asc" : "desc"}</span>
           </div>
         </div>
       </div>

--- a/src/ReactorSheet/layout/Minibar.tsx
+++ b/src/ReactorSheet/layout/Minibar.tsx
@@ -109,7 +109,7 @@ export function Minibar({ identity, vitals, onSetHp }: Props) {
         </div>
         <div className="rs-mb-ac">
           <Stamp className="rs-mb-stamp">AC</Stamp>
-          <span className="rs-mb-ac-v">{vitals.ac.ascending}</span>
+          <span className="rs-mb-ac-v">{vitals.ac.value}</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Problem
Turning the OSE `ascendingAC` setting off still showed ascending AC on the sheet.

## Cause
`HeaderBand` and `Minibar` hardcoded `vitals.ac.ascending` (value + "Ascending" label) and never read the setting. `VitalsVM.ac` carried both values but the components ignored the descending one.

## Fix
- Resolve AC at the VM layer (`SheetShell`) via `usesAscendingAC()` into `{ value, ascending }` (new `selectAc` helper).
- Components display `vitals.ac.value`; HeaderBand label switches Ascending/Descending (asc/desc).

## Tests
- New `domain/vitals.test.ts` covers value selection both ways.
- Full `pnpm test`, `lint`, `build` pass.