### PR TITLE
Vellum: single-source spacer scale (OLD-39) + generate design-sync README

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -81,7 +81,26 @@ library under `src/OscSheet/components/ui/`.
 - **KvCard has its own `KvCard.stories.tsx`** (Card.tsx's 2nd export) — split out of Card.stories
   so each design card is focused. A component in `componentSrcMap` MUST have a matching story file.
 
+## README is NOT staged — regenerate by hand on any rename/count change
+
+- `generate.mjs` deliberately does **not** stage `README.md` (it has no exemplar). The
+  remote README = `conventions.md` header + a hand-written body (naming, loading, token
+  buckets, component index). On the 2026-07-07 sync this was badly stale: the module was
+  renamed `reactor-sheet` → `osc-character-sheet` (global `ReactorSheet` → `OscSheet`,
+  scope `.reactor-sheet` → `.osc-sheet`, 24 → 32 components) but the remote README still
+  said `window.ReactorSheet` — which would tell the design agent to use a global the new
+  bundle doesn't export. **Whenever the package name, global, scope, token count, or
+  component set changes, re-author `README.md` and upload it** (header = current
+  `conventions.md`, body updated to match). Consider teaching `generate.mjs` to emit the
+  README so this stops being manual.
+
 ## Re-sync risks (what can silently go stale)
+
+- **`build-css.mjs` read a renamed file (fixed 2026-07-07).** `tokens.css` became
+  `tokens.scss` (now emits `--fs-*`/`--r-*` from `_scales.scss` maps via `@each`), which
+  broke the CSS build. Fixed to compile it through dart-sass like `utilities.scss`. This is
+  exactly the "mirrors the app pipeline by hand" drift risk below — re-check after any
+  vellum style refactor (partial rename, new `@use`, sass upgrade).
 
 - **`build-css.mjs` mirrors the app pipeline by hand.** If the repo changes how Vellum CSS
   is scoped/compiled (postcss config, new style partial, sass version), this script can drift

--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -81,18 +81,17 @@ library under `src/OscSheet/components/ui/`.
 - **KvCard has its own `KvCard.stories.tsx`** (Card.tsx's 2nd export) — split out of Card.stories
   so each design card is focused. A component in `componentSrcMap` MUST have a matching story file.
 
-## README is NOT staged — regenerate by hand on any rename/count change
+## README is generated — edit the header (`conventions.md`), never README itself
 
-- `generate.mjs` deliberately does **not** stage `README.md` (it has no exemplar). The
-  remote README = `conventions.md` header + a hand-written body (naming, loading, token
-  buckets, component index). On the 2026-07-07 sync this was badly stale: the module was
-  renamed `reactor-sheet` → `osc-character-sheet` (global `ReactorSheet` → `OscSheet`,
-  scope `.reactor-sheet` → `.osc-sheet`, 24 → 32 components) but the remote README still
-  said `window.ReactorSheet` — which would tell the design agent to use a global the new
-  bundle doesn't export. **Whenever the package name, global, scope, token count, or
-  component set changes, re-author `README.md` and upload it** (header = current
-  `conventions.md`, body updated to match). Consider teaching `generate.mjs` to emit the
-  README so this stops being manual.
+- `generate.mjs` stages `README.md` = `cfg.readmeHeader` (`conventions.md`) prepended
+  verbatim + a body derived from the build (namespace, `cfg.pkg`, `SCOPE`, token-kind
+  counts, groups, `globalCssPaths`). So a rename/count change updates the README
+  automatically — the drift that bit us before is gone: on the 2026-07-07 sync the module
+  rename `reactor-sheet` → `osc-character-sheet` (global `ReactorSheet` → `OscSheet`, scope
+  `.reactor-sheet` → `.osc-sheet`, 24 → 32 components) left the remote README pointing at
+  `window.ReactorSheet`, a global the new bundle doesn't export. **`README.md` in `.stage/`
+  is overwritten every run — never hand-edit it.** To change the authored prose (wrapping,
+  styling idiom, section-header rules), edit `conventions.md`; the body is data-driven.
 
 ## Re-sync risks (what can silently go stale)
 

--- a/.design-sync/build-css.mjs
+++ b/.design-sync/build-css.mjs
@@ -25,8 +25,10 @@ async function scopeCss(css, from) {
   return res.css;
 }
 const scope = (file) => scopeCss(readFileSync(file, "utf8"), file);
-// utilities.scss is generated (token maps → @each); compile with dart-sass first,
-// then scope through the same postcss prefixer (from-path stays under vellum/).
+// tokens.scss and utilities.scss are Sass (token maps → @each emitting the
+// --fs-*/--r-*/--spacer-* custom properties and matching u-* classes); compile
+// each with dart-sass first, then scope through the same postcss prefixer
+// (from-path stays under vellum/).
 function sass(file, extraArgs = []) {
   return execFileSync(
     path.join(root, "node_modules/.bin/sass"),

--- a/.design-sync/build-css.mjs
+++ b/.design-sync/build-css.mjs
@@ -36,7 +36,10 @@ function sass(file, extraArgs = []) {
 }
 
 export async function buildParts() {
-  const tokens = await scope(path.join(vellum, "tokens.css"));
+  // tokens.scss (was tokens.css) now emits --fs-*/--r-* from _scales.scss maps
+  // via @each — compile with dart-sass first, then scope (same as utilities).
+  const tokensScss = path.join(vellum, "tokens.scss");
+  const tokens = await scopeCss(sass(tokensScss), tokensScss);
   const utilitiesScss = path.join(vellum, "utilities.scss");
   const utilities = await scopeCss(sass(utilitiesScss), utilitiesScss);
   const components = await scope(path.join(vellum, "components.css"));

--- a/.design-sync/generate.mjs
+++ b/.design-sync/generate.mjs
@@ -400,6 +400,80 @@ const manifest = {
 write("_ds_manifest.json", JSON.stringify(manifest, null, 2) + "\n");
 writes.push("_ds_manifest.json");
 
+// ── README.md (conventions header + generated body) ──
+// The body is derived from the SAME data the manifest is built from (namespace,
+// pkg version, token kinds, groups), so a rename/count change can't leave it
+// stale — the failure that the reactor-sheet→osc-character-sheet rename caused.
+// The header is authored prose (cfg.readmeHeader) prepended verbatim.
+function readmeBody() {
+  const kc = (k) => tokensDump.filter((t) => t.kind === k).length;
+  const index = ["controls", "display", "layout", "overlays", "navigation", "data"]
+    .map((g) => {
+      const items = sortedNames.filter((n) => GROUP[n] === g);
+      return items.length ? `### ${g}\n${items.map((n) => `- \`${n}\``).join("\n")}` : "";
+    })
+    .filter(Boolean)
+    .join("\n\n");
+  const themeSel = manifest.themes.map((t) => `\`${t.selector}\``).join(", ");
+  return `# ${cfg.globalName} (osc-character-sheet@${pkgVersion})
+
+This design system is the Vellum UI primitive library from \`osc-character-sheet\`, bundled
+as a single browser global. All ${names.length} components are the real library code.
+
+## Where things are
+
+- \`_ds_bundle.js\` — the whole-DS bundle at the project root; loads every component to \`window.${cfg.globalName}\`. First line is a \`/* @ds-bundle: … */\` metadata header.
+- \`styles.css\` — the single stylesheet entry: it \`@import\`s the tokens, fonts, and component styles (\`_ds_bundle.css\`). Link this one file.
+- \`components/<group>/<Name>/<Name>.prompt.md\` (example JSX + variants), \`<Name>.d.ts\` (types), \`<Name>.html\` (variant grid).
+- \`fonts/\` — \`@font-face\` files + \`fonts.css\`.
+- \`guidelines/\` — the design system's own usage guidance (see \`guidelines/index.md\`). Read these before composing larger layouts.
+
+For a specific component, \`read_file("components/<group>/<Name>/<Name>.prompt.md")\`.
+
+## Loading
+
+Add these two lines to your page once (React must be on the page first):
+
+\`\`\`html
+<link rel="stylesheet" href="styles.css">
+<script src="_ds_bundle.js"></script>
+\`\`\`
+
+Components are then available at \`window.${cfg.globalName}.*\`. Mount into a dedicated child node (e.g. \`<div id="ds-root">\`), not the host page's own React root, so the two trees don't collide:
+
+\`\`\`jsx
+const { Button } = window.${cfg.globalName};
+ReactDOM.createRoot(document.getElementById('ds-root')).render(<Button />);
+\`\`\`
+
+Wrap the tree in the provider — components read theme/tokens from the scoped root:
+
+\`\`\`jsx
+<VellumRoot>{children}</VellumRoot>
+\`\`\`
+
+## Tokens
+
+${tokensDump.length} CSS custom properties, declared inside \`_ds_bundle.css\` under \`.osc-sheet\`
+(one compiled stylesheet, not separate token files). Themes: ${themeSel}. See the
+styling-idiom section above for the families and their real names.
+
+- Color & surface: ${kc("color")}
+- Text / ink color: ${kc("font")}
+- Space, radius & type sizes: ${kc("spacing")}
+- Font families & line-heights: ${kc("other")}
+
+## Components
+
+${index}
+`;
+}
+const readmeHeader = cfg.readmeHeader
+  ? readFileSync(path.join(ROOT, cfg.readmeHeader), "utf8").trimEnd()
+  : "";
+write("README.md", (readmeHeader ? readmeHeader + "\n\n" : "") + readmeBody());
+writes.push("README.md");
+
 // ── _ds_sync.json ──
 // Reproducible fields recomputed; opaque tool-internal hashes (renderHashes,
 // sourceKeys, keyRecipe) left empty and governed by _ds_needs_recompile.
@@ -435,7 +509,7 @@ writeFileSync(
         "renderHashes/sourceKeys left {} and keyRecipe=7 carried; _ds_needs_recompile written so the tool recomputes opaque hashes (do NOT splice remote render hashes — Wave-2 CSS changes made them stale).",
         "styleSha = sha256(_ds_bundle.css + '\\n' + styles.css); bundleSha12 = sha256(_ds_bundle.js)[:12] — inferred recipes; scriptsSha/auxSha carried from remote.",
         "tokens[].kind matched to remote taxonomy (confirmed): text colors (--text*/--stamp-text*)→font; families/line-heights/--vellum-grain→other; dimensions→spacing; rest→color.",
-        "README.md exists on remote but has no exemplar — deliberately NOT generated/staged (left as-is).",
+        "README.md is now generated: cfg.readmeHeader (conventions.md) prepended verbatim + a body derived from the manifest data (namespace/version/token-kind counts/groups), so it can't go stale on a rename the way reactor-sheet→osc-character-sheet did.",
         "config.dtsPropsFor reconciled against current Props: Tag (+variant/icon/tooltip/onRemove/removeLabel), Button (+\"outline\"), Die (sides: 4|6|8|20). Other 29 verified in sync. Their d.ts + prompt.md (and sourceHashes) change accordingly.",
         "_vendor/react.js + react-dom.js unchanged remotely — NOT staged.",
         "deletes empty: remote's 24 components are a subset of the 32 written; no removals.",

--- a/.design-sync/generate.mjs
+++ b/.design-sync/generate.mjs
@@ -50,6 +50,9 @@ const GROUP_LABEL = {
 };
 // Cards rendered at a wider viewport (matches remote: multi-cell / overlay cards).
 const WIDE = new Set(["SectionTitle", "Menu", "Modal", "ConfirmDialog"]);
+// The CSS scope every Vellum selector is prefixed with (postcss scope-vellum).
+// Single-sourced so the manifest themes + generated README can't disagree.
+const SCOPE = ".osc-sheet";
 
 // dtsPropsFor for the 8 Wave-2 components (config.json only carries the original 24).
 const NEW_PROPS = {
@@ -390,8 +393,8 @@ const manifest = {
   globalCssPaths: ["fonts/fonts.css", "_ds_bundle.css", "styles.css"],
   tokens: tokensDump,
   themes: [
-    { selector: '.osc-sheet[data-theme="cream"]', label: "OSC Sheet Cream" },
-    { selector: ".osc-sheet[data-kind=hireling]", label: "OSC Sheet Kind Hireling" },
+    { selector: `${SCOPE}[data-theme="cream"]`, label: "OSC Sheet Cream" },
+    { selector: `${SCOPE}[data-kind=hireling]`, label: "OSC Sheet Kind Hireling" },
   ],
   fonts,
   brandFonts: [{ family: "IM Fell English SC", status: "unreferenced", tokens: [], path: "fonts/fonts.css" }],
@@ -402,40 +405,43 @@ writes.push("_ds_manifest.json");
 
 // ── README.md (conventions header + generated body) ──
 // The body is derived from the SAME data the manifest is built from (namespace,
-// pkg version, token kinds, groups), so a rename/count change can't leave it
-// stale — the failure that the reactor-sheet→osc-character-sheet rename caused.
-// The header is authored prose (cfg.readmeHeader) prepended verbatim.
+// pkg, scope, token kinds, groups, globalCssPaths), so a rename/count change
+// can't leave it stale — the failure the reactor-sheet→osc-character-sheet
+// rename caused. The header is authored prose (cfg.readmeHeader) prepended
+// verbatim.
 function readmeBody() {
   const kc = (k) => tokensDump.filter((t) => t.kind === k).length;
-  const index = ["controls", "display", "layout", "overlays", "navigation", "data"]
+  // Loading links come straight from the manifest's globalCssPaths — every CSS
+  // file a design must link. styles.css alone is NOT the closure (it does not
+  // @import _ds_bundle.css / fonts), so link them all, as the preview cards do.
+  const links = manifest.globalCssPaths.map((p) => `<link rel="stylesheet" href="${p}">`).join("\n");
+  const index = Object.keys(GROUP_LABEL)
     .map((g) => {
       const items = sortedNames.filter((n) => GROUP[n] === g);
-      return items.length ? `### ${g}\n${items.map((n) => `- \`${n}\``).join("\n")}` : "";
+      return items.length ? `### ${GROUP_LABEL[g]}\n${items.map((n) => `- \`${n}\``).join("\n")}` : "";
     })
     .filter(Boolean)
     .join("\n\n");
   const themeSel = manifest.themes.map((t) => `\`${t.selector}\``).join(", ");
-  return `# ${cfg.globalName} (osc-character-sheet@${pkgVersion})
+  return `# ${cfg.globalName} (${cfg.pkg}@${pkgVersion})
 
-This design system is the Vellum UI primitive library from \`osc-character-sheet\`, bundled
-as a single browser global. All ${names.length} components are the real library code.
+This design system is the Vellum UI primitive library from \`${cfg.pkg}\`, bundled as a
+single browser global. All ${names.length} components are the real library code.
 
 ## Where things are
 
-- \`_ds_bundle.js\` — the whole-DS bundle at the project root; loads every component to \`window.${cfg.globalName}\`. First line is a \`/* @ds-bundle: … */\` metadata header.
-- \`styles.css\` — the single stylesheet entry: it \`@import\`s the tokens, fonts, and component styles (\`_ds_bundle.css\`). Link this one file.
-- \`components/<group>/<Name>/<Name>.prompt.md\` (example JSX + variants), \`<Name>.d.ts\` (types), \`<Name>.html\` (variant grid).
+- \`_ds_bundle.js\` — the whole-DS bundle at the project root; loads every component to \`window.${cfg.globalName}\`.
+- \`_ds_bundle.css\` — the compiled Vellum stylesheet (tokens, utilities, component styles), scoped under \`${SCOPE}\`.
+- \`styles.css\` — the app-level styles compile (adds the \`data-kind=hireling\` theme overrides).
 - \`fonts/\` — \`@font-face\` files + \`fonts.css\`.
-- \`guidelines/\` — the design system's own usage guidance (see \`guidelines/index.md\`). Read these before composing larger layouts.
-
-For a specific component, \`read_file("components/<group>/<Name>/<Name>.prompt.md")\`.
+- \`components/<group>/<Name>/<Name>.prompt.md\` (example JSX + variants), \`<Name>.d.ts\` (types), \`<Name>.html\` (variant grid). For one component, \`read_file("components/<group>/<Name>/<Name>.prompt.md")\`.
 
 ## Loading
 
-Add these two lines to your page once (React must be on the page first):
+Link every design-system stylesheet, then the bundle (React must be on the page first):
 
 \`\`\`html
-<link rel="stylesheet" href="styles.css">
+${links}
 <script src="_ds_bundle.js"></script>
 \`\`\`
 
@@ -454,9 +460,9 @@ Wrap the tree in the provider — components read theme/tokens from the scoped r
 
 ## Tokens
 
-${tokensDump.length} CSS custom properties, declared inside \`_ds_bundle.css\` under \`.osc-sheet\`
-(one compiled stylesheet, not separate token files). Themes: ${themeSel}. See the
-styling-idiom section above for the families and their real names.
+${tokensDump.length} CSS custom properties under the \`${SCOPE}\` scopes (mostly in
+\`_ds_bundle.css\`; the \`data-kind=hireling\` overrides live in \`styles.css\`). Themes: ${themeSel}.
+See the styling-idiom section above for the families and their real names.
 
 - Color & surface: ${kc("color")}
 - Text / ink color: ${kc("font")}

--- a/src/OscSheet/styles/vellum/_scales.scss
+++ b/src/OscSheet/styles/vellum/_scales.scss
@@ -32,3 +32,20 @@ $radius: (
   "lg": 10px,
   "xl": 14px,
 );
+
+// Spacing scale → --spacer-N (N*4px). The ONLY place spacer steps are declared.
+// tokens.scss emits the --spacer-* custom properties from this map; utilities.scss
+// derives its p/px/py family from these keys and validates its deliberate subsets
+// (pt/m/gap/…) against it, so a renamed/removed step fails the build, never drifts.
+// Steps are non-contiguous by design (no 7/9/11) — the scale is curated, not a range.
+$spacers: (
+  1: 4px,
+  2: 8px,
+  3: 12px,
+  4: 16px,
+  5: 20px,
+  6: 24px,
+  8: 32px,
+  10: 40px,
+  12: 48px,
+);

--- a/src/OscSheet/styles/vellum/tokens.scss
+++ b/src/OscSheet/styles/vellum/tokens.scss
@@ -28,16 +28,10 @@
     --r-#{$step}: #{$value};
   }
 
-  /* Space scale — numbered, 4px base (--spacer-N = N*4px) */
-  --spacer-1:       4px;
-  --spacer-2:       8px;
-  --spacer-3:       12px;
-  --spacer-4:       16px;
-  --spacer-5:       20px;
-  --spacer-6:       24px;
-  --spacer-8:       32px;
-  --spacer-10:      40px;
-  --spacer-12:      48px;
+  /* Space scale — generated from $spacers in _scales.scss (--spacer-N = N*4px) */
+  @each $step, $value in scales.$spacers {
+    --spacer-#{$step}: #{$value};
+  }
 
   /* ─── Type scale — generated from $type-scale in _scales.scss ─────── */
   @each $step, $value in scales.$type-scale {

--- a/src/OscSheet/styles/vellum/utilities.scss
+++ b/src/OscSheet/styles/vellum/utilities.scss
@@ -18,14 +18,27 @@
    /styles/vellum/ path).
    ======================================================================== */
 @use "scales" as scales;
+@use "sass:map";
+@use "sass:list";
 
 /* ─── Token inventory (lists + maps) ────────────────────────────────────── */
-/* spacer steps → --spacer-N; `0` emits a literal 0 reset. */
-$scale-full: 0 1 2 3 4 5 6 8 10 12; // p / px / py
-$scale-mid:  0 1 2 3 4 6;           // pt/pr/pb/pl, m/my/mt/mb
-$scale-sm:   0 1 2 3 4;             // mx / mr / ml
-$gap-steps:  0 1 2 3 4 5 6 8;
-$gap-axis:   1 2 3 4;
+/* spacer steps → --spacer-N (`0` emits a literal 0 reset). Steps come from the
+   single-source scales.$spacers map: the full p/px/py family is its keys; the
+   other families are deliberate subsets, each validated against the map so a
+   renamed/removed spacer step fails the build instead of silently drifting. */
+@function sp-subset($steps) {
+  @each $n in $steps {
+    @if $n != 0 and not map.has-key(scales.$spacers, $n) {
+      @error "u-* spacer subset references --spacer-#{$n}, absent from scales.$spacers.";
+    }
+  }
+  @return $steps;
+}
+$scale-full: list.join(0, map.keys(scales.$spacers), $separator: space); // p / px / py — full scale
+$scale-mid:  sp-subset(0 1 2 3 4 6);     // pt/pr/pb/pl, m/my/mt/mb
+$scale-sm:   sp-subset(0 1 2 3 4);       // mx / mr / ml
+$gap-steps:  sp-subset(0 1 2 3 4 5 6 8);
+$gap-axis:   sp-subset(1 2 3 4);
 
 /* one spacer value: `0` literal, else var(--spacer-N) */
 @function sp($n) {


### PR DESCRIPTION
Bundles three related design-system changes. Supersedes #66 (its build-css fix is included here as the first commit).

## OLD-39 — single-source the spacer scale
`--spacer-N` and the `u-*` spacer utilities now derive from one `$spacers` map in `_scales.scss` (same pattern as `$type-scale`/`$radius`). The `p/px/py` family is the map keys; the deliberate per-family subsets (`pt`/`m`/`gap`/…) stay explicit but validate against the map via `sp-subset()`, so a renamed/removed step fails the build instead of silently drifting. `dist/main.css` byte-identical.

## Generate the design-sync README
`generate.mjs` now emits `README.md` = `conventions.md` header + a body derived from the build (namespace, `cfg.pkg`, scope, token-kind counts, groups, `globalCssPaths`). Previously README was left untouched on the remote, which let the `reactor-sheet`→`osc-character-sheet` rename ship a README telling the design agent to use `window.ReactorSheet` — a global the new bundle doesn't export. Deriving it from the build makes that drift impossible.

## build-css fix (was #66)
`tokens.css` → `tokens.scss` (now emits `--fs-*`/`--r-*`/`--spacer-*` via `@each`) broke the design-sync CSS build; compile it through dart-sass like `utilities.scss`.

Verification: `pnpm lint` clean, 112 tests pass, `dist/main.css` byte-identical, `_ds_manifest.json` byte-identical. Design-sync itself will be run from `main` after merge.