### PR TITLE
ci: pin e2e pnpm to 10.33.0

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 10.33.0
 
       - name: Setup Node.js 22
         uses: actions/setup-node@v4


### PR DESCRIPTION
Aligns `e2e.yml` with `ci.yml`/`deploy-storybook.yml` (both already pin `10.33.0`).

`e2e.yml` floated `version: 10` → pnpm 10.34.x, which changed git-dep `prepare` gating to match `onlyBuiltDependencies` by resolved URL rather than package name, hard-erroring `ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED` on the `foundry-vtt-types` git dep. Pinning removes the float.

Prerequisite for #46 (Storybook migration): because `e2e.yml` runs via `pull_request_target`, the pin only takes effect once on `main`.