### PR TITLE
design-sync: fix build-css for tokens.scss rename

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -81,7 +81,26 @@ library under `src/OscSheet/components/ui/`.
 - **KvCard has its own `KvCard.stories.tsx`** (Card.tsx's 2nd export) — split out of Card.stories
   so each design card is focused. A component in `componentSrcMap` MUST have a matching story file.
 
+## README is NOT staged — regenerate by hand on any rename/count change
+
+- `generate.mjs` deliberately does **not** stage `README.md` (it has no exemplar). The
+  remote README = `conventions.md` header + a hand-written body (naming, loading, token
+  buckets, component index). On the 2026-07-07 sync this was badly stale: the module was
+  renamed `reactor-sheet` → `osc-character-sheet` (global `ReactorSheet` → `OscSheet`,
+  scope `.reactor-sheet` → `.osc-sheet`, 24 → 32 components) but the remote README still
+  said `window.ReactorSheet` — which would tell the design agent to use a global the new
+  bundle doesn't export. **Whenever the package name, global, scope, token count, or
+  component set changes, re-author `README.md` and upload it** (header = current
+  `conventions.md`, body updated to match). Consider teaching `generate.mjs` to emit the
+  README so this stops being manual.
+
 ## Re-sync risks (what can silently go stale)
+
+- **`build-css.mjs` read a renamed file (fixed 2026-07-07).** `tokens.css` became
+  `tokens.scss` (now emits `--fs-*`/`--r-*` from `_scales.scss` maps via `@each`), which
+  broke the CSS build. Fixed to compile it through dart-sass like `utilities.scss`. This is
+  exactly the "mirrors the app pipeline by hand" drift risk below — re-check after any
+  vellum style refactor (partial rename, new `@use`, sass upgrade).
 
 - **`build-css.mjs` mirrors the app pipeline by hand.** If the repo changes how Vellum CSS
   is scoped/compiled (postcss config, new style partial, sass version), this script can drift

--- a/.design-sync/build-css.mjs
+++ b/.design-sync/build-css.mjs
@@ -36,7 +36,10 @@ function sass(file, extraArgs = []) {
 }
 
 export async function buildParts() {
-  const tokens = await scope(path.join(vellum, "tokens.css"));
+  // tokens.scss (was tokens.css) now emits --fs-*/--r-* from _scales.scss maps
+  // via @each — compile with dart-sass first, then scope (same as utilities).
+  const tokensScss = path.join(vellum, "tokens.scss");
+  const tokens = await scopeCss(sass(tokensScss), tokensScss);
   const utilitiesScss = path.join(vellum, "utilities.scss");
   const utilities = await scopeCss(sass(utilitiesScss), utilitiesScss);
   const components = await scope(path.join(vellum, "components.css"));


### PR DESCRIPTION
The `tokens.css` → `tokens.scss` rename (Sentry error-boundary PR #55) broke the
design-sync CSS build — `build-css.mjs` still read the old `.css`. `tokens.scss` now
emits `--fs-*`/`--r-*` from `_scales.scss` maps via `@each`, so it needs dart-sass
compilation like `utilities.scss`. Fixed.

Also ran the sync itself against claude.ai/design (project "Old School Chronicle (Vellum DS)"):
the remote was fully stale from the `reactor-sheet` → `osc-character-sheet` module rename —
every component re-exported `window.ReactorSheet`. Re-uploaded all 32 components + rebuilt CSS
+ a corrected README (the old one told the design agent to use `window.ReactorSheet`, which the
new bundle doesn't export). NOTES.md now flags that the generator doesn't stage README, so
renames/count changes need a manual README refresh.