### PR TITLE
CI: upload source maps to Sentry on release (OLD-36)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,25 @@ jobs:
         env:
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
 
+      # Symbolication for crash reports. `inject` stamps debug ids into the
+      # dist JS before it's zipped, so matching is path-independent (works even
+      # behind a Foundry routePrefix); release + url-prefix is the fallback for
+      # events from non-injected builds — Foundry serves modules at
+      # <origin>/modules/<id>/, and "~" matches any origin. The release name
+      # must equal what crashReporter.ts tags: <module id>@<stamped version>.
+      # Runs for prereleases too: beta crash reports should symbolicate.
+      # Must run before the zip step (it strips sourcemap refs from dist).
+      - name: Upload source maps to Sentry
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          pnpm exec sentry-cli sourcemaps inject dist
+          pnpm exec sentry-cli sourcemaps upload dist \
+            --org old-school-chronicle --project osc-character-sheet \
+            --release "osc-character-sheet@$VERSION" \
+            --url-prefix "~/modules/osc-character-sheet/dist"
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
       - name: Stamp module.json from tag + zip
         run: |
           VERSION="${GITHUB_REF_NAME#v}"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@eslint/js": "^9.33.0",
     "@ose-foundry-core/types": "github:tasandberg/ose-foundry-core#types-v0.1.0",
     "@pixi/compressed-textures": "github:foundry-vtt-types/pixi-compressed-textures#main",
+    "@sentry/cli": "^3.6.0",
     "@storybook/addon-a11y": "^10.4.6",
     "@storybook/react-vite": "^10.4.6",
     "@types/node": "^24.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@pixi/compressed-textures':
         specifier: github:foundry-vtt-types/pixi-compressed-textures#main
         version: https://codeload.github.com/foundry-vtt-types/pixi-compressed-textures/tar.gz/890bd5cf9f92d6e48103b733513ccb603e5d1a36(@pixi/assets@7.4.3(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e))(@pixi/core@https://codeload.github.com/foundry-vtt-types/pixi-core/tar.gz/b2554df0b43183980830a08d92a960ede78ad25e)
+      '@sentry/cli':
+        specifier: ^3.6.0
+        version: 3.6.0
       '@storybook/addon-a11y':
         specifier: ^10.4.6
         version: 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react@19.2.7))
@@ -1536,6 +1539,58 @@ packages:
   '@sentry/browser@10.63.0':
     resolution: {integrity: sha512-0mi56YOkwgyjdLOcN5cB1//EcYzEOt3NZ2GLygE92B3zAAwVM1WgbmibZCXToKFClH7z1uH3VWVfBffmkwIMYw==}
     engines: {node: '>=18'}
+
+  '@sentry/cli-darwin@3.6.0':
+    resolution: {integrity: sha512-C2SWHKaEP8NoYkLDr5jwrzklTwlJkzPIx7lu2LZrwBuHG/sNhWdili0ED2mD86b6Q90hlcMtuBm5IHUwcZ6FTQ==}
+    engines: {node: '>=18'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@3.6.0':
+    resolution: {integrity: sha512-Rc+DB8vuTDpwqY2BxIPnooYk2ZDYQytF+n4nfi6pZZsJtr3SFFe+3wIWVmCVqxiHkaISb33+iJIDxOOqhkSNbQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@3.6.0':
+    resolution: {integrity: sha512-S9xsDZTvybOGbrqqZ7DvF7JCNKp4cakDWJ4LdvQX+z82cHQSoLkYOXkA3EafDfWV9BGIRMIXitMMiSsV2PMU4g==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@3.6.0':
+    resolution: {integrity: sha512-PQ7+ctNmWtHgmbKa+rJheHU7D9GHJXafgWYfVW6gt7R0Ag9LxiDVYLGjrL4G/i7AGFNgudXFaLkGKNX7HUjc+g==}
+    engines: {node: '>=18'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@3.6.0':
+    resolution: {integrity: sha512-c+7xNg5BAaPE8N2Q6pg3Q/kt97JSaskuQIjRxHaFuDbCkJvww4VozY6mW5NUMJaW48rEs3mahWKamTLqJsO3wQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@3.6.0':
+    resolution: {integrity: sha512-zhZ7YyGreHSKZ92Mwb9h4cEyL0I/eND7W6XIUXUW0BCCmxFOMc71vlQpUw8gijHIsFDbv8c8a6VOSkeRuwbSwQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@3.6.0':
+    resolution: {integrity: sha512-JaxzVDdyetrPBp8NHh2yNAYdDk79ROXqfAfjQwG5z6V764MMMrf2WrhQ7EwoKXOPtBLm/drbOcYgaxHuDZKGRw==}
+    engines: {node: '>=18'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@3.6.0':
+    resolution: {integrity: sha512-LW0078VlxaUeVMMLA15A1zhkvZ5vby/lwthtBXPoBSDdTcgbTE4D4gQXM9vEapV28SvCO3fVIek3pbtrkaeDMw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@3.6.0':
+    resolution: {integrity: sha512-79XC8o59G/i3VqmnoQD74a/QD/422eQQlUqiPd3sEvcYCxnaZialRVAsxuNEFd6sx4aVGpqt775MMDT9cV/lMg==}
+    engines: {node: '>= 18'}
+    hasBin: true
 
   '@sentry/core@10.63.0':
     resolution: {integrity: sha512-OtUbsrnbEHffOF2S2+M5zXa3HIM0U2b4CDVLKMY1dgS0J3ivRF8XvkjvyIcEG/y8JXnwXbnprLyjhG+AqMdUZQ==}
@@ -3144,6 +3199,10 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   prosemirror-collab@1.3.1:
     resolution: {integrity: sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==}
 
@@ -3182,6 +3241,9 @@ packages:
 
   prosemirror-view@1.40.1:
     resolution: {integrity: sha512-pbwUjt3G7TlsQQHDiYSupWBhJswpLVB09xXm1YiJPdkjkh9Pe7Y51XdLh5VWIZmROLY8UpUpG03lkdhm9lzIBA==}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@1.4.1:
     resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
@@ -3734,6 +3796,10 @@ packages:
 
   undici-types@7.10.0:
     resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
+
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
+    engines: {node: '>=18.17'}
 
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
@@ -5305,6 +5371,46 @@ snapshots:
       '@sentry/feedback': 10.63.0
       '@sentry/replay': 10.63.0
       '@sentry/replay-canvas': 10.63.0
+
+  '@sentry/cli-darwin@3.6.0':
+    optional: true
+
+  '@sentry/cli-linux-arm64@3.6.0':
+    optional: true
+
+  '@sentry/cli-linux-arm@3.6.0':
+    optional: true
+
+  '@sentry/cli-linux-i686@3.6.0':
+    optional: true
+
+  '@sentry/cli-linux-x64@3.6.0':
+    optional: true
+
+  '@sentry/cli-win32-arm64@3.6.0':
+    optional: true
+
+  '@sentry/cli-win32-i686@3.6.0':
+    optional: true
+
+  '@sentry/cli-win32-x64@3.6.0':
+    optional: true
+
+  '@sentry/cli@3.6.0':
+    dependencies:
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      undici: 6.27.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 3.6.0
+      '@sentry/cli-linux-arm': 3.6.0
+      '@sentry/cli-linux-arm64': 3.6.0
+      '@sentry/cli-linux-i686': 3.6.0
+      '@sentry/cli-linux-x64': 3.6.0
+      '@sentry/cli-win32-arm64': 3.6.0
+      '@sentry/cli-win32-i686': 3.6.0
+      '@sentry/cli-win32-x64': 3.6.0
 
   '@sentry/core@10.63.0': {}
 
@@ -6987,6 +7093,8 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  progress@2.0.3: {}
+
   prosemirror-collab@1.3.1:
     dependencies:
       prosemirror-state: 1.4.3
@@ -7060,6 +7168,8 @@ snapshots:
       prosemirror-model: 1.25.3
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.10.4
+
+  proxy-from-env@1.1.0: {}
 
   punycode@1.4.1: {}
 
@@ -7680,6 +7790,8 @@ snapshots:
     optional: true
 
   undici-types@7.10.0: {}
+
+  undici@6.27.0: {}
 
   undici@7.28.0: {}
 

--- a/tools/package.mjs
+++ b/tools/package.mjs
@@ -15,7 +15,8 @@
 //   download → releases/download/<tag>/module.zip — pinned to THIS release.
 
 import { execSync } from "child_process";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
 
 const [version, tagArg] = process.argv.slice(2);
 if (!/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(version ?? "")) {
@@ -31,10 +32,21 @@ manifest.download = `${manifest.url}/releases/download/${tag}/module.zip`;
 writeFileSync("./module.json", JSON.stringify(manifest, null, 2) + "\n");
 console.log(`Stamped module.json ${version} (download → ${manifest.download})`);
 
+// Source maps stay out of the zip — release CI uploads them to Sentry instead.
+// Strip vite's sourceMappingURL comments too: a pointer to a map that isn't
+// shipped makes DevTools log fetch failures on users' machines.
+for (const file of readdirSync("dist", { recursive: true })) {
+  if (!file.endsWith(".js")) continue;
+  const path = join("dist", file);
+  const src = readFileSync(path, "utf8");
+  const stripped = src.replace(/^\/\/# sourceMappingURL=.*\n?/gm, "");
+  if (stripped !== src) writeFileSync(path, stripped);
+}
+
 mkdirSync("build", { recursive: true });
 // Always zip from scratch — `zip -r` updates in place, so a stale archive
 // would keep entries for files that no longer exist (renamed dist chunks).
 rmSync("build/module.zip", { force: true });
-execSync("zip -r build/module.zip module.json dist/ lang/ templates/ README.md", {
+execSync('zip -r build/module.zip module.json dist/ lang/ templates/ README.md -x "*.map"', {
   stdio: "inherit",
 });


### PR DESCRIPTION
Stacked on #61 — retarget to main after it merges.

Crash reports currently show minified frames. This makes release CI upload the dist source maps to Sentry (release `osc-character-sheet@<version>`, the same key `crashReporter.ts` tags events with) and stops shipping maps to users.

## What
- **release.yml**: after build, `sentry-cli sourcemaps inject dist` + `sourcemaps upload` with `SENTRY_AUTH_TOKEN`. Runs for prereleases too (beta crashes should symbolicate); the registry-skip logic in #61 is untouched. Upload failure fails the job (sentry-cli's default exit behavior).
- **tools/package.mjs**: excludes `*.map` from module.zip and strips vite's `sourceMappingURL` comments from the packaged JS — a pointer to a missing map makes DevTools log fetch failures on every user machine with the console open. Shared with local `pnpm release`, so local zips match CI.
- **package.json**: adds `@sentry/cli` (binary ships via platform optionalDependencies — no postinstall approval needed; lockfile change is the dep).

## Why inject + url-prefix (both)
- Debug ids make frame↔map matching path-independent — it works even when a host runs Foundry behind a `routePrefix`, where the frame URL isn't `/modules/...`. Verified the manual-client path: `@sentry/core` 10.63.0 applies `_sentryDebugIds` in `prepareEvent` (core, not an integration, so `integrations: []` doesn't disable it), and `scrubEvent` doesn't strip `debug_meta`.
- `--url-prefix "~/modules/osc-character-sheet/dist"` is the fallback for events from non-injected builds (e.g. the locally-built assets `pnpm release` uploads at create time before CI clobbers them). `~` matches any origin; Foundry serves module files at `<origin>/modules/<id>/dist/...`, and sentry-cli preserves the `dist/assets/…` substructure.

## Verified locally
- `sentry-cli sourcemaps inject dist` works on the vite output (both chunks stamped; ESM-safe snippet).
- `package.mjs` zip: no `.map` entries, no `sourceMappingURL` comments, `debugId` comment retained.
- YAML parses; build, lint, tests green.

## Unverifiable until a real release
The authenticated upload itself, and end-to-end symbolication of a real crash event (needs a published release + a crash from that build).

https://claude.ai/code/session_01G8VmWSfBRHT3qpgoDSb9Ht