### PR TITLE
Hide unimplemented features for v1 (Level Up, Rest, Send Item)

### DIFF
--- a/src/ReactorSheet/app/features.ts
+++ b/src/ReactorSheet/app/features.ts
@@ -1,0 +1,14 @@
+// Build-time feature gates for controls not yet ready for release.
+// Flip a flag to `true` to re-surface its UI — the underlying components stay
+// wired, so re-enabling is a one-line change. Tracked in OLD-19.
+
+export const FEATURES = {
+  /** Topbar "Level Up" — no advancement flow yet (GH #22). */
+  levelUp: false,
+  /** Topbar "Rest" — no character-level HP/HD recovery yet. */
+  rest: false,
+  /** Inventory "Send Item" to another actor (GH #16). */
+  sendItem: false,
+} as const;
+
+export type FeatureKey = keyof typeof FEATURES;

--- a/src/ReactorSheet/features/inventory/InventoryViewDnd.tsx
+++ b/src/ReactorSheet/features/inventory/InventoryViewDnd.tsx
@@ -24,6 +24,7 @@ import { WealthSection } from "@features/inventory/WealthSection";
 import { ItemImage } from "@features/inventory/ItemImage";
 import { SortHeader } from "@features/inventory/SortHeader";
 import { useReactorSheetContext } from "@app/context";
+import { FEATURES } from "@app/features";
 import { SectionTitle } from "@ui/SectionTitle";
 import { Tag } from "@ui/Tag";
 import { cx } from "@ui/cx";
@@ -628,15 +629,17 @@ function ItemContextMenu({
       >
         <i className="fa-solid fa-eye" aria-hidden="true" /> View Item
       </button>
-      {/* Send Item is a WIP — see https://github.com/tasandberg/reactor-sheet/issues/16 */}
-      <button
-        type="button"
-        className="rs-ctx-item"
-        disabled
-        title="Coming soon"
-      >
-        <i className="fa-solid fa-gift" aria-hidden="true" /> Send Item
-      </button>
+      {/* Send Item is a WIP — gated off for v1. See GH #16 / OLD-19. */}
+      {FEATURES.sendItem && (
+        <button
+          type="button"
+          className="rs-ctx-item"
+          disabled
+          title="Coming soon"
+        >
+          <i className="fa-solid fa-gift" aria-hidden="true" /> Send Item
+        </button>
+      )}
       {menu.item.equipped === true && (
         <button
           type="button"

--- a/src/ReactorSheet/layout/Topbar.tsx
+++ b/src/ReactorSheet/layout/Topbar.tsx
@@ -1,12 +1,13 @@
 import { useState, useRef, useEffect } from "react";
 import type { TopbarVM } from "@domain/vm-types";
 import { toggleTheme } from "@src/ReactorSheet/theme";
+import { FEATURES } from "@app/features";
 
 type Props = { vm: TopbarVM; onEdit: () => void; onLevelUp: () => void };
 
 /** Persistent topbar: level, XP, and chrome actions. The bar stays dark in both
- *  themes (--ink). Rest is inert in the display pass; Level Up fires a toast;
- *  Edit opens the Edit Character modal; the theme toggle is live. At XS the three
+ *  themes (--ink). Rest and Level Up are gated behind FEATURES until implemented;
+ *  Edit opens the Edit Character modal; the theme toggle is live. At XS the
  *  action buttons collapse into a ⋮ overflow menu. */
 export function Topbar({ vm, onEdit, onLevelUp }: Props) {
   const pct = vm.pct;
@@ -27,14 +28,18 @@ export function Topbar({ vm, onEdit, onLevelUp }: Props) {
 
   const actionButtons = (
     <>
-      <button type="button" className="rs-tb-btn" disabled>
-        <span className="i" aria-hidden="true">☾</span>
-        <span className="lbl">Rest</span>
-      </button>
-      <button type="button" className="rs-tb-btn up" onClick={() => { setMenuOpen(false); onLevelUp(); }}>
-        <span className="i" aria-hidden="true">▲</span>
-        <span className="lbl">Level Up</span>
-      </button>
+      {FEATURES.rest && (
+        <button type="button" className="rs-tb-btn" disabled>
+          <span className="i" aria-hidden="true">☾</span>
+          <span className="lbl">Rest</span>
+        </button>
+      )}
+      {FEATURES.levelUp && (
+        <button type="button" className="rs-tb-btn up" onClick={() => { setMenuOpen(false); onLevelUp(); }}>
+          <span className="i" aria-hidden="true">▲</span>
+          <span className="lbl">Level Up</span>
+        </button>
+      )}
       <button type="button" className="rs-tb-btn" onClick={() => { setMenuOpen(false); onEdit(); }}>
         <span className="i" aria-hidden="true">✎</span>
         <span className="lbl">Edit</span>


### PR DESCRIPTION
A v1 shouldn't ship visibly-dead controls. Gates the three consciously-deferred stubs behind build-time flags in `src/ReactorSheet/app/features.ts` (all off):

- **Level Up** — Topbar button (was a "Coming soon ;)" toast)
- **Rest** — Topbar button (was hard-disabled)
- **Send Item** — inventory context-menu item (was disabled, GH #16)

Components stay wired; re-enabling any of them is a one-line flag flip. Implementation tracked in Linear: OLD-25 (Level Up), OLD-26 (Rest), OLD-27 (Send Item); the hiding itself is OLD-19.

Verified: build ✓ lint ✓ test 83/83 ✓