### PR TITLE
Portrait: left-click opens image FilePicker

### DIFF
--- a/src/OscSheet/app/SheetShell.tsx
+++ b/src/OscSheet/app/SheetShell.tsx
@@ -213,6 +213,7 @@ export default function SheetShell() {
             vitals={vitals}
             onSetHp={onSetHp}
             onPortraitContextMenu={() => showTokenVariantsPortraitPicker(actor)}
+            canEditPortrait={actor.isOwner}
           />
         }
         minibar={

--- a/src/OscSheet/layout/HeaderBand.tsx
+++ b/src/OscSheet/layout/HeaderBand.tsx
@@ -33,11 +33,13 @@ type Props = {
   onSetHp?: (value: number) => void;
   /** Right-click on the portrait (e.g. Token Variant Art's picker). */
   onPortraitContextMenu?: React.MouseEventHandler<HTMLImageElement>;
+  /** When true, left-click opens the image FilePicker (core `editImage` action). */
+  canEditPortrait?: boolean;
 };
 
 /** Header band. Grid areas (see actions.scss) place: portrait · name+Init/HD/Move
  *  · HP/AC in medium, and stack them in the rail. */
-export function HeaderBand({ identity, vitals, onSetHp, onPortraitContextMenu }: Props) {
+export function HeaderBand({ identity, vitals, onSetHp, onPortraitContextMenu, canEditPortrait }: Props) {
   const m = vitals.moveBands;
   const nameRef = useFitText(identity.name);
   const hp = useHpInput({ value: vitals.hp.value, max: vitals.hp.max, onSet: onSetHp ?? (() => {}) });
@@ -49,10 +51,15 @@ export function HeaderBand({ identity, vitals, onSetHp, onPortraitContextMenu }:
           imperatively in osc-sheet.js — outside React's tree — so React
           never clobbers an injected child. */}
       <div className="osc-portrait-wrap profile">
+        {/* `data-action="editImage"` (core AppV2 vocabulary) rides the frame's
+            delegated click listener — no React onClick needed — and doubles as
+            a compat surface for modules keyed on the core attribute. Rendered
+            only when editable so non-owners get no action and no affordance. */}
         <img
           className="osc-portrait profile-img"
           src={identity.img || undefined}
           alt={identity.name}
+          data-action={canEditPortrait ? "editImage" : undefined}
           data-edit="img"
           title={identity.name}
           onContextMenu={onPortraitContextMenu}

--- a/src/OscSheet/styles/actions.scss
+++ b/src/OscSheet/styles/actions.scss
@@ -108,6 +108,11 @@
   border: 2px solid var(--gold-dim);
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
 }
+// Click-to-edit affordance; the attribute only renders on editable sheets.
+.osc-portrait[data-action="editImage"] {
+  cursor: pointer;
+  &:hover { border-color: var(--gold); }
+}
 // Overlay anchor for module-injected portrait controls (see HeaderBand +
 // osc-sheet.js renderActorSheet forwarding). Class is exactly
 // `modifiers-btn` (no extra classes) so the module's `[class="modifiers-btn"]`


### PR DESCRIPTION
Left-clicking the portrait never opened the image picker: the `editImage` action was registered in `osc-sheet.js` but nothing in the React DOM carried `data-action="editImage"`.

## Change
- `HeaderBand.tsx`: render `data-action="editImage"` on the portrait img (paired with the existing `data-edit="img"`), gated on new `canEditPortrait` prop. Deliberately the core AppV2 vocabulary — doubles as a compat surface for modules keyed on the attribute. No React onClick; the click rides ApplicationV2's delegated frame listener into the registered action.
- `SheetShell.tsx`: `canEditPortrait={actor.isOwner}` (same gate as the TVA bridge). Non-owners get no attribute → no action, no affordance, mirroring core sheets.
- `actions.scss`: `cursor: pointer` + gold border on hover, keyed off `[data-action="editImage"]` so it only shows when editable.

## Verified live (v14, build 364, Playwright)
- Left-click portrait → FilePicker opens at the actor's current image; pick updates `actor.img`.
- Right-click → TVA ArtSelect (PR #56 path) still opens; no FilePicker, no errors.
- OSRCB `.modifiers-btn` overlay click opens the character builder only — it's a sibling of the img, so `closest("[data-action]")` never matches editImage.
- `pnpm build`, `pnpm lint`, `pnpm test` green.

## Manual check for non-owners
Log in as a player without ownership, open an observed sheet: portrait shows no pointer cursor and clicking is a no-op.