### PR TITLE
Compat: Token Variant Art — right-click portrait opens its art picker

### DIFF
--- a/src/OscSheet/app/SheetShell.tsx
+++ b/src/OscSheet/app/SheetShell.tsx
@@ -18,6 +18,7 @@ import {
   selectCoins,
 } from "@features/inventory/inventory";
 import { flagPath, FLAGS, readFlag } from "@domain/flags";
+import { showTokenVariantsPortraitPicker } from "@domain/tokenVariants";
 import { selectAc } from "@domain/vitals";
 import { usesAscendingAC } from "@domain/chat/targeting";
 import { useToast } from "@ui/toastContext";
@@ -207,7 +208,12 @@ export default function SheetShell() {
           />
         }
         header={
-          <HeaderBand identity={identity} vitals={vitals} onSetHp={onSetHp} />
+          <HeaderBand
+            identity={identity}
+            vitals={vitals}
+            onSetHp={onSetHp}
+            onPortraitContextMenu={() => showTokenVariantsPortraitPicker(actor)}
+          />
         }
         minibar={
           <Minibar identity={identity} vitals={vitals} onSetHp={onSetHp} />

--- a/src/OscSheet/domain/tokenVariants.ts
+++ b/src/OscSheet/domain/tokenVariants.ts
@@ -1,0 +1,42 @@
+import type { OSEActor } from "@domain/types";
+
+type ShowArtSelect = (
+  search: string,
+  options: {
+    searchType?: string;
+    object?: unknown;
+    callback?: (imgSrc: string) => void;
+  },
+) => Promise<void>;
+
+type TvaModule = {
+  active: boolean;
+  api?: {
+    showArtSelect?: ShowArtSelect;
+    TVA_CONFIG?: {
+      permissions?: { portrait_right_click?: Record<number, boolean> };
+    };
+  };
+};
+
+/**
+ * Token Variant Art bridge. TVA wires portrait right-click via the v1
+ * `renderActorSheet` hook, which our ApplicationV2 sheet never fires — so we
+ * call its public API (`game.modules.get("token-variants").api.showArtSelect`)
+ * ourselves, mirroring TVA's own default-sheet handler: search by actor name,
+ * searchType "Portrait", picked image → `actor.img`. Gated the same way
+ * (editable sheet + TVA's portrait_right_click role permission). No-ops when
+ * TVA is absent or inactive.
+ */
+export function showTokenVariantsPortraitPicker(actor: OSEActor) {
+  const tva = game.modules.get("token-variants") as TvaModule | undefined;
+  if (!tva?.active || !tva.api?.showArtSelect) return;
+  if (!actor.isOwner) return;
+  const perm = tva.api.TVA_CONFIG?.permissions?.portrait_right_click;
+  if (perm && !perm[game.user.role]) return;
+  void tva.api.showArtSelect(actor.name, {
+    searchType: "Portrait",
+    object: actor,
+    callback: (imgSrc) => void actor.update({ img: imgSrc }),
+  });
+}

--- a/src/OscSheet/layout/HeaderBand.tsx
+++ b/src/OscSheet/layout/HeaderBand.tsx
@@ -31,11 +31,13 @@ type Props = {
   vitals: VitalsVM;
   /** Commit a new current-HP value; when provided, HP renders an editable input. */
   onSetHp?: (value: number) => void;
+  /** Right-click on the portrait (e.g. Token Variant Art's picker). */
+  onPortraitContextMenu?: React.MouseEventHandler<HTMLImageElement>;
 };
 
 /** Header band. Grid areas (see actions.scss) place: portrait · name+Init/HD/Move
  *  · HP/AC in medium, and stack them in the rail. */
-export function HeaderBand({ identity, vitals, onSetHp }: Props) {
+export function HeaderBand({ identity, vitals, onSetHp, onPortraitContextMenu }: Props) {
   const m = vitals.moveBands;
   const nameRef = useFitText(identity.name);
   const hp = useHpInput({ value: vitals.hp.value, max: vitals.hp.max, onSet: onSetHp ?? (() => {}) });
@@ -47,7 +49,14 @@ export function HeaderBand({ identity, vitals, onSetHp }: Props) {
           imperatively in osc-sheet.js — outside React's tree — so React
           never clobbers an injected child. */}
       <div className="osc-portrait-wrap profile">
-        <img className="osc-portrait profile-img" src={identity.img || undefined} alt={identity.name} data-edit="img" title={identity.name} />
+        <img
+          className="osc-portrait profile-img"
+          src={identity.img || undefined}
+          alt={identity.name}
+          data-edit="img"
+          title={identity.name}
+          onContextMenu={onPortraitContextMenu}
+        />
       </div>
       <div className="osc-ident">
         <div className="osc-name" ref={nameRef}>{identity.name}</div>


### PR DESCRIPTION
TVA adds its portrait right-click via the v1 `renderActorSheet` hook, which our ApplicationV2 sheet never fires. Bridge with TVA's public API instead: `contextmenu` on the header portrait calls `game.modules.get("token-variants").api.showArtSelect(actor.name, { searchType: "Portrait", object: actor, callback })`, applying the pick to `actor.img` — same behavior as TVA's own default-sheet handler, including its owner/`portrait_right_click` permission gating. All references sit behind the active-check; no hard dependency.

Fixes OLD-22
Closes #14

## Manual verification

With TVA installed (manifest: `https://github.com/Aedif/TokenVariants/releases/latest/download/module.json`), module enabled:
1. Open a character with the OSC sheet, right-click the header portrait.
2. TVA's Art Select window opens with portrait results for the actor's name.
3. Pick an image — actor `img` updates and the sheet portrait re-renders.

Without TVA (disabled or uninstalled):
1. Right-click the portrait — browser default context menu only (prior behavior), no console errors.