### PR TITLE
CI: push releases to the Foundry package registry (OLD-35)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,13 @@
 # points `download` at THIS release's zip and `manifest` at
 # releases/latest/download/module.json.
 #
+# After the assets are attached, the version is pushed to the Foundry package
+# registry (tools/publish-registry.mjs) so the public listing updates.
+#
 # Prereleases: they get assets like any release, but GitHub's "latest" is the
 # newest non-prerelease, non-draft release — so a release marked prerelease
 # never becomes what releases/latest/download (i.e. Foundry auto-update)
-# resolves to.
+# resolves to. They are also NOT pushed to the registry.
 #
 # The Sentry endpoint comes from the repo Actions variable VITE_SENTRY_DSN
 # (crash reports are only ever sent when a user presses the button — see
@@ -59,3 +62,18 @@ jobs:
         run: gh release upload "$GITHUB_REF_NAME" build/module.zip module.json --clobber
         env:
           GH_TOKEN: ${{ github.token }}
+
+      # Dry-run validates the payload registry-side without saving, then the
+      # real POST publishes. Re-runs are idempotent: an already-released
+      # version comes back 400 unique_together, which the script treats as
+      # success; any other registry error fails the job.
+      - name: Publish to Foundry package registry
+        run: |
+          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            echo "Prerelease — skipping registry publish."
+            exit 0
+          fi
+          node tools/publish-registry.mjs "$GITHUB_REF_NAME" --dry-run
+          node tools/publish-registry.mjs "$GITHUB_REF_NAME"
+        env:
+          FOUNDRY_RELEASE_TOKEN: ${{ secrets.FOUNDRY_RELEASE_TOKEN }}

--- a/tools/publish-registry.mjs
+++ b/tools/publish-registry.mjs
@@ -1,0 +1,63 @@
+// Push a release to the Foundry package registry
+// (https://foundryvtt.com/article/package-release-api/) so the public
+// listing updates. Reads id/version/compatibility from the stamped
+// module.json (run tools/package.mjs first). The registry wants a
+// VERSION-PINNED manifest URL, so it's built from the tag
+// (releases/download/<tag>/module.json) — NOT module.json's stable
+// `manifest` field, which floats with releases/latest.
+//
+// Usage: FOUNDRY_RELEASE_TOKEN=… node tools/publish-registry.mjs <tag> [--dry-run]
+//   --dry-run — registry validates the payload without saving (precheck).
+//
+// Re-run semantics: re-POSTing an already-released version returns 400
+// unique_together; treated as success so workflow re-runs are idempotent.
+// Any other non-2xx exits 1 — the release job must go red on rejection.
+
+import { readFileSync } from "fs";
+
+const API =
+  process.env.FOUNDRY_API_URL ?? "https://foundryvtt.com/_api/packages/release_version/";
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const tag = args.find((a) => a !== "--dry-run");
+if (!tag) {
+  console.error("Usage: node tools/publish-registry.mjs <tag> [--dry-run]");
+  process.exit(1);
+}
+const token = process.env.FOUNDRY_RELEASE_TOKEN;
+if (!token) {
+  console.error("FOUNDRY_RELEASE_TOKEN is not set");
+  process.exit(1);
+}
+
+const manifest = JSON.parse(readFileSync("./module.json", "utf8"));
+const body = {
+  id: manifest.id,
+  ...(dryRun && { "dry-run": true }),
+  release: {
+    version: manifest.version,
+    manifest: `${manifest.url}/releases/download/${tag}/module.json`,
+    notes: `${manifest.url}/releases/tag/${tag}`,
+    compatibility: manifest.compatibility,
+  },
+};
+
+console.log(
+  `${dryRun ? "Dry-run" : "Publishing"} ${body.id} ${body.release.version} → ${body.release.manifest}`,
+);
+const res = await fetch(API, {
+  method: "POST",
+  headers: { "Content-Type": "application/json", Authorization: token },
+  body: JSON.stringify(body),
+});
+const text = await res.text();
+
+if (res.ok) {
+  console.log(`Registry ${dryRun ? "dry-run" : "publish"} OK: ${text}`);
+} else if (res.status === 400 && text.includes("unique_together")) {
+  console.log(`Version ${body.release.version} already on the registry — nothing to do.`);
+} else {
+  console.error(`Registry ${dryRun ? "dry-run" : "publish"} failed (${res.status}): ${text}`);
+  process.exit(1);
+}


### PR DESCRIPTION
Automates what was done manually for 0.4.2: after release assets upload, the workflow POSTs the version to https://foundryvtt.com/_api/packages/release_version/ via new `tools/publish-registry.mjs`.

- Payload read from the stamped module.json (id, version, compatibility); manifest URL is the version-pinned asset `releases/download/<tag>/module.json`, notes → the GitHub release page.
- Dry-run precheck (`dry-run: true`, validates without saving) before the real POST.
- Prereleases: logged and skipped — never pushed to the registry.
- Re-runs idempotent: an already-released version returns 400 `unique_together`, treated as success. Any other registry error fails the job.
- Auth via `FOUNDRY_RELEASE_TOKEN` secret (already set); never printed.

Verification: YAML lints; payload/success/dupe/error/usage paths exercised against a local mock with a real `package.mjs`-stamped module.json; pnpm build/lint/test green. The live authenticated path can only be proven by the next real release.

https://claude.ai/code/session_01G8VmWSfBRHT3qpgoDSb9Ht