### PR TITLE
Terminology sweep: remove "chrome" from comments/docs/Storybook

### DIFF
--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -11,7 +11,6 @@ addons.setConfig({
       "layout",
       "navigation",
       "data",
-      "chrome",
       "shell",
       "actions",
       "inventory",

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -49,7 +49,7 @@ const preview: Preview = {
     layout: "fullscreen", // we own the outer padding via .osc-sheet-app
     controls: { matchers: { color: /(background|color)$/i, date: /Date$/i } },
     options: {
-      // Foundations on top, then primitives by kind, app chrome, features last.
+      // Foundations on top, then primitives by kind, app shell, features last.
       storySort: {
         method: "alphabetical",
         order: [
@@ -61,7 +61,6 @@ const preview: Preview = {
           "Layout",
           "Navigation",
           "Data",
-          "Chrome",
           "Shell",
           "*",
         ],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ lives in `../CLAUDE.md`.
 - pnpm. `pnpm dev` (vite, serves into local Foundry), `pnpm build` (`tsc -b && vite build`),
   `pnpm lint`, `pnpm test` (vitest). Verify changes with all four before committing.
 - App entry: `src/OscSheet/index.tsx` → `OscSheetProvider` (Foundry actor sync) →
-  `SheetShell` (view-models + chrome slots) → tab bodies. State = React Context + Foundry
+  `SheetShell` (view-models + layout slots) → tab bodies. State = React Context + Foundry
   actor as source of truth; view-models in `viewModels/` compute derived data.
 - Tokens/spacing: use the `--space-*`/`--spacer-*` (4px) scale and design tokens, never
   hardcoded px or invented colors. Brass = `--accent-alt`; equipped = `--teal`.

--- a/src/OscSheet/app/SheetShell.tsx
+++ b/src/OscSheet/app/SheetShell.tsx
@@ -25,7 +25,7 @@ import type { OseItem } from "@domain/types";
 import type { IdentityVM, VitalsVM } from "@domain/vm-types";
 
 /**
- * Foundry-aware container: computes view-models, fills the Shell chrome slots,
+ * Foundry-aware container: computes view-models, fills the Shell layout slots,
  * and mounts the Actions body (other tabs still render their legacy Content).
  */
 export default function SheetShell() {
@@ -40,7 +40,7 @@ export default function SheetShell() {
   const toast = useToast();
   const [editOpen, setEditOpen] = useState(false);
 
-  // Chrome props built inline from the actor (HeaderBand + Minibar share the shape).
+  // Layout-slot props built inline from the actor (HeaderBand + Minibar share the shape).
   const { details, hp, aac, ac, scores, movement, initiative } = actor.system;
   const identity: IdentityVM = {
     name: actor.name,

--- a/src/OscSheet/domain/chat/applyDamage.ts
+++ b/src/OscSheet/domain/chat/applyDamage.ts
@@ -44,7 +44,7 @@ export function onRenderChatMessage(message: ChatMessage, html: HTMLElement): vo
     Boolean(flags(message).getFlag(MODULE_ID, "damage")) ||
     Boolean(html.querySelector(".osc-card"));
   if (!isOurs) return;
-  // Take over the message chrome (padding/border/flavor handled in chat.scss).
+  // Take over the message frame (padding/border/flavor handled in chat.scss).
   html.classList.add("osc-message");
 
   const btn = html.querySelector<HTMLButtonElement>('[data-action="osc-apply-damage"]');

--- a/src/OscSheet/layout/Frame.tsx
+++ b/src/OscSheet/layout/Frame.tsx
@@ -11,7 +11,7 @@ type Props = {
   onSelect: (id: string) => void;
   /** Active tab body — rendered in the right pane. */
   children: ReactNode;
-  /** Optional chrome slots; each falls back to its placeholder. */
+  /** Optional layout slots; each falls back to its placeholder. */
   topbar?: ReactNode;
   header?: ReactNode;
   railExtra?: ReactNode;
@@ -20,7 +20,7 @@ type Props = {
 };
 
 /**
- * Presentational app frame. Chrome regions are slots (placeholder fallback);
+ * Presentational app frame. Layout regions are slots (placeholder fallback);
  * the right pane mounts the active tab body. Responsive reflow lives in shell.scss.
  */
 export function Frame({ tabs, active, onSelect, children, topbar, header, railExtra, minibar }: Props) {

--- a/src/OscSheet/layout/HeaderBand.stories.tsx
+++ b/src/OscSheet/layout/HeaderBand.stories.tsx
@@ -1,6 +1,6 @@
 import { HeaderBand } from "@layout/HeaderBand";
 
-export default { title: "Chrome / HeaderBand" };
+export default { title: "Shell / HeaderBand" };
 
 export const Default = () => (
   <HeaderBand

--- a/src/OscSheet/layout/Placeholder.tsx
+++ b/src/OscSheet/layout/Placeholder.tsx
@@ -1,6 +1,6 @@
 type Props = { label: string; hint?: string };
 
-/** Labeled dashed box marking a chrome region built in a later phase. */
+/** Labeled dashed box marking a layout region built in a later phase. */
 export function Placeholder({ label, hint }: Props) {
   return (
     <div className="osc-placeholder" role="presentation">

--- a/src/OscSheet/layout/Topbar.stories.tsx
+++ b/src/OscSheet/layout/Topbar.stories.tsx
@@ -1,6 +1,6 @@
 import { Topbar } from "@layout/Topbar";
 
-export default { title: "Chrome / Topbar" };
+export default { title: "Shell / Topbar" };
 
 export const Default = () => (
   <Topbar vm={{ level: 3, nextLevel: 4, xp: { value: 6420, next: 10000 }, pct: 28.4 }} onEdit={() => {}} onLevelUp={() => {}} />

--- a/src/OscSheet/layout/Topbar.tsx
+++ b/src/OscSheet/layout/Topbar.tsx
@@ -5,7 +5,7 @@ import { FEATURES } from "@app/features";
 
 type Props = { vm: TopbarVM; onEdit: () => void; onLevelUp: () => void };
 
-/** Persistent topbar: level, XP, and chrome actions. The bar stays dark in both
+/** Persistent topbar: level, XP, and sheet controls. The bar stays dark in both
  *  themes (--ink). Rest and Level Up are gated behind FEATURES until implemented;
  *  Edit opens the Edit Character modal; the theme toggle is live. At XS the
  *  action buttons collapse into a ⋮ overflow menu. */

--- a/src/OscSheet/styles/actions.scss
+++ b/src/OscSheet/styles/actions.scss
@@ -1,5 +1,5 @@
 @use "mixins" as *;
-// Display-layout helpers for the Actions tab + chrome (pass 1).
+// Display-layout helpers for the Actions tab + sheet furniture (pass 1).
 // Pure layout on top of the Vellum component classes; colors come from tokens.
 
 // --- topbar (ported from prototype .fvtt-topbar) ---

--- a/src/OscSheet/styles/chat.scss
+++ b/src/OscSheet/styles/chat.scss
@@ -31,7 +31,7 @@
 }
 
 // ─── Take over the whole message box ───────────────────────────────────────
-// Strip Foundry's default message chrome so our card frame IS the message; keep the
+// Strip Foundry's default message styling so our card frame IS the message; keep the
 // header (sender · timestamp · delete) but theme it; hide the redundant flavor line.
 .chat-message.osc-message {
   padding: 0;

--- a/src/OscSheet/styles/minibar.scss
+++ b/src/OscSheet/styles/minibar.scss
@@ -10,7 +10,7 @@
 .osc-minibar {
   position: sticky;
   top: 0;
-  z-index: 6; // above tab content / sticky inventory heads, below Foundry chrome
+  z-index: 6; // above tab content / sticky inventory heads, below Foundry's window frame
   display: flex;
   align-items: center;
   gap: var(--spacer-3);

--- a/src/OscSheet/styles/shell.scss
+++ b/src/OscSheet/styles/shell.scss
@@ -142,7 +142,7 @@
 // ----- horizontal tab bar (shown when wide) -----
 .osc-htabs { display: none; }
 
-// ----- placeholder chrome region -----
+// ----- placeholder layout region -----
 .osc-placeholder {
   display: flex;
   flex-direction: column;

--- a/src/OscSheet/styles/styles.scss
+++ b/src/OscSheet/styles/styles.scss
@@ -126,7 +126,7 @@
 
   // Scoped element reset — ONLY elements WE render inside the React app, never
   // Foundry's window-frame controls. Classed Vellum controls (.btn/.input) still win.
-  // Excludes <prose-mirror> internals: that editor is Foundry-rendered chrome
+  // Excludes <prose-mirror> internals: that editor is Foundry-rendered UI
   // (toggle button, menu, contenteditable) and must keep its own core styles.
   :is(button, input, select, textarea):not(prose-mirror *) {
     all: unset;


### PR DESCRIPTION
Replaces UI-jargon "chrome" with concrete terms across comments, docstrings, and Storybook organization; no runtime changes.

Storybook: "Chrome" category folded into the existing "Shell" category (Topbar, HeaderBand) rather than "Layout" — "Layout" already holds ui primitives (Card, KvCard, …), and Frame/BottomBar from the same `layout/` dir already live under "Shell". Story IDs/URLs change accordingly.

Remaining `grep -rni chrome` hits (deliberate browser references):
- `tools/e2e/playwright.config.ts:31` — Playwright `devices["Desktop Chrome"]`