### PR TITLE
CI: release workflow — attach module artifacts on release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+# Attaches the Foundry module artifacts (module.json + module.zip) when a
+# GitHub Release is published. The release tag is the source of truth for the
+# version: tools/package.mjs stamps module.json from it in the runner (an
+# optional leading "v" is stripped, so both `0.5.0` and `v0.5.0` work) and
+# points `download` at THIS release's zip and `manifest` at
+# releases/latest/download/module.json.
+#
+# Prereleases: they get assets like any release, but GitHub's "latest" is the
+# newest non-prerelease, non-draft release — so a release marked prerelease
+# never becomes what releases/latest/download (i.e. Foundry auto-update)
+# resolves to.
+#
+# The Sentry endpoint comes from the repo Actions variable VITE_SENTRY_DSN
+# (crash reports are only ever sent when a user presses the button — see
+# README). No DSN variable ⇒ the build ships with reporting compiled out.
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write # gh release upload
+
+jobs:
+  attach-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4 # checks out the release tag
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Gate: never attach artifacts from a red tree.
+      - run: pnpm lint
+      - run: pnpm test
+
+      - name: Build
+        run: pnpm build
+        env:
+          VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
+
+      - name: Stamp module.json from tag + zip
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          node tools/package.mjs "$VERSION" "$GITHUB_REF_NAME"
+
+      # --clobber: pnpm release already uploads locally built assets at create
+      # time (avoids an asset gap); these CI-built ones are canonical.
+      - name: Attach assets to the release
+        run: gh release upload "$GITHUB_REF_NAME" build/module.zip module.json --clobber
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/module.json
+++ b/module.json
@@ -51,6 +51,6 @@
     ]
   },
   "url": "https://github.com/tasandberg/osc-character-sheet",
-  "manifest": "https://raw.githubusercontent.com/tasandberg/osc-character-sheet/main/module.json",
+  "manifest": "https://github.com/tasandberg/osc-character-sheet/releases/latest/download/module.json",
   "download": "https://github.com/tasandberg/osc-character-sheet/releases/download/0.4.1/module.zip"
 }

--- a/tools/package.mjs
+++ b/tools/package.mjs
@@ -1,0 +1,40 @@
+// Stamp module.json for a release and zip the module artifacts.
+// Single source for the packaged file list + release-URL conventions — used
+// by CI (.github/workflows/release.yml) and the local release script.
+//
+// Usage: node tools/package.mjs <version> [tag]
+//   version — semver stamped into module.json (no leading v)
+//   tag     — the git/release tag the download URL points at (defaults to
+//             version; this repo tags bare versions, but a v-prefixed tag
+//             still yields a working URL)
+//
+// URL conventions (Foundry auto-update):
+//   manifest → releases/latest/download/module.json — a STABLE url; GitHub's
+//              "latest" is the newest non-prerelease, non-draft release, so
+//              prereleases never become what updaters resolve.
+//   download → releases/download/<tag>/module.zip — pinned to THIS release.
+
+import { execSync } from "child_process";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+
+const [version, tagArg] = process.argv.slice(2);
+if (!/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(version ?? "")) {
+  console.error("Usage: node tools/package.mjs <semver-version> [tag]");
+  process.exit(1);
+}
+const tag = tagArg || version;
+
+const manifest = JSON.parse(readFileSync("./module.json", "utf8"));
+manifest.version = version;
+manifest.manifest = `${manifest.url}/releases/latest/download/module.json`;
+manifest.download = `${manifest.url}/releases/download/${tag}/module.zip`;
+writeFileSync("./module.json", JSON.stringify(manifest, null, 2) + "\n");
+console.log(`Stamped module.json ${version} (download → ${manifest.download})`);
+
+mkdirSync("build", { recursive: true });
+// Always zip from scratch — `zip -r` updates in place, so a stale archive
+// would keep entries for files that no longer exist (renamed dist chunks).
+rmSync("build/module.zip", { force: true });
+execSync("zip -r build/module.zip module.json dist/ lang/ templates/ README.md", {
+  stdio: "inherit",
+});

--- a/tools/release.mjs
+++ b/tools/release.mjs
@@ -1,5 +1,4 @@
 import moduleManifest from "../module.json" with { type: "json" };
-import { writeFileSync } from 'fs';
 import { execSync } from 'child_process';
 
 const args = process.argv.slice(2);
@@ -40,18 +39,12 @@ function getNewVersion(currentVersion, releaseType) {
   return newVersion;
 }
 
-// Update manifest and write back to file
-function updateManifest(newVersion) {
-  console.log(`Updating manifest version version: ${newVersion}`);
-  
-  moduleManifest.version = newVersion;
-  moduleManifest.download = `${moduleManifest.url}/releases/download/${newVersion}/module.zip`;
-  if (dryRun) {
-    console.log("New module.json:", JSON.stringify(moduleManifest, null, 2));
-    return
-  }
-  writeFileSync('./module.json', JSON.stringify(moduleManifest, null, 2) + '\n');
-  console.log(`Version updated from ${currentVersion} to ${newVersion}`);
+// Stamp module.json + build the zip — shared with CI (tools/package.mjs is
+// the single source for the file list and manifest/download URL conventions).
+function stampAndArchive(newVersion) {
+  console.log(`Packaging ${newVersion} (was ${currentVersion})`);
+  if (dryRun) return;
+  execSync(`node tools/package.mjs ${newVersion}`, { stdio: 'inherit' });
 }
 
 function abortIfGitDirty() {
@@ -86,12 +79,6 @@ function ensureGithubCLI() {
   }
 }
 
-function buildArchive() {
-  const cmd = `zip -r build/module.zip module.json dist/ lang/ templates/ README.md`;
-  console.log(`Building archive...`);
-  execSync(cmd, { stdio: 'inherit' });
-}
-
 function createGithubRelease(tag) {
   const cmd = `git push \
     && gh release create ${tag} --title "${tag}" --generate-notes build/module.zip module.json \
@@ -107,10 +94,11 @@ const newVersion = getNewVersion(moduleManifest.version, releaseType)
 
 abortIfGitDirty()
 ensureGithubCLI()
-updateManifest(newVersion)
 buildDist()
-buildArchive(newVersion)
+stampAndArchive(newVersion)
 commitRelease(newVersion)
+// CI (release.yml) re-builds on "release published" and re-attaches the
+// canonical assets with --clobber; the upload here just avoids an asset gap.
 createGithubRelease(newVersion)
 
 if (dryRun) {


### PR DESCRIPTION
Publishing a GitHub Release now builds and attaches the Foundry module artifacts (`module.json` + `module.zip`), so users install/update by manifest URL. Prereq for OLD-23 (package-registry submission).

## What
- **`.github/workflows/release.yml`** — on `release: published`: pnpm install → lint + test gate → `pnpm build` with `VITE_SENTRY_DSN` from the repo Actions variable → stamp `module.json` from the release tag (optional `v` prefix stripped) → zip → `gh release upload --clobber`.
- **`tools/package.mjs`** (new) — stamp + zip extracted from `release.mjs`; single source for the packaged file list (`module.json dist/ lang/ templates/ README.md`) and URL conventions. Also fixes a staleness bug: the zip is now rebuilt from scratch (previously `zip -r` updated in place, keeping entries for renamed dist chunks).
- **`tools/release.mjs`** — delegates stamp+zip to `package.mjs`; behavior otherwise unchanged (its create-time asset upload stays, avoiding a window where `releases/latest/download` 404s; CI clobbers with canonical builds).
- **`module.json`** — `manifest` now points at `releases/latest/download/module.json` (stable Foundry auto-update URL) instead of raw `main`.

## Versioning & prereleases
Tag = source of truth: `version` and `download` (`releases/download/<tag>/module.zip`) are stamped in the runner. GitHub's `latest` excludes prereleases/drafts, so a prerelease gets assets + a pinned download URL but never becomes what auto-update resolves.

## How to cut a release
1. On a clean `main`: `pnpm release --type=<patch|minor|major>` (bumps, builds, commits, tags, creates the GitHub release with assets).
2. CI re-builds on publish and replaces the assets with canonical ones (DSN from the Actions variable).
3. Prerelease: create the release manually with **Set as a pre-release** checked (or `gh release create <tag> --prerelease`); CI attaches assets the same way.

Not verifiable without cutting a real release: the workflow end-to-end (trigger, `vars.VITE_SENTRY_DSN` availability, upload permissions). Everything local verified: YAML lints, `package.mjs` runs end-to-end (zip = 18 files, no `src`/`node_modules` junk), `release.mjs --dry-run` works, build/lint/test green.

Note: the existing 0.4.1 release's `module.json` asset still carries the pre-rename id `reactor-sheet` — the next release cut through this pipeline supersedes it as `latest`.

https://claude.ai/code/session_01G8VmWSfBRHT3qpgoDSb9Ht
