### PR TITLE
feat: Send Item — transfer item to another actor (OLD-27)

### DIFF
--- a/module.json
+++ b/module.json
@@ -19,6 +19,7 @@
   "esmodules": [
     "dist/main.js"
   ],
+  "socket": true,
   "packs": [],
   "languages": [
     {

--- a/src/OscSheet/app/SheetShell.tsx
+++ b/src/OscSheet/app/SheetShell.tsx
@@ -187,9 +187,11 @@ export default function SheetShell() {
   const onSend = (itemId: string, target: SendTargetVM, qty: number) => {
     const it = resolveItem(itemId);
     if (!it) return;
+    // Resolve the picked token's actor by UUID (fromUuidSync handles linked and
+    // unlinked/synthetic token actors on the loaded scene).
     const targetActor = (
-      game.actors as { get(id: string): unknown } | undefined
-    )?.get(target.id) as EmbeddedDocActor | undefined;
+      foundry.utils as { fromUuidSync?: (u: string) => unknown }
+    ).fromUuidSync?.(target.uuid) as EmbeddedDocActor | undefined;
     if (!targetActor && target.ownedByMe) {
       toast({
         intent: "danger",
@@ -235,8 +237,8 @@ export default function SheetShell() {
     emitSendItem({
       type: "sendItem",
       requestId: foundry.utils.randomID(),
-      fromActorId: actor.id ?? "",
-      toActorId: target.id,
+      sourceUuid: actor.uuid ?? "",
+      targetUuid: target.uuid,
       create: plan.create,
       deleteIds: plan.deleteIds,
       decrement: plan.decrement,

--- a/src/OscSheet/app/SheetShell.tsx
+++ b/src/OscSheet/app/SheetShell.tsx
@@ -18,6 +18,13 @@ import {
   selectCoins,
 } from "@features/inventory/inventory";
 import { flagPath, FLAGS, readFlag } from "@domain/flags";
+import { collectTree, classifyRoute } from "@features/inventory/sendItem";
+import {
+  applySend,
+  emitSendItem,
+  type EmbeddedDocActor,
+} from "@features/inventory/sendItemSocket";
+import type { SendTargetVM } from "@features/inventory/sendTargets";
 import { showTokenVariantsPortraitPicker } from "@domain/tokenVariants";
 import { selectAc } from "@domain/vitals";
 import { usesAscendingAC } from "@domain/chat/targeting";
@@ -174,6 +181,75 @@ export default function SheetShell() {
     void it.delete();
   };
 
+  // Send an item to another actor. Direct apply when I own the target; otherwise
+  // relay the whole op through the active GM. Pure plan/route logic lives in
+  // sendItem.ts; the socket + apply routine in sendItemSocket.ts.
+  const onSend = (itemId: string, target: SendTargetVM, qty: number) => {
+    const it = resolveItem(itemId);
+    if (!it) return;
+    const targetActor = (
+      game.actors as { get(id: string): unknown } | undefined
+    )?.get(target.id) as EmbeddedDocActor | undefined;
+    if (!targetActor && target.ownedByMe) {
+      toast({
+        intent: "danger",
+        title: "Send failed",
+        message: `Couldn't find ${target.name}.`,
+      });
+      return;
+    }
+    const plan = collectTree(it, invItems as OseItem[], qty);
+    const route = classifyRoute(
+      { isOwner: actor.isOwner },
+      { isOwner: target.ownedByMe },
+    );
+    const gift = <i className="fa-solid fa-gift" aria-hidden="true" />;
+
+    if (route === "local" && targetActor) {
+      void applySend({
+        fromActor: actor as unknown as EmbeddedDocActor,
+        toActor: targetActor,
+        create: plan.create,
+        deleteIds: plan.deleteIds,
+        decrement: plan.decrement,
+      })
+        .then(() =>
+          toast({
+            intent: "success",
+            title: "Sent",
+            message: `${it.name} → ${target.name}`,
+            icon: gift,
+          }),
+        )
+        .catch(() =>
+          toast({
+            intent: "danger",
+            title: "Send failed",
+            message: `Couldn't send ${it.name}.`,
+          }),
+        );
+      return;
+    }
+
+    // Cross-owner: relay to the GM. Emit the whole op and toast optimistically.
+    emitSendItem({
+      type: "sendItem",
+      requestId: foundry.utils.randomID(),
+      fromActorId: actor.id ?? "",
+      toActorId: target.id,
+      create: plan.create,
+      deleteIds: plan.deleteIds,
+      decrement: plan.decrement,
+      requesterUserId: game.user?.id ?? "",
+    });
+    toast({
+      intent: "success",
+      title: "Sent",
+      message: `${it.name} → ${target.name} (via GM)`,
+      icon: gift,
+    });
+  };
+
   const visible = tabs(actor).filter((t) => !t.disabled);
   const items: TabItem[] = visible.map((t) => ({
     id: t.id,
@@ -244,6 +320,7 @@ export default function SheetShell() {
             onReorder={onReorder}
             onReorderEquipped={onReorderEquipped}
             onNest={onNest}
+            onSend={onSend}
           />
         ) : (
           activeTab.Content && <activeTab.Content />

--- a/src/OscSheet/app/features.ts
+++ b/src/OscSheet/app/features.ts
@@ -8,7 +8,7 @@ export const FEATURES = {
   /** Topbar "Rest" — no character-level HP/HD recovery yet. */
   rest: false,
   /** Inventory "Send Item" to another actor (GH #16). */
-  sendItem: false,
+  sendItem: true,
 } as const;
 
 export type FeatureKey = keyof typeof FEATURES;

--- a/src/OscSheet/features/inventory/InventoryViewDnd.stories.tsx
+++ b/src/OscSheet/features/inventory/InventoryViewDnd.stories.tsx
@@ -67,6 +67,7 @@ export const Default = () => (
       onReorder={log("reorder")}
       onReorderEquipped={log("reorderEquipped")}
       onNest={log("nest")}
+      onSend={log("send")}
     />
   </div>
 );

--- a/src/OscSheet/features/inventory/InventoryViewDnd.tsx
+++ b/src/OscSheet/features/inventory/InventoryViewDnd.tsx
@@ -26,6 +26,7 @@ import { SortHeader } from "@features/inventory/SortHeader";
 import { SendItemModal } from "@features/inventory/SendItemModal";
 import {
   selectSendTargets,
+  isGmConnected,
   type SendTargetVM,
 } from "@features/inventory/sendTargets";
 import { useOscSheetContext } from "@app/context";
@@ -1022,7 +1023,9 @@ export function InventoryViewDnd({
           onEquip={onEquip}
           onConsume={onConsume}
           onDelete={onDelete}
-          onSend={byId.has(menu.item.id) ? openSend : undefined}
+          onSend={
+            byId.has(menu.item.id) && isGmConnected() ? openSend : undefined
+          }
         />
       )}
 

--- a/src/OscSheet/features/inventory/InventoryViewDnd.tsx
+++ b/src/OscSheet/features/inventory/InventoryViewDnd.tsx
@@ -23,6 +23,11 @@ import { buildItemMacroDragData } from "@features/inventory/dragToMacro";
 import { WealthSection } from "@features/inventory/WealthSection";
 import { ItemImage } from "@features/inventory/ItemImage";
 import { SortHeader } from "@features/inventory/SortHeader";
+import { SendItemModal } from "@features/inventory/SendItemModal";
+import {
+  selectSendTargets,
+  type SendTargetVM,
+} from "@features/inventory/sendTargets";
 import { useOscSheetContext } from "@app/context";
 import { FEATURES } from "@app/features";
 import { SectionTitle } from "@ui/SectionTitle";
@@ -46,6 +51,8 @@ type Ops = {
   /** Persist the equipped tray's own order (writes the `equippedOrder` flag). */
   onReorderEquipped: (updates: { id: string; sort: number }[]) => void;
   onNest: (itemId: string, containerId: string | null) => void;
+  /** Transfer an item (optionally a stack split) to another actor. */
+  onSend: (itemId: string, target: SendTargetVM, qty: number) => void;
 };
 
 /** Right-click context-menu target: which item, and where to anchor the menu.
@@ -587,6 +594,7 @@ function ItemContextMenu({
   onEquip,
   onConsume,
   onDelete,
+  onSend,
 }: {
   menu: MenuState;
   onClose: () => void;
@@ -594,6 +602,8 @@ function ItemContextMenu({
   onEquip: (id: string) => void;
   onConsume: (id: string) => void;
   onDelete: (id: string) => void;
+  /** Open the Send dialog for this item. Absent → item can't be sent (e.g. coins). */
+  onSend?: (id: string) => void;
 }) {
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
@@ -630,13 +640,14 @@ function ItemContextMenu({
       >
         <i className="fa-solid fa-eye" aria-hidden="true" /> View Item
       </button>
-      {/* Send Item is a WIP — gated off for v1. See GH #16 / OLD-19. */}
-      {FEATURES.sendItem && (
+      {FEATURES.sendItem && onSend && (
         <button
           type="button"
           className="osc-ctx-item"
-          disabled
-          title="Coming soon"
+          onClick={() => {
+            onSend(menu.item.id);
+            onClose();
+          }}
         >
           <i className="fa-solid fa-gift" aria-hidden="true" /> Send Item
         </button>
@@ -696,6 +707,7 @@ export function InventoryViewDnd({
   onReorder,
   onReorderEquipped,
   onNest,
+  onSend,
 }: Props) {
   // Rows always render in manual order (from `groups`); a sort-header click bakes the
   // chosen order into the `order` flag and returns here, so drags keep sticking.
@@ -713,6 +725,8 @@ export function InventoryViewDnd({
   );
   const [listOver, setListOver] = useState(false); // tray tile hovering the list → unequip
   const [menu, setMenu] = useState<MenuState | null>(null);
+  // The item whose Send dialog is open (a full inventory VM node), null = closed.
+  const [sending, setSending] = useState<InventoryItemVM | null>(null);
 
   // Foundry items by id — source for the hotbar drag payload. Dragging a row onto
   // the macro bar creates an item macro (OSE's hotbarDrop hook), like the stock sheet.
@@ -729,6 +743,11 @@ export function InventoryViewDnd({
   };
 
   const byId = indexById(inventory.items);
+  // Open the Send dialog for a list item (coins aren't in the VM → not sendable).
+  const openSend = (id: string) => {
+    const it = byId.get(id);
+    if (it) setSending(it);
+  };
   const groupsRef = useRef(groups);
   groupsRef.current = groups;
   // Holds the *rendered* tray ids (stale ids dropped), kept index-aligned with the
@@ -1003,8 +1022,29 @@ export function InventoryViewDnd({
           onEquip={onEquip}
           onConsume={onConsume}
           onDelete={onDelete}
+          onSend={byId.has(menu.item.id) ? openSend : undefined}
         />
       )}
+
+      {sending &&
+        (() => {
+          const { targets, gmOnline } = selectSendTargets(actor);
+          const contentCount = flattenItems(sending.children).length;
+          return (
+            <SendItemModal
+              open
+              item={sending}
+              contentCount={contentCount}
+              targets={targets}
+              gmOnline={gmOnline}
+              onClose={() => setSending(null)}
+              onSend={(target, qty) => {
+                onSend(sending.id, target, qty);
+                setSending(null);
+              }}
+            />
+          );
+        })()}
     </section>
   );
 }

--- a/src/OscSheet/features/inventory/InventoryViewDnd.tsx
+++ b/src/OscSheet/features/inventory/InventoryViewDnd.tsx
@@ -590,6 +590,7 @@ function EquippedTray({
 
 function ItemContextMenu({
   menu,
+  canEdit,
   onClose,
   onOpen,
   onEquip,
@@ -598,6 +599,8 @@ function ItemContextMenu({
   onSend,
 }: {
   menu: MenuState;
+  /** Whether the current user owns this actor. Non-owners get view-only. */
+  canEdit: boolean;
   onClose: () => void;
   onOpen: (id: string) => void;
   onEquip: (id: string) => void;
@@ -653,7 +656,7 @@ function ItemContextMenu({
           <i className="fa-solid fa-gift" aria-hidden="true" /> Send Item
         </button>
       )}
-      {menu.item.equipped === true && (
+      {canEdit && menu.item.equipped === true && (
         <button
           type="button"
           className="osc-ctx-item"
@@ -665,7 +668,7 @@ function ItemContextMenu({
           <i className="fa-solid fa-hand" aria-hidden="true" /> Unequip
         </button>
       )}
-      {menu.item.quantity != null && (
+      {canEdit && menu.item.quantity != null && (
         <button
           type="button"
           className="osc-ctx-item"
@@ -678,16 +681,18 @@ function ItemContextMenu({
           one
         </button>
       )}
-      <button
-        type="button"
-        className="osc-ctx-item is-danger"
-        onClick={() => {
-          onDelete(menu.item.id);
-          onClose();
-        }}
-      >
-        <i className="fa-solid fa-trash" aria-hidden="true" /> Delete Item
-      </button>
+      {canEdit && (
+        <button
+          type="button"
+          className="osc-ctx-item is-danger"
+          onClick={() => {
+            onDelete(menu.item.id);
+            onClose();
+          }}
+        >
+          <i className="fa-solid fa-trash" aria-hidden="true" /> Delete Item
+        </button>
+      )}
     </div>
   );
 }
@@ -1018,13 +1023,16 @@ export function InventoryViewDnd({
       {menu && (
         <ItemContextMenu
           menu={menu}
+          canEdit={actor.isOwner}
           onClose={() => setMenu(null)}
           onOpen={onOpen}
           onEquip={onEquip}
           onConsume={onConsume}
           onDelete={onDelete}
           onSend={
-            byId.has(menu.item.id) && isGmConnected() ? openSend : undefined
+            actor.isOwner && byId.has(menu.item.id) && isGmConnected()
+              ? openSend
+              : undefined
           }
         />
       )}

--- a/src/OscSheet/features/inventory/SendItemModal.tsx
+++ b/src/OscSheet/features/inventory/SendItemModal.tsx
@@ -106,37 +106,40 @@ export function SendItemModal({
           No visible characters in this scene to send to.
         </p>
       ) : (
-        <ul className="osc-send-targets u-stack u-gap-1 u-mt-4">
-          {targets.map((t) => {
-            const blocked = relayBlocked(t);
-            return (
-              <li key={t.id}>
-                <button
-                  type="button"
-                  className={cx(
-                    "osc-send-target",
-                    selectedId === t.id && "is-selected",
-                  )}
-                  disabled={blocked}
-                  aria-pressed={selectedId === t.id}
-                  title={
-                    blocked
-                      ? "A GM must be online to send to this character"
-                      : undefined
-                  }
-                  onClick={() => setSelectedId(t.id)}
-                >
-                  <Monogram
-                    img={t.img}
-                    monogram={initials(t.name)}
-                    className="osc-send-target-ic"
-                  />
-                  <span className="u-flex-1">{t.name}</span>
-                </button>
-              </li>
-            );
-          })}
-        </ul>
+        <div className="u-mt-4 u-stack u-gap-2">
+          <label className="field-label">Send item(s) to:</label>
+          <ul className="osc-send-targets u-stack u-gap-1">
+            {targets.map((t) => {
+              const blocked = relayBlocked(t);
+              return (
+                <li key={t.id}>
+                  <button
+                    type="button"
+                    className={cx(
+                      "osc-send-target",
+                      selectedId === t.id && "is-selected",
+                    )}
+                    disabled={blocked}
+                    aria-pressed={selectedId === t.id}
+                    title={
+                      blocked
+                        ? "A GM must be online to send to this character"
+                        : undefined
+                    }
+                    onClick={() => setSelectedId(t.id)}
+                  >
+                    <Monogram
+                      img={t.img}
+                      monogram={initials(t.name)}
+                      className="osc-send-target-ic"
+                    />
+                    <span className="u-flex-1">{t.name}</span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
       )}
     </Modal>
   );

--- a/src/OscSheet/features/inventory/SendItemModal.tsx
+++ b/src/OscSheet/features/inventory/SendItemModal.tsx
@@ -1,0 +1,124 @@
+// "Send Item" dialog: pick a target actor, optionally split a stack, and send.
+// Composed from DS primitives (Modal / Monogram / Tag / Stepper / Button). Targets
+// I own send directly; cross-owner targets relay through a GM and are disabled
+// when no GM is online.
+import { useEffect, useState } from "react";
+import { Modal } from "@ui/Modal";
+import { Monogram } from "@ui/Monogram";
+import { Tag } from "@ui/Tag";
+import { Stepper } from "@ui/Stepper";
+import { Button } from "@ui/Button";
+import { cx } from "@ui/cx";
+import type { InventoryItemVM } from "@domain/vm-types";
+import type { SendTargetVM } from "@features/inventory/sendTargets";
+
+type Props = {
+  open: boolean;
+  item: InventoryItemVM;
+  /** Descendant count when `item` is a container (0 otherwise). */
+  contentCount: number;
+  targets: SendTargetVM[];
+  gmOnline: boolean;
+  onClose: () => void;
+  /** Fire the transfer: chosen target + quantity to send. */
+  onSend: (target: SendTargetVM, qty: number) => void;
+};
+
+/** 2-letter initials for the target's monogram fallback. */
+function initials(name: string): string {
+  const words = name.match(/[A-Za-z]+/g) ?? [];
+  if (words.length === 0) return "?";
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
+  return (words[0][0] + words[1][0]).toUpperCase();
+}
+
+export function SendItemModal({
+  open,
+  item,
+  contentCount,
+  targets,
+  gmOnline,
+  onClose,
+  onSend,
+}: Props) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [qty, setQty] = useState(1);
+
+  // Reset selection/qty whenever a new item opens the dialog.
+  useEffect(() => {
+    setSelectedId(null);
+    setQty(1);
+  }, [item.id]);
+
+  const max = item.quantity?.value ?? 1;
+  const stacked = !item.isContainer && max > 1;
+  const selected = targets.find((t) => t.id === selectedId) ?? null;
+  const relayBlocked = (t: SendTargetVM) => t.crossOwner && !gmOnline;
+  const valid = selected != null && !relayBlocked(selected);
+
+  const footer = (
+    <>
+      <Button variant="ghost" onClick={onClose}>
+        Cancel
+      </Button>
+      <Button
+        variant="primary"
+        disabled={!valid}
+        onClick={() => selected && onSend(selected, stacked ? qty : max)}
+      >
+        Send
+      </Button>
+    </>
+  );
+
+  return (
+    <Modal open={open} title={`Send ${item.name}`} onClose={onClose} footer={footer}>
+      {targets.length === 0 ? (
+        <p className="osc-send-empty">No other party members to send to.</p>
+      ) : (
+        <ul className="osc-send-targets">
+          {targets.map((t) => {
+            const blocked = relayBlocked(t);
+            return (
+              <li key={t.id}>
+                <button
+                  type="button"
+                  className={cx(
+                    "osc-send-target",
+                    selectedId === t.id && "is-selected",
+                  )}
+                  disabled={blocked}
+                  aria-pressed={selectedId === t.id}
+                  title={blocked ? "No GM online to relay this transfer" : undefined}
+                  onClick={() => setSelectedId(t.id)}
+                >
+                  <Monogram
+                    img={t.img}
+                    monogram={initials(t.name)}
+                    className="osc-send-target-ic"
+                  />
+                  <span className="osc-send-target-nm">{t.name}</span>
+                  {t.crossOwner && <Tag intent="mustard">via GM</Tag>}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {stacked && (
+        <div className="osc-send-qty">
+          <span className="osc-send-qty-label">Quantity</span>
+          <Stepper value={qty} onValueChange={setQty} min={1} max={max} />
+          <span className="osc-send-qty-of">of {max}</span>
+        </div>
+      )}
+
+      {item.isContainer && contentCount > 0 && (
+        <p className="osc-send-note">
+          Includes {contentCount} {contentCount === 1 ? "item" : "items"} inside.
+        </p>
+      )}
+    </Modal>
+  );
+}

--- a/src/OscSheet/features/inventory/SendItemModal.tsx
+++ b/src/OscSheet/features/inventory/SendItemModal.tsx
@@ -62,7 +62,7 @@ export function SendItemModal({
       </Button>
       <Button
         variant="primary"
-        disabled={!valid}
+        disabled={!valid || targets.length === 0}
         onClick={() => selected && onSend(selected, stacked ? qty : max)}
       >
         Send
@@ -95,13 +95,14 @@ export function SendItemModal({
 
       {item.isContainer && contentCount > 0 && (
         <p className="u-mt-2 u-fs-sm u-text-muted">
-          Includes {contentCount} {contentCount === 1 ? "item" : "items"} inside.
+          Includes {contentCount} {contentCount === 1 ? "item" : "items"}{" "}
+          inside.
         </p>
       )}
 
       {/* Target characters: visible, non-hostile scene tokens. */}
       {targets.length === 0 ? (
-        <p className="u-mt-4 u-fs-sm u-text-muted">
+        <p className="u-pt-3 u-fs-lg u-text-muted">
           No visible characters in this scene to send to.
         </p>
       ) : (

--- a/src/OscSheet/features/inventory/SendItemModal.tsx
+++ b/src/OscSheet/features/inventory/SendItemModal.tsx
@@ -5,7 +5,6 @@
 import { useEffect, useState } from "react";
 import { Modal } from "@ui/Modal";
 import { Monogram } from "@ui/Monogram";
-import { Tag } from "@ui/Tag";
 import { Stepper } from "@ui/Stepper";
 import { Button } from "@ui/Button";
 import { cx } from "@ui/cx";
@@ -72,11 +71,41 @@ export function SendItemModal({
   );
 
   return (
-    <Modal open={open} title={`Send ${item.name}`} onClose={onClose} footer={footer}>
+    <Modal
+      open={open}
+      title={`Send ${item.name}`}
+      onClose={onClose}
+      footer={footer}
+    >
+      {/* The item being sent: art, name, and (for stacks) a quantity stepper. */}
+      <div className="u-row u-gap-3">
+        <Monogram
+          img={item.img}
+          monogram={initials(item.name)}
+          className="osc-send-target-ic"
+        />
+        <span className="u-flex-1">{item.name}</span>
+        {stacked && (
+          <div className="u-row u-gap-2">
+            <Stepper value={qty} onValueChange={setQty} min={1} max={max} />
+            <span className="u-fs-sm u-text-muted">of {max}</span>
+          </div>
+        )}
+      </div>
+
+      {item.isContainer && contentCount > 0 && (
+        <p className="u-mt-2 u-fs-sm u-text-muted">
+          Includes {contentCount} {contentCount === 1 ? "item" : "items"} inside.
+        </p>
+      )}
+
+      {/* Target characters: visible, non-hostile scene tokens. */}
       {targets.length === 0 ? (
-        <p className="osc-send-empty">No other party members to send to.</p>
+        <p className="u-mt-4 u-fs-sm u-text-muted">
+          No visible characters in this scene to send to.
+        </p>
       ) : (
-        <ul className="osc-send-targets">
+        <ul className="osc-send-targets u-stack u-gap-1 u-mt-4">
           {targets.map((t) => {
             const blocked = relayBlocked(t);
             return (
@@ -89,7 +118,11 @@ export function SendItemModal({
                   )}
                   disabled={blocked}
                   aria-pressed={selectedId === t.id}
-                  title={blocked ? "No GM online to relay this transfer" : undefined}
+                  title={
+                    blocked
+                      ? "A GM must be online to send to this character"
+                      : undefined
+                  }
                   onClick={() => setSelectedId(t.id)}
                 >
                   <Monogram
@@ -97,27 +130,12 @@ export function SendItemModal({
                     monogram={initials(t.name)}
                     className="osc-send-target-ic"
                   />
-                  <span className="osc-send-target-nm">{t.name}</span>
-                  {t.crossOwner && <Tag intent="mustard">via GM</Tag>}
+                  <span className="u-flex-1">{t.name}</span>
                 </button>
               </li>
             );
           })}
         </ul>
-      )}
-
-      {stacked && (
-        <div className="osc-send-qty">
-          <span className="osc-send-qty-label">Quantity</span>
-          <Stepper value={qty} onValueChange={setQty} min={1} max={max} />
-          <span className="osc-send-qty-of">of {max}</span>
-        </div>
-      )}
-
-      {item.isContainer && contentCount > 0 && (
-        <p className="osc-send-note">
-          Includes {contentCount} {contentCount === 1 ? "item" : "items"} inside.
-        </p>
       )}
     </Modal>
   );

--- a/src/OscSheet/features/inventory/sendItem.test.ts
+++ b/src/OscSheet/features/inventory/sendItem.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { collectTree, rebuildNesting, classifyRoute, type SendNode } from "./sendItem";
+import { MODULE_ID, FLAGS } from "@domain/flags";
+import type { OseItem } from "@domain/types";
+
+type Sys = Record<string, unknown>;
+
+/** Live-item mock: `.toObject()` returns a deep clone of the raw source data. */
+const mk = (
+  id: string,
+  type: string,
+  system: Sys = {},
+  flags: Record<string, unknown> = {},
+): OseItem => {
+  const base = {
+    _id: id,
+    name: id,
+    img: "",
+    type,
+    system: { containerId: "", equipped: false, quantity: { value: 1, max: 0 }, ...system },
+    flags,
+    effects: [] as unknown[],
+  };
+  return { ...base, toObject: () => structuredClone(base) } as unknown as OseItem;
+};
+
+const sys = (n: SendNode) => n.system as Record<string, unknown>;
+const qty = (n: SendNode) => (sys(n).quantity as { value: number }).value;
+
+describe("collectTree — stacked non-container", () => {
+  const rations = mk("rat", "item", { quantity: { value: 7, max: 7 } });
+
+  it("partial send: copy carries sent qty, source is decremented", () => {
+    const plan = collectTree(rations, [rations], 3);
+    expect(plan.create).toHaveLength(1);
+    expect(qty(plan.create[0])).toBe(3);
+    expect(plan.decrement).toEqual({ id: "rat", value: 4 });
+    expect(plan.deleteIds).toEqual([]);
+  });
+
+  it("full send: copy carries all, source deleted (no decrement)", () => {
+    const plan = collectTree(rations, [rations], 7);
+    expect(qty(plan.create[0])).toBe(7);
+    expect(plan.deleteIds).toEqual(["rat"]);
+    expect(plan.decrement).toBeNull();
+  });
+});
+
+describe("collectTree — copy hygiene", () => {
+  const sword = mk(
+    "sw",
+    "weapon",
+    { quantity: { value: 1, max: 0 }, equipped: true, containerId: "somebag" },
+    { [MODULE_ID]: { [FLAGS.order]: 100, [FLAGS.equippedOrder]: 200 }, core: { keep: true } },
+  );
+  const plan = collectTree(sword, [sword], 1);
+  const node = plan.create[0];
+
+  it("non-stacked item is a full move", () => {
+    expect(plan.deleteIds).toEqual(["sw"]);
+    expect(plan.decrement).toBeNull();
+  });
+
+  it("strips _id", () => {
+    expect(node._id).toBeUndefined();
+  });
+
+  it("clears order/equippedOrder flags but keeps other scopes", () => {
+    const f = node.flags as Record<string, Record<string, unknown>>;
+    expect(f[MODULE_ID]?.[FLAGS.order]).toBeUndefined();
+    expect(f[MODULE_ID]?.[FLAGS.equippedOrder]).toBeUndefined();
+    expect(f.core).toEqual({ keep: true });
+  });
+
+  it("unequips the copy", () => {
+    expect(sys(node).equipped).toBe(false);
+  });
+
+  it("clears the root copy's containerId", () => {
+    expect(sys(node).containerId).toBe("");
+    expect(node._parentKey).toBeNull();
+  });
+});
+
+describe("collectTree — container with nested contents", () => {
+  const bag = mk("bag", "container", {});
+  const subBag = mk("sub", "container", { containerId: "bag" });
+  const torch = mk("torch", "item", { containerId: "bag" });
+  const gem = mk("gem", "treasure", { containerId: "sub" });
+  const rope = mk("rope", "item", {}); // top-level — not part of the bag
+  const plan = collectTree(bag, [bag, subBag, torch, gem, rope], 1);
+
+  it("gathers the root + all descendants incl sub-containers", () => {
+    expect(plan.create.map((n) => n._key).sort()).toEqual(
+      ["bag", "gem", "sub", "torch"].sort(),
+    );
+    expect(plan.deleteIds.sort()).toEqual(["bag", "gem", "sub", "torch"].sort());
+  });
+
+  it("records original parent keys for nesting rebuild", () => {
+    const by = (k: string) => plan.create.find((n) => n._key === k)!;
+    expect(by("bag")._parentKey).toBeNull();
+    expect(sys(by("bag")).containerId).toBe("");
+    expect(by("torch")._parentKey).toBe("bag");
+    expect(by("sub")._parentKey).toBe("bag");
+    expect(by("gem")._parentKey).toBe("sub");
+  });
+});
+
+describe("rebuildNesting", () => {
+  it("remaps old→new container ids down a chain (root excluded)", () => {
+    const nodes: SendNode[] = [
+      { _key: "bag", _parentKey: null, system: {}, flags: {} },
+      { _key: "sub", _parentKey: "bag", system: {}, flags: {} },
+      { _key: "gem", _parentKey: "sub", system: {}, flags: {} },
+    ];
+    const idMap = new Map([
+      ["bag", "b2"],
+      ["sub", "s2"],
+      ["gem", "g2"],
+    ]);
+    expect(rebuildNesting(nodes, idMap)).toEqual([
+      { _id: "s2", "system.containerId": "b2" },
+      { _id: "g2", "system.containerId": "s2" },
+    ]);
+  });
+});
+
+describe("classifyRoute", () => {
+  it("both actors owned by me → local apply", () => {
+    expect(classifyRoute({ isOwner: true }, { isOwner: true })).toBe("local");
+  });
+  it("cross-owner target → GM relay", () => {
+    expect(classifyRoute({ isOwner: true }, { isOwner: false })).toBe("gm-relay");
+  });
+});

--- a/src/OscSheet/features/inventory/sendItem.ts
+++ b/src/OscSheet/features/inventory/sendItem.ts
@@ -1,0 +1,138 @@
+// Pure logic for "Send Item" — transfer an item (optionally a stack split, or a
+// container with all its nested contents) from one actor to another. No React,
+// no Foundry side effects here: this builds the create/delete/decrement plan that
+// `applySend` (SheetShell) executes locally or a GM executes via the socket relay.
+//
+// Nesting is rebuilt on the target after creation: each copy carries a temporary
+// `_key` (its original id) and `_parentKey` (its original containerId, null at
+// root). Once the target assigns fresh ids, `rebuildNesting` maps old→new so
+// children re-nest under the newly-created container.
+
+import { MODULE_ID, FLAGS } from "@domain/flags";
+import type { OseItem } from "@domain/types";
+
+/** A serialized item copy destined for the target, tagged for nesting rebuild. */
+export type SendNode = Record<string, unknown> & {
+  /** Original item id — key for old→new id remap. */
+  _key: string;
+  /** Original containerId (null at the sent root). */
+  _parentKey: string | null;
+};
+
+export interface SendPlan {
+  /** Item docs to create on the target (root first, then descendants). */
+  create: SendNode[];
+  /** Source item ids to delete after the target copy exists (full moves). */
+  deleteIds: string[];
+  /** Source stack to decrement instead of delete (partial stacked send). */
+  decrement: { id: string; value: number } | null;
+}
+
+/** Direct children of `containerId` in `allItems`. */
+function childrenOf(containerId: string, allItems: OseItem[]): OseItem[] {
+  return allItems.filter(
+    (i) => (i.system as { containerId?: string }).containerId === containerId,
+  );
+}
+
+/** Depth-first descendants of `containerId` (incl. sub-containers). */
+function descendantsOf(containerId: string, allItems: OseItem[]): OseItem[] {
+  const out: OseItem[] = [];
+  for (const child of childrenOf(containerId, allItems)) {
+    out.push(child);
+    out.push(...descendantsOf(child._id as string, allItems));
+  }
+  return out;
+}
+
+/** Serialize `item` into a clean create node: strip _id, clear our order flags,
+ *  unequip, and tag with `_key`/`_parentKey` for nesting rebuild. `qty` overrides
+ *  the copy's stack size; `rootContainerId` is "" at the sent root. */
+function toSendNode(
+  item: OseItem,
+  parentKey: string | null,
+  opts: { qty?: number; containerIdOverride?: string } = {},
+): SendNode {
+  const raw = item.toObject() as Record<string, unknown>;
+  delete raw._id;
+
+  const flags = (raw.flags ?? {}) as Record<string, Record<string, unknown>>;
+  const scope = { ...(flags[MODULE_ID] ?? {}) };
+  delete scope[FLAGS.order];
+  delete scope[FLAGS.equippedOrder];
+  raw.flags = { ...flags, [MODULE_ID]: scope };
+
+  const system = { ...((raw.system ?? {}) as Record<string, unknown>) };
+  if ("equipped" in system) system.equipped = false;
+  if (opts.containerIdOverride !== undefined)
+    system.containerId = opts.containerIdOverride;
+  if (opts.qty !== undefined) {
+    const q = (system.quantity ?? {}) as { value?: number; max?: number };
+    system.quantity = { ...q, value: opts.qty };
+  }
+  raw.system = system;
+
+  return { ...raw, _key: item._id as string, _parentKey: parentKey } as SendNode;
+}
+
+/** Build the transfer plan for sending `qty` of `root` (a live item) off its
+ *  actor. Containers send their whole subtree (qty ignored); a stacked non-
+ *  container splits (partial → decrement source, full → delete source). */
+export function collectTree(
+  root: OseItem,
+  allItems: OseItem[],
+  qty: number,
+): SendPlan {
+  const isContainer = root.type === "container";
+
+  if (isContainer) {
+    const kids = descendantsOf(root._id as string, allItems);
+    const create: SendNode[] = [
+      toSendNode(root, null, { containerIdOverride: "" }),
+      ...kids.map((k) =>
+        toSendNode(k, (k.system as { containerId?: string }).containerId ?? null),
+      ),
+    ];
+    return {
+      create,
+      deleteIds: [root._id as string, ...kids.map((k) => k._id as string)],
+      decrement: null,
+    };
+  }
+
+  const current = (root.system as { quantity?: { value?: number } }).quantity?.value ?? 1;
+  const sending = Math.min(qty, current);
+  const partial = sending < current;
+  const node = toSendNode(root, null, { qty: sending, containerIdOverride: "" });
+  return {
+    create: [node],
+    deleteIds: partial ? [] : [root._id as string],
+    decrement: partial ? { id: root._id as string, value: current - sending } : null,
+  };
+}
+
+/** After the target creates the copies, remap each child's containerId from its
+ *  original parent key to the parent's freshly-assigned id. Root nodes (already
+ *  containerId "") are skipped. `idMap` maps original `_key` → new doc id. */
+export function rebuildNesting(
+  nodes: SendNode[],
+  idMap: Map<string, string>,
+): { _id: string; "system.containerId": string }[] {
+  const out: { _id: string; "system.containerId": string }[] = [];
+  for (const n of nodes) {
+    if (n._parentKey == null) continue;
+    const newId = idMap.get(n._key);
+    const newParent = idMap.get(n._parentKey);
+    if (newId && newParent)
+      out.push({ _id: newId, "system.containerId": newParent });
+  }
+  return out;
+}
+
+/** Local apply when I own both actors; otherwise the op is relayed through a GM. */
+export function classifyRoute(
+  source: { isOwner: boolean },
+  target: { isOwner: boolean },
+): "local" | "gm-relay" {
+  return source.isOwner && target.isOwner ? "local" : "gm-relay";
+}

--- a/src/OscSheet/features/inventory/sendItemSocket.test.ts
+++ b/src/OscSheet/features/inventory/sendItemSocket.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { applySend } from "./sendItemSocket";
+import type { SendNode } from "./sendItem";
+
+// A mock actor whose createEmbeddedDocuments assigns fresh ids AND — like real
+// Foundry — does NOT guarantee the returned docs match input order (it reverses
+// any multi-doc batch). This is exactly the condition that broke container
+// transfers: an index-based old→new id map scrambles the nesting.
+function mockActor() {
+  let n = 0;
+  const created: Record<string, unknown>[] = [];
+  const updates: Record<string, unknown>[] = [];
+  const deleted: string[] = [];
+  return {
+    created,
+    updates,
+    deleted,
+    async createEmbeddedDocuments(_t: "Item", data: Record<string, unknown>[]) {
+      const docs = data.map((d) => {
+        const doc = { ...d, _id: `new-${n++}` };
+        created.push(doc);
+        return { id: doc._id as string };
+      });
+      return data.length > 1 ? docs.reverse() : docs;
+    },
+    async updateEmbeddedDocuments(_t: "Item", u: Record<string, unknown>[]) {
+      updates.push(...u);
+    },
+    async deleteEmbeddedDocuments(_t: "Item", ids: string[]) {
+      deleted.push(...ids);
+    },
+  };
+}
+
+const node = (
+  key: string,
+  parentKey: string | null,
+  containerId: string,
+  type = "item",
+): SendNode => ({
+  _key: key,
+  _parentKey: parentKey,
+  type,
+  system: { containerId },
+});
+
+describe("applySend — container nesting", () => {
+  it("re-nests children under the container's new id regardless of create order", async () => {
+    const to = mockActor();
+    const from = mockActor();
+    // A container (root, containerId "") holding one child (containerId → root key).
+    const create = [
+      node("R", null, "", "container"),
+      node("C", "R", "R"),
+    ];
+    await applySend({
+      fromActor: from,
+      toActor: to,
+      create,
+      deleteIds: ["R", "C"],
+      decrement: null,
+    });
+
+    // Identify the freshly-created docs by their (old) containerId value.
+    const rootNewId = to.created.find(
+      (d) => (d.system as { containerId: string }).containerId === "",
+    )!._id;
+    const childNewId = to.created.find(
+      (d) => (d.system as { containerId: string }).containerId === "R",
+    )!._id;
+
+    // The child's nesting update must point at the ROOT's new id, not a scrambled one.
+    expect(to.updates).toEqual([
+      { _id: childNewId, "system.containerId": rootNewId },
+    ]);
+    // Source items removed after the copies exist.
+    expect(from.deleted).toEqual(["R", "C"]);
+  });
+});

--- a/src/OscSheet/features/inventory/sendItemSocket.test.ts
+++ b/src/OscSheet/features/inventory/sendItemSocket.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { applySend } from "./sendItemSocket";
+import { describe, it, expect, afterEach } from "vitest";
+import { applySend, onRequest, type SendItemRequest } from "./sendItemSocket";
 import type { SendNode } from "./sendItem";
 
 // A mock actor whose createEmbeddedDocuments assigns fresh ids AND — like real
@@ -75,5 +75,84 @@ describe("applySend — container nesting", () => {
     ]);
     // Source items removed after the copies exist.
     expect(from.deleted).toEqual(["R", "C"]);
+  });
+});
+
+// A user the source actor may or may not own.
+const user = (id: string) => ({ id });
+
+/** Source actor that grants OWNER only to `owner`. */
+function relaySource(owner: unknown) {
+  const a = mockActor();
+  return {
+    ...a,
+    testUserPermission: (u: unknown, p: string) => p === "OWNER" && u === owner,
+  };
+}
+
+function setGame(
+  gm: unknown,
+  requester: { id: string },
+  src: unknown,
+  tgt: unknown,
+) {
+  (globalThis as unknown as { game: unknown }).game = {
+    user: gm,
+    users: {
+      activeGM: gm, // this client is the acting GM
+      get: (id: string) => (id === requester.id ? requester : undefined),
+    },
+  };
+  (globalThis as unknown as { foundry: unknown }).foundry = {
+    utils: {
+      fromUuid: async (u: string) =>
+        u === "Actor.src" ? src : u === "Actor.tgt" ? tgt : null,
+    },
+  };
+}
+
+afterEach(() => {
+  delete (globalThis as unknown as { game?: unknown }).game;
+  delete (globalThis as unknown as { foundry?: unknown }).foundry;
+});
+
+const request = (requesterId: string): SendItemRequest => ({
+  type: "sendItem",
+  requestId: "req-1",
+  sourceUuid: "Actor.src",
+  targetUuid: "Actor.tgt",
+  create: [node("I", null, "")],
+  deleteIds: ["I"],
+  decrement: null,
+  requesterUserId: requesterId,
+});
+
+describe("onRequest — relay authorization", () => {
+  it("rejects a relay whose requester does not own the source actor", async () => {
+    const gm = user("gm");
+    const owner = user("owner"); // owns the source
+    const attacker = user("attacker"); // does NOT own it
+    const src = relaySource(owner);
+    const tgt = mockActor();
+    setGame(gm, attacker, src, tgt);
+
+    await onRequest(request(attacker.id));
+
+    // No copy created, no source item deleted — the relay was refused.
+    expect(tgt.created).toEqual([]);
+    expect(src.deleted).toEqual([]);
+  });
+
+  it("applies a relay whose requester owns the source actor", async () => {
+    const gm = user("gm");
+    const owner = user("owner");
+    const src = relaySource(owner);
+    const tgt = mockActor();
+    setGame(gm, owner, src, tgt);
+
+    await onRequest(request(owner.id));
+
+    expect(tgt.created).toHaveLength(1);
+    expect(src.deleted).toEqual(["I"]);
   });
 });

--- a/src/OscSheet/features/inventory/sendItemSocket.ts
+++ b/src/OscSheet/features/inventory/sendItemSocket.ts
@@ -1,0 +1,132 @@
+// Cross-client relay for "Send Item". When the sender doesn't own the target
+// actor, the whole transfer (create-on-target + delete/decrement-on-source) is
+// emitted over the module socket and applied by the single active GM — mirroring
+// the GM-election precedent in migrations.ts and the GM-gated write in applyDamage.
+//
+// `applySend` is the shared apply routine used both locally (sender owns both
+// actors) and by the GM handler. It always creates on the target FIRST so a
+// failure can never destroy the source before its copy exists.
+
+import { rebuildNesting, type SendNode } from "./sendItem";
+import logger from "@src/util/logger";
+
+/** Module socket channel (Foundry requires the `module.<id>` prefix). */
+export const SOCKET = "module.osc-character-sheet";
+
+export interface SendItemRequest {
+  type: "sendItem";
+  requestId: string;
+  fromActorId: string;
+  toActorId: string;
+  create: SendNode[];
+  deleteIds: string[];
+  decrement: { id: string; value: number } | null;
+  requesterUserId: string;
+}
+
+/** The embedded-document surface `applySend` drives — actors expose these. */
+export interface EmbeddedDocActor {
+  createEmbeddedDocuments(
+    type: "Item",
+    data: Record<string, unknown>[],
+  ): Promise<Array<{ id?: string; _id?: string }>>;
+  updateEmbeddedDocuments(
+    type: "Item",
+    updates: Record<string, unknown>[],
+  ): Promise<unknown>;
+  deleteEmbeddedDocuments(type: "Item", ids: string[]): Promise<unknown>;
+}
+
+/** Drop the transient nesting keys before the data hits Foundry's create. */
+function stripKeys(node: SendNode): Record<string, unknown> {
+  const { _key, _parentKey, ...data } = node;
+  void _key;
+  void _parentKey;
+  return data;
+}
+
+/** Execute a transfer: create the copies on the target (remapping nesting), then
+ *  delete/decrement the source. Target-first so source is never lost on failure. */
+export async function applySend(args: {
+  fromActor: EmbeddedDocActor;
+  toActor: EmbeddedDocActor;
+  create: SendNode[];
+  deleteIds: string[];
+  decrement: { id: string; value: number } | null;
+}): Promise<void> {
+  const { fromActor, toActor, create, deleteIds, decrement } = args;
+
+  // 1. Create on the target. Creation preserves order → align new ids to _keys.
+  const created = await toActor.createEmbeddedDocuments(
+    "Item",
+    create.map(stripKeys),
+  );
+  const idMap = new Map<string, string>();
+  create.forEach((node, i) => {
+    const newId = created[i]?.id ?? created[i]?._id;
+    if (newId) idMap.set(node._key, newId);
+  });
+  const nesting = rebuildNesting(create, idMap);
+  if (nesting.length) await toActor.updateEmbeddedDocuments("Item", nesting);
+
+  // 2. Mutate the source only after the target copy exists.
+  if (deleteIds.length) {
+    await fromActor.deleteEmbeddedDocuments("Item", deleteIds);
+  } else if (decrement) {
+    await fromActor.updateEmbeddedDocuments("Item", [
+      { _id: decrement.id, "system.quantity.value": decrement.value },
+    ]);
+  }
+}
+
+// --- socket wiring -----------------------------------------------------------
+
+interface LooseSocket {
+  on(event: string, cb: (data: unknown) => void): void;
+  emit(event: string, data: unknown): void;
+}
+interface GameLike {
+  socket?: LooseSocket;
+  user: unknown;
+  users?: { activeGM: unknown };
+  actors?: { get(id: string): EmbeddedDocActor | undefined };
+}
+// fvtt-types narrows `game.socket` to a socket.io shape; read the members we use
+// through a loose surface (mirrors applyDamage.ts / flags.ts).
+const getGame = (): GameLike =>
+  (globalThis as unknown as { game: GameLike }).game;
+
+/** GM-side: apply an incoming relay request. No-ops on every client but the
+ *  single active GM (mirrors migrations.ts / applyDamage.ts). */
+async function onRequest(data: SendItemRequest): Promise<void> {
+  if (data?.type !== "sendItem") return;
+  const game = getGame();
+  if (!game.users?.activeGM || game.users.activeGM !== game.user) return;
+  const from = game.actors?.get(data.fromActorId);
+  const to = game.actors?.get(data.toActorId);
+  if (!from || !to) {
+    logger(`sendItem relay: could not resolve actors ${data.fromActorId}→${data.toActorId}`);
+    return;
+  }
+  try {
+    await applySend({
+      fromActor: from,
+      toActor: to,
+      create: data.create,
+      deleteIds: data.deleteIds,
+      decrement: data.decrement,
+    });
+  } catch (err) {
+    logger(`sendItem relay failed: ${String(err)}`);
+  }
+}
+
+/** Bind the relay handler. Call once from the `ready` hook. */
+export function registerSendItemSocket(): void {
+  getGame().socket?.on(SOCKET, (data) => void onRequest(data as SendItemRequest));
+}
+
+/** Sender-side: emit a transfer request for the active GM to apply. */
+export function emitSendItem(req: SendItemRequest): void {
+  getGame().socket?.emit(SOCKET, req);
+}

--- a/src/OscSheet/features/inventory/sendItemSocket.ts
+++ b/src/OscSheet/features/inventory/sendItemSocket.ts
@@ -16,8 +16,10 @@ export const SOCKET = "module.osc-character-sheet";
 export interface SendItemRequest {
   type: "sendItem";
   requestId: string;
-  fromActorId: string;
-  toActorId: string;
+  /** Actor UUID of the source (sender's sheet actor). */
+  sourceUuid: string;
+  /** Actor UUID of the target (the picked token's actor; may be unlinked). */
+  targetUuid: string;
   create: SendNode[];
   deleteIds: string[];
   decrement: { id: string; value: number } | null;
@@ -89,12 +91,24 @@ interface GameLike {
   socket?: LooseSocket;
   user: unknown;
   users?: { activeGM: unknown };
-  actors?: { get(id: string): EmbeddedDocActor | undefined };
 }
 // fvtt-types narrows `game.socket` to a socket.io shape; read the members we use
 // through a loose surface (mirrors applyDamage.ts / flags.ts).
 const getGame = (): GameLike =>
   (globalThis as unknown as { game: GameLike }).game;
+
+// Resolve an actor UUID to its live document. `foundry.utils.fromUuid` loads the
+// parent scene if needed, so it resolves unlinked token actors even when the GM
+// is viewing a different scene than the sender.
+async function resolveActor(uuid: string): Promise<EmbeddedDocActor | null> {
+  const fromUuid = (
+    globalThis as unknown as {
+      foundry?: { utils?: { fromUuid?: (u: string) => Promise<unknown> } };
+    }
+  ).foundry?.utils?.fromUuid;
+  if (!fromUuid) return null;
+  return (await fromUuid(uuid)) as EmbeddedDocActor | null;
+}
 
 /** GM-side: apply an incoming relay request. No-ops on every client but the
  *  single active GM (mirrors migrations.ts / applyDamage.ts). */
@@ -102,10 +116,12 @@ async function onRequest(data: SendItemRequest): Promise<void> {
   if (data?.type !== "sendItem") return;
   const game = getGame();
   if (!game.users?.activeGM || game.users.activeGM !== game.user) return;
-  const from = game.actors?.get(data.fromActorId);
-  const to = game.actors?.get(data.toActorId);
+  const [from, to] = await Promise.all([
+    resolveActor(data.sourceUuid),
+    resolveActor(data.targetUuid),
+  ]);
   if (!from || !to) {
-    logger(`sendItem relay: could not resolve actors ${data.fromActorId}→${data.toActorId}`);
+    logger(`sendItem relay: could not resolve actors ${data.sourceUuid}→${data.targetUuid}`);
     return;
   }
   try {

--- a/src/OscSheet/features/inventory/sendItemSocket.ts
+++ b/src/OscSheet/features/inventory/sendItemSocket.ts
@@ -37,6 +37,8 @@ export interface EmbeddedDocActor {
     updates: Record<string, unknown>[],
   ): Promise<unknown>;
   deleteEmbeddedDocuments(type: "Item", ids: string[]): Promise<unknown>;
+  /** Foundry Document permission check — used GM-side to authorize a relay. */
+  testUserPermission?(user: unknown, permission: string): boolean;
 }
 
 /** Drop the transient nesting keys before the data hits Foundry's create. */
@@ -91,7 +93,7 @@ interface LooseSocket {
 interface GameLike {
   socket?: LooseSocket;
   user: unknown;
-  users?: { activeGM: unknown };
+  users?: { activeGM: unknown; get?(id: string): unknown };
 }
 // fvtt-types narrows `game.socket` to a socket.io shape; read the members we use
 // through a loose surface (mirrors applyDamage.ts / flags.ts).
@@ -112,8 +114,8 @@ async function resolveActor(uuid: string): Promise<EmbeddedDocActor | null> {
 }
 
 /** GM-side: apply an incoming relay request. No-ops on every client but the
- *  single active GM (mirrors migrations.ts / applyDamage.ts). */
-async function onRequest(data: SendItemRequest): Promise<void> {
+ *  single active GM (mirrors migrations.ts / applyDamage.ts). Exported for tests. */
+export async function onRequest(data: SendItemRequest): Promise<void> {
   if (data?.type !== "sendItem") return;
   const game = getGame();
   if (!game.users?.activeGM || game.users.activeGM !== game.user) return;
@@ -123,6 +125,16 @@ async function onRequest(data: SendItemRequest): Promise<void> {
   ]);
   if (!from || !to) {
     logger(`sendItem relay: could not resolve actors ${data.sourceUuid}→${data.targetUuid}`);
+    return;
+  }
+  // Authorize: never move items on the GM's authority unless the requesting user
+  // actually owns the SOURCE actor. Otherwise anyone who can open another
+  // character's sheet could relay its items away.
+  const requester = game.users?.get?.(data.requesterUserId);
+  if (!requester || !from.testUserPermission?.(requester, "OWNER")) {
+    logger(
+      `sendItem relay: user ${data.requesterUserId} does not own source ${data.sourceUuid} — rejected`,
+    );
     return;
   }
   try {

--- a/src/OscSheet/features/inventory/sendItemSocket.ts
+++ b/src/OscSheet/features/inventory/sendItemSocket.ts
@@ -58,16 +58,17 @@ export async function applySend(args: {
 }): Promise<void> {
   const { fromActor, toActor, create, deleteIds, decrement } = args;
 
-  // 1. Create on the target. Creation preserves order → align new ids to _keys.
-  const created = await toActor.createEmbeddedDocuments(
-    "Item",
-    create.map(stripKeys),
-  );
+  // 1. Create on the target one node at a time so each returned id maps
+  //    unambiguously to its source `_key`. A batch create does NOT guarantee the
+  //    returned docs match input order, which would scramble the nesting remap.
   const idMap = new Map<string, string>();
-  create.forEach((node, i) => {
-    const newId = created[i]?.id ?? created[i]?._id;
+  for (const node of create) {
+    const [doc] = await toActor.createEmbeddedDocuments("Item", [
+      stripKeys(node),
+    ]);
+    const newId = doc?.id ?? doc?._id;
     if (newId) idMap.set(node._key, newId);
-  });
+  }
   const nesting = rebuildNesting(create, idMap);
   if (nesting.length) await toActor.updateEmbeddedDocuments("Item", nesting);
 

--- a/src/OscSheet/features/inventory/sendTargets.test.ts
+++ b/src/OscSheet/features/inventory/sendTargets.test.ts
@@ -6,67 +6,110 @@ interface MockActor {
   uuid: string;
   name: string;
   img: string;
-  type: string;
   isOwner: boolean;
-  hasPlayerOwner: boolean;
+}
+interface MockToken {
+  visible: boolean;
+  actor: MockActor | null;
+  document: { disposition: number };
 }
 
-const actor = (id: string, over: Partial<MockActor> = {}): MockActor => ({
-  id,
-  uuid: `Actor.${id}`,
-  name: id,
-  img: "",
-  type: "character",
-  isOwner: false,
-  hasPlayerOwner: true,
-  ...over,
-});
+// Dispositions: SECRET -2, HOSTILE -1, NEUTRAL 0, FRIENDLY 1.
+const token = (
+  id: string,
+  over: Partial<MockActor> & { visible?: boolean; disposition?: number } = {},
+): MockToken => {
+  const { visible = true, disposition = 1, ...actorOver } = over;
+  return {
+    visible,
+    document: { disposition },
+    actor: { id, uuid: `Actor.${id}`, name: id, img: "", isOwner: false, ...actorOver },
+  };
+};
 
-function setGame(actors: MockActor[], activeGM: unknown) {
+function setScene(tokens: MockToken[], activeGM: unknown) {
+  (globalThis as unknown as { canvas: unknown }).canvas = {
+    tokens: { placeables: tokens },
+  };
   (globalThis as unknown as { game: unknown }).game = {
-    actors,
     users: { activeGM },
   };
 }
 
 afterEach(() => {
+  delete (globalThis as unknown as { canvas?: unknown }).canvas;
   delete (globalThis as unknown as { game?: unknown }).game;
 });
 
-const me = actor("me", { isOwner: true });
+const me = { id: "me", uuid: "Actor.me" };
 
 describe("selectSendTargets", () => {
-  it("excludes self and unowned actors, keeps the rest", () => {
-    const owned = actor("ally", { isOwner: true });
-    const cross = actor("bob", { isOwner: false });
-    const unowned = actor("monster", { type: "npc", hasPlayerOwner: false });
-    setGame([me, owned, cross, unowned], {});
+  it("keeps visible non-hostile tokens, excludes self", () => {
+    const mine = token("me", { isOwner: true }); // self
+    const owned = token("ally", { isOwner: true });
+    const cross = token("bob", { isOwner: false });
+    setScene([mine, owned, cross], {});
     const { targets } = selectSendTargets(me);
     expect(targets.map((t) => t.id)).toEqual(["ally", "bob"]);
   });
 
-  it("excludes non-character/npc types", () => {
-    const vehicle = actor("cart", { type: "vehicle", isOwner: true });
-    const npc = actor("hench", { type: "npc", isOwner: true });
-    setGame([me, vehicle, npc], {});
-    expect(selectSendTargets(me).targets.map((t) => t.id)).toEqual(["hench"]);
+  it("excludes hostile and secret tokens", () => {
+    const friendly = token("ally", { isOwner: true, disposition: 1 });
+    const neutral = token("merchant", { isOwner: true, disposition: 0 });
+    const hostile = token("orc", { isOwner: true, disposition: -1 });
+    const secret = token("spy", { isOwner: true, disposition: -2 });
+    setScene([friendly, neutral, hostile, secret], {});
+    expect(selectSendTargets(me).targets.map((t) => t.id)).toEqual([
+      "ally",
+      "merchant",
+    ]);
+  });
+
+  it("excludes tokens hidden from this user and tokens without an actor", () => {
+    const hidden = token("ghost", { isOwner: true, visible: false });
+    const empty: MockToken = {
+      visible: true,
+      actor: null,
+      document: { disposition: 1 },
+    };
+    const shown = token("ally", { isOwner: true });
+    setScene([hidden, empty, shown], {});
+    expect(selectSendTargets(me).targets.map((t) => t.id)).toEqual(["ally"]);
+  });
+
+  it("dedupes multiple tokens sharing one actor", () => {
+    const a = token("ally", { isOwner: true });
+    const b = token("ally", { isOwner: true }); // second token, same actor uuid
+    setScene([a, b], {});
+    expect(selectSendTargets(me).targets.map((t) => t.id)).toEqual(["ally"]);
   });
 
   it("classifies owned-by-me vs cross-owner and carries display fields", () => {
-    const owned = actor("ally", { isOwner: true, name: "Ally", img: "a.png" });
-    const cross = actor("bob", { isOwner: false, name: "Bob" });
-    setGame([me, owned, cross], {});
+    const owned = token("ally", { isOwner: true, name: "Ally", img: "a.png" });
+    const cross = token("bob", { isOwner: false, name: "Bob" });
+    setScene([owned, cross], {});
     const { targets } = selectSendTargets(me);
     const a = targets.find((t) => t.id === "ally")!;
     const b = targets.find((t) => t.id === "bob")!;
-    expect(a).toMatchObject({ ownedByMe: true, crossOwner: false, name: "Ally", img: "a.png", uuid: "Actor.ally" });
+    expect(a).toMatchObject({
+      ownedByMe: true,
+      crossOwner: false,
+      name: "Ally",
+      img: "a.png",
+      uuid: "Actor.ally",
+    });
     expect(b).toMatchObject({ ownedByMe: false, crossOwner: true, name: "Bob" });
   });
 
   it("reports gmOnline from game.users.activeGM", () => {
-    setGame([me, actor("ally", { isOwner: true })], {});
+    setScene([token("ally", { isOwner: true })], {});
     expect(selectSendTargets(me).gmOnline).toBe(true);
-    setGame([me, actor("ally", { isOwner: true })], null);
+    setScene([token("ally", { isOwner: true })], null);
     expect(selectSendTargets(me).gmOnline).toBe(false);
+  });
+
+  it("returns empty when there is no active scene", () => {
+    (globalThis as unknown as { game: unknown }).game = { users: { activeGM: {} } };
+    expect(selectSendTargets(me).targets).toEqual([]);
   });
 });

--- a/src/OscSheet/features/inventory/sendTargets.test.ts
+++ b/src/OscSheet/features/inventory/sendTargets.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { selectSendTargets } from "./sendTargets";
+
+interface MockActor {
+  id: string;
+  uuid: string;
+  name: string;
+  img: string;
+  type: string;
+  isOwner: boolean;
+  hasPlayerOwner: boolean;
+}
+
+const actor = (id: string, over: Partial<MockActor> = {}): MockActor => ({
+  id,
+  uuid: `Actor.${id}`,
+  name: id,
+  img: "",
+  type: "character",
+  isOwner: false,
+  hasPlayerOwner: true,
+  ...over,
+});
+
+function setGame(actors: MockActor[], activeGM: unknown) {
+  (globalThis as unknown as { game: unknown }).game = {
+    actors,
+    users: { activeGM },
+  };
+}
+
+afterEach(() => {
+  delete (globalThis as unknown as { game?: unknown }).game;
+});
+
+const me = actor("me", { isOwner: true });
+
+describe("selectSendTargets", () => {
+  it("excludes self and unowned actors, keeps the rest", () => {
+    const owned = actor("ally", { isOwner: true });
+    const cross = actor("bob", { isOwner: false });
+    const unowned = actor("monster", { type: "npc", hasPlayerOwner: false });
+    setGame([me, owned, cross, unowned], {});
+    const { targets } = selectSendTargets(me);
+    expect(targets.map((t) => t.id)).toEqual(["ally", "bob"]);
+  });
+
+  it("excludes non-character/npc types", () => {
+    const vehicle = actor("cart", { type: "vehicle", isOwner: true });
+    const npc = actor("hench", { type: "npc", isOwner: true });
+    setGame([me, vehicle, npc], {});
+    expect(selectSendTargets(me).targets.map((t) => t.id)).toEqual(["hench"]);
+  });
+
+  it("classifies owned-by-me vs cross-owner and carries display fields", () => {
+    const owned = actor("ally", { isOwner: true, name: "Ally", img: "a.png" });
+    const cross = actor("bob", { isOwner: false, name: "Bob" });
+    setGame([me, owned, cross], {});
+    const { targets } = selectSendTargets(me);
+    const a = targets.find((t) => t.id === "ally")!;
+    const b = targets.find((t) => t.id === "bob")!;
+    expect(a).toMatchObject({ ownedByMe: true, crossOwner: false, name: "Ally", img: "a.png", uuid: "Actor.ally" });
+    expect(b).toMatchObject({ ownedByMe: false, crossOwner: true, name: "Bob" });
+  });
+
+  it("reports gmOnline from game.users.activeGM", () => {
+    setGame([me, actor("ally", { isOwner: true })], {});
+    expect(selectSendTargets(me).gmOnline).toBe(true);
+    setGame([me, actor("ally", { isOwner: true })], null);
+    expect(selectSendTargets(me).gmOnline).toBe(false);
+  });
+});

--- a/src/OscSheet/features/inventory/sendTargets.ts
+++ b/src/OscSheet/features/inventory/sendTargets.ts
@@ -1,16 +1,25 @@
-// Enumerate valid "Send Item" targets: party/owned character & npc actors, minus
-// self and GM-only (unowned) actors. Each target is classified `ownedByMe` (direct
-// move) vs `crossOwner` (needs a GM socket relay). `gmOnline` gates the relay path.
+// Enumerate valid "Send Item" targets: the actors behind every visible, non-hostile
+// token in the current scene, minus the sender. Each is classified `ownedByMe`
+// (direct move) vs `crossOwner` (needs a GM socket relay). `gmOnline` gates the relay.
+//
+// Token-based (not game.actors) so the list matches what the player can actually see
+// on the map, and so it works without any formal "party" concept. Targets are keyed
+// by actor UUID — this resolves both linked and unlinked (synthetic) token actors.
 
-/** A live actor as far as target selection cares. */
+/** The actor behind a token, as far as target selection cares. */
 interface TargetActorLike {
   id: string;
   uuid: string;
   name: string;
   img: string;
-  type: string;
   isOwner: boolean;
-  hasPlayerOwner: boolean;
+}
+
+/** A placeable token on the active scene. */
+interface TokenLike {
+  visible: boolean;
+  actor: TargetActorLike | null;
+  document: { disposition: number };
 }
 
 export interface SendTargetVM {
@@ -20,7 +29,7 @@ export interface SendTargetVM {
   img: string;
   /** I own this actor → transfer applies directly on my client. */
   ownedByMe: boolean;
-  /** Owned by another player → transfer must be relayed through a GM. */
+  /** I don't own this actor → transfer must be relayed through a GM. */
   crossOwner: boolean;
 }
 
@@ -30,25 +39,40 @@ export interface SendTargetsResult {
   gmOnline: boolean;
 }
 
+interface CanvasView {
+  tokens?: { placeables: Iterable<TokenLike> } | null;
+}
 interface GameView {
-  actors: Iterable<TargetActorLike>;
   users: { activeGM: unknown };
 }
 const getGame = (): GameView =>
   (globalThis as unknown as { game: GameView }).game;
+const getCanvas = (): CanvasView =>
+  (globalThis as unknown as { canvas?: CanvasView }).canvas ?? {};
 
-const SENDABLE_TYPES = new Set(["character", "npc"]);
+// Non-hostile = NEUTRAL(0) or FRIENDLY(1); excludes HOSTILE(-1) and SECRET(-2).
+// (CONST.TOKEN_DISPOSITIONS — hardcoded to avoid a global dependency in tests.)
+const MIN_DISPOSITION = 0;
 
-/** Targets a player may send items to from `current`'s sheet, plus GM availability. */
+/** Targets a player may send items to from `current`'s sheet, plus GM availability.
+ *  = the actor behind every visible, non-hostile scene token except the sender. */
 export function selectSendTargets(current: {
   id: string | null;
+  uuid?: string | null;
 }): SendTargetsResult {
-  const game = getGame();
+  const canvas = getCanvas();
   const targets: SendTargetVM[] = [];
-  for (const a of game.actors) {
-    if (a.id === current.id) continue; // never send to self
-    if (!SENDABLE_TYPES.has(a.type)) continue;
-    if (!a.hasPlayerOwner) continue; // GM-only actors aren't party members
+  const seen = new Set<string>(); // dedupe multiple tokens sharing one actor
+  for (const t of canvas.tokens?.placeables ?? []) {
+    const a = t.actor;
+    if (!a) continue;
+    if (!t.visible) continue; // hidden or out of this user's sight
+    if (t.document.disposition < MIN_DISPOSITION) continue; // hostile / secret
+    if (a.id === current.id || (!!current.uuid && a.uuid === current.uuid)) {
+      continue; // never send to self
+    }
+    if (seen.has(a.uuid)) continue;
+    seen.add(a.uuid);
     targets.push({
       id: a.id,
       uuid: a.uuid,
@@ -58,5 +82,5 @@ export function selectSendTargets(current: {
       crossOwner: !a.isOwner,
     });
   }
-  return { targets, gmOnline: !!game.users.activeGM };
+  return { targets, gmOnline: !!getGame().users.activeGM };
 }

--- a/src/OscSheet/features/inventory/sendTargets.ts
+++ b/src/OscSheet/features/inventory/sendTargets.ts
@@ -1,0 +1,62 @@
+// Enumerate valid "Send Item" targets: party/owned character & npc actors, minus
+// self and GM-only (unowned) actors. Each target is classified `ownedByMe` (direct
+// move) vs `crossOwner` (needs a GM socket relay). `gmOnline` gates the relay path.
+
+/** A live actor as far as target selection cares. */
+interface TargetActorLike {
+  id: string;
+  uuid: string;
+  name: string;
+  img: string;
+  type: string;
+  isOwner: boolean;
+  hasPlayerOwner: boolean;
+}
+
+export interface SendTargetVM {
+  id: string;
+  uuid: string;
+  name: string;
+  img: string;
+  /** I own this actor → transfer applies directly on my client. */
+  ownedByMe: boolean;
+  /** Owned by another player → transfer must be relayed through a GM. */
+  crossOwner: boolean;
+}
+
+export interface SendTargetsResult {
+  targets: SendTargetVM[];
+  /** A GM is connected → cross-owner relays can be delivered. */
+  gmOnline: boolean;
+}
+
+interface GameView {
+  actors: Iterable<TargetActorLike>;
+  users: { activeGM: unknown };
+}
+const getGame = (): GameView =>
+  (globalThis as unknown as { game: GameView }).game;
+
+const SENDABLE_TYPES = new Set(["character", "npc"]);
+
+/** Targets a player may send items to from `current`'s sheet, plus GM availability. */
+export function selectSendTargets(current: {
+  id: string | null;
+}): SendTargetsResult {
+  const game = getGame();
+  const targets: SendTargetVM[] = [];
+  for (const a of game.actors) {
+    if (a.id === current.id) continue; // never send to self
+    if (!SENDABLE_TYPES.has(a.type)) continue;
+    if (!a.hasPlayerOwner) continue; // GM-only actors aren't party members
+    targets.push({
+      id: a.id,
+      uuid: a.uuid,
+      name: a.name,
+      img: a.img,
+      ownedByMe: a.isOwner,
+      crossOwner: !a.isOwner,
+    });
+  }
+  return { targets, gmOnline: !!game.users.activeGM };
+}

--- a/src/OscSheet/features/inventory/sendTargets.ts
+++ b/src/OscSheet/features/inventory/sendTargets.ts
@@ -50,6 +50,12 @@ const getGame = (): GameView =>
 const getCanvas = (): CanvasView =>
   (globalThis as unknown as { canvas?: CanvasView }).canvas ?? {};
 
+/** True when a GM is connected. Cross-owner transfers can't be delivered without
+ *  one, so Send is hidden entirely when no GM is online. */
+export function isGmConnected(): boolean {
+  return !!getGame().users.activeGM;
+}
+
 // Non-hostile = NEUTRAL(0) or FRIENDLY(1); excludes HOSTILE(-1) and SECRET(-2).
 // (CONST.TOKEN_DISPOSITIONS — hardcoded to avoid a global dependency in tests.)
 const MIN_DISPOSITION = 0;

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -566,3 +566,52 @@
   &.is-danger:hover { background: color-mix(in srgb, var(--crimson, #c75044) 18%, transparent); }
   &.is-danger i { color: var(--crimson, #c75044); }
 }
+
+// ---------------------------------------------------------------------------
+// Send Item dialog (target picker + stack split)
+// ---------------------------------------------------------------------------
+
+.osc-send-targets {
+  list-style: none; margin: 0; padding: 0;
+  display: flex; flex-direction: column; gap: var(--spacer-1);
+}
+// Button selectors qualified with .osc-inv (the dialog is a DOM descendant) so
+// they beat the `.osc-sheet-app button { all: unset }` reset.
+.osc-inv .osc-send-target {
+  display: flex; align-items: center; gap: var(--spacer-3); width: 100%;
+  padding: var(--spacer-2) var(--spacer-3);
+  background: transparent; cursor: pointer; text-align: left;
+  border: 1px solid var(--border-soft, #2c2823); border-radius: var(--r-md, 6px);
+  font-family: var(--sans); font-size: var(--fs-md, 14px);
+  color: var(--text, #e5dec8);
+  &:hover { background: var(--bg-2, #1f1c17); }
+  &.is-selected {
+    border-color: var(--accent-alt, #c89e54);
+    background: color-mix(in srgb, var(--accent-alt, #c89e54) 12%, transparent);
+  }
+  &:disabled { opacity: 0.4; cursor: not-allowed; }
+}
+.osc-send-target-ic {
+  width: var(--spacer-8); height: var(--spacer-8); flex: 0 0 auto;
+  display: grid; place-items: center; overflow: hidden;
+  border-radius: var(--r-sm, 4px);
+  background: var(--bg-2, #1f1c17);
+  font-family: var(--display); color: var(--text-dim, #b5ad97);
+  object-fit: cover;
+}
+.osc-send-target-nm { flex: 1; }
+
+.osc-send-empty,
+.osc-send-note {
+  margin: var(--spacer-3) 0 0; color: var(--text-mute, #8a8270);
+  font-family: var(--sans); font-size: var(--fs-sm, 13px);
+}
+.osc-send-qty {
+  display: flex; align-items: center; gap: var(--spacer-3);
+  margin-top: var(--spacer-4);
+}
+.osc-send-qty-label {
+  font-family: var(--display); font-size: var(--fs-sm, 13px);
+  color: var(--text-dim, #b5ad97);
+}
+.osc-send-qty-of { color: var(--text-mute, #8a8270); font-size: var(--fs-sm, 13px); }

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -571,10 +571,9 @@
 // Send Item dialog (target picker + stack split)
 // ---------------------------------------------------------------------------
 
-.osc-send-targets {
-  list-style: none; margin: 0; padding: 0;
-  display: flex; flex-direction: column; gap: var(--spacer-1);
-}
+// Layout/size/color come from u-* utilities in the JSX; only the bespoke target
+// button (hover / selected color-mix / disabled) and its icon tile live here.
+.osc-send-targets { list-style: none; margin: 0; padding: 0; }
 // Button selectors qualified with .osc-inv (the dialog is a DOM descendant) so
 // they beat the `.osc-sheet-app button { all: unset }` reset.
 .osc-inv .osc-send-target {
@@ -599,19 +598,3 @@
   font-family: var(--display); color: var(--text-dim, #b5ad97);
   object-fit: cover;
 }
-.osc-send-target-nm { flex: 1; }
-
-.osc-send-empty,
-.osc-send-note {
-  margin: var(--spacer-3) 0 0; color: var(--text-mute, #8a8270);
-  font-family: var(--sans); font-size: var(--fs-sm, 13px);
-}
-.osc-send-qty {
-  display: flex; align-items: center; gap: var(--spacer-3);
-  margin-top: var(--spacer-4);
-}
-.osc-send-qty-label {
-  font-family: var(--display); font-size: var(--fs-sm, 13px);
-  color: var(--text-dim, #b5ad97);
-}
-.osc-send-qty-of { color: var(--text-mute, #8a8270); font-size: var(--fs-sm, 13px); }

--- a/src/OscSheet/styles/vellum/components.css
+++ b/src/OscSheet/styles/vellum/components.css
@@ -104,11 +104,15 @@
   background: var(--bg-2);
 }
 .stepper button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background: transparent;
   border: none;
   color: var(--text-dim);
   font-family: var(--mono);
   font-size: var(--fs-md);
+  line-height: 1;
   width: 28px;
   cursor: pointer;
   padding: 0;

--- a/src/OscSheet/styles/vellum/tokens.scss
+++ b/src/OscSheet/styles/vellum/tokens.scss
@@ -940,14 +940,15 @@ body {
   transition: all 0.12s;
   white-space: nowrap;
 }
-.btn:hover { border-color: var(--brass); }
+.btn:hover:not(:disabled) { border-color: var(--brass); }
+.btn:disabled { opacity: 0.4; cursor: not-allowed; }
 .btn.primary { background: var(--brass); color: var(--on-accent); border-color: var(--brass); }
-.btn.primary:hover { background: var(--brass-dim); }
+.btn.primary:hover:not(:disabled) { background: var(--brass-dim); }
 /* outline (primary) — the brass accent, outlined rather than filled */
 .btn.outline { background: transparent; color: var(--brass); border-color: var(--brass); }
-.btn.outline:hover { background: color-mix(in srgb, var(--brass) 12%, transparent); }
+.btn.outline:hover:not(:disabled) { background: color-mix(in srgb, var(--brass) 12%, transparent); }
 .btn.danger { color: var(--oxblood-2); border-color: oklch(0.56 0.15 25 / 0.5); }
-.btn.danger:hover { background: oklch(0.56 0.15 25 / 0.15); }
+.btn.danger:hover:not(:disabled) { background: oklch(0.56 0.15 25 / 0.15); }
 .btn.ghost { background: transparent; border-color: var(--border-soft); color: var(--text-dim); }
 .btn.sm { font-size: var(--fs-3xs); padding: 5px 9px 4px; }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import OscSheet from "@src/applications/osc-sheet";
 import { installAdvancedClasses } from "@src/util/adaptAdvancedClasses";
 import { onRenderChatMessage } from "@domain/chat/applyDamage";
+import { registerSendItemSocket } from "@features/inventory/sendItemSocket";
 import {
   migrateLocalStorage,
   registerMigrationSetting,
@@ -27,6 +28,7 @@ export function initialize() {
     migrateLocalStorage(); // every user; independent of the GM world pass
     await runWorldMigration();
     installAdvancedClasses();
+    registerSendItemSocket(); // GM relay for cross-owner "Send Item" transfers
 
     // Debug API. `crashTest()` throws a deliberate error inside any open OSC
     // sheet on its next render — exercises the ErrorBoundary fallback (and the


### PR DESCRIPTION
Right-click an inventory item → **Send** to transfer it to another actor.

## Behavior
- **Targets**: party/owned character & npc actors (self and GM-only actors excluded).
- **Routing**: I own the target → direct apply; cross-owner → relayed through the single active GM via the module socket. Cross-owner targets are disabled (with tooltip) when no GM is online.
- **Stacks**: stacked items get a quantity stepper (1..qty) — partial send decrements the source, full send deletes it.
- **Containers**: sent with their entire nested subtree (recursive, incl. sub-containers); nesting is rebuilt on the target. Sent copies drop order/equippedOrder flags and equipped state.
- Coins/currency: Send hidden in v1.

## Safety
`applySend` always creates on the target **before** mutating the source, so a failure can never destroy the item before its copy exists.

## Layout
- `sendItem.ts` — pure plan logic (`collectTree` / `rebuildNesting` / `classifyRoute`), unit-tested.
- `sendTargets.ts` — target enumeration + GM-online flag, unit-tested.
- `sendItemSocket.ts` — shared `applySend` + GM-gated relay handler/emitter.
- `SendItemModal.tsx` — picker composed from DS primitives (Modal/Monogram/Tag/Stepper/Button).

## Verification
`pnpm lint && pnpm test && pnpm build` all pass (128 tests, incl. 16 new).

⚠️ **The socket / cross-client relay path needs manual two-client Foundry verification** — the pure logic and local path are tested, but the GM relay across two connected clients is not covered by unit tests.