### PR TITLE
deps: foundry-vtt-react ^0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@sentry/browser": "^10.63.0",
     "clsx": "^2.1.1",
-    "foundry-vtt-react": "0.2.0-beta.1",
+    "foundry-vtt-react": "^0.2.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       foundry-vtt-react:
-        specifier: 0.2.0-beta.1
-        version: 0.2.0-beta.1(@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@24.3.0)(esbuild@0.27.7)(sass-embedded@1.91.0)(sass@1.91.0)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@24.3.0)(esbuild@0.27.7)(sass-embedded@1.91.0)(sass@1.91.0))
+        specifier: ^0.2.0
+        version: 0.2.0(@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@24.3.0)(esbuild@0.27.7)(sass-embedded@1.91.0)(sass@1.91.0)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@24.3.0)(esbuild@0.27.7)(sass-embedded@1.91.0)(sass@1.91.0))
       react:
         specifier: ^19.2.0
         version: 19.2.7
@@ -2539,8 +2539,8 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  foundry-vtt-react@0.2.0-beta.1:
-    resolution: {integrity: sha512-HeAD3ERq8bHVsuO6uVN3D3kzmaB6Vxb3STzLqsyrtVDjbA0n+BPSUgNQr3nqE7VJRKh0H4mmu38sDT0jzDvfhg==}
+  foundry-vtt-react@0.2.0:
+    resolution: {integrity: sha512-+PLjgrfoDtu1k5yvF8FoA2QFnC6IF4ryga79HXo2zFractyXvsjZwRDu15aUSfOPntB/23kAihsHR/YtSTQ80A==}
     peerDependencies:
       '@vitejs/plugin-react': '>=4'
       react: ^19.2.0
@@ -6440,7 +6440,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  foundry-vtt-react@0.2.0-beta.1(@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@24.3.0)(esbuild@0.27.7)(sass-embedded@1.91.0)(sass@1.91.0)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@24.3.0)(esbuild@0.27.7)(sass-embedded@1.91.0)(sass@1.91.0)):
+  foundry-vtt-react@0.2.0(@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@24.3.0)(esbuild@0.27.7)(sass-embedded@1.91.0)(sass@1.91.0)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@24.3.0)(esbuild@0.27.7)(sass-embedded@1.91.0)(sass@1.91.0)):
     dependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)


### PR DESCRIPTION
Promotes the pin from `0.2.0-beta.1` to `^0.2.0` now that fvr 0.2.0 is on npm `latest`. Same code as the beta — mixin generics (fvr #11) + flushSync render-hook timing (fvr #12).

Build, lint, 112 tests green.