### PR TITLE
feat: read-only sheet for non-owners — global mechanism (OLD-41)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -125,6 +125,12 @@ jobs:
         working-directory: tools/e2e
         run: |
           npm install --no-package-lock --no-audit --no-fund
+          # The hosted runner's packages.microsoft.com apt repo intermittently
+          # ships a malformed Release file ("Clearsigned file isn't valid, got
+          # 'NOSPLIT'"), which fails `--with-deps`' apt-get update. Chromium's
+          # deps come from the standard Ubuntu archive, so drop the MS sources.
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list \
+                     /etc/apt/sources.list.d/azure-cli.list || true
           npx playwright install chromium --with-deps
 
       - name: Wait for Foundry to be healthy

--- a/src/OscSheet/app/OptimisticProvider.tsx
+++ b/src/OscSheet/app/OptimisticProvider.tsx
@@ -17,7 +17,7 @@ const ACTOR_KEY = "actor";
  */
 export function OptimisticProvider({ children }: { children: ReactNode }) {
   const parent = useOscSheetContext();
-  const { actor, items } = parent;
+  const { actor, items, canEdit } = parent;
   const [pending, setPending] = useState<Pending>({});
 
   // Reconcile against Foundry truth on every sync: keep only patches it hasn't
@@ -51,12 +51,14 @@ export function OptimisticProvider({ children }: { children: ReactNode }) {
 
   const optimisticUpdate = useCallback(
     (key: string, patch: FlatPatch, commit: () => Promise<unknown>, debounceMs = 250) => {
+      // Read-only sheets: refuse at the write layer — no overlay, no backend commit.
+      if (!canEdit) return;
       setPending((p) => ({ ...p, [key]: { ...p[key], ...patch } })); // overlay now
       writes.current[key] = commit; // latest write wins
       clearTimeout(timers.current[key]);
       timers.current[key] = setTimeout(() => flush(key), debounceMs);
     },
-    [flush],
+    [flush, canEdit],
   );
 
   // Flush in-flight debounced writes on unmount (sheet close) so none are lost.

--- a/src/OscSheet/app/OscSheetProvider.tsx
+++ b/src/OscSheet/app/OscSheetProvider.tsx
@@ -9,11 +9,13 @@ function OscSheetProvider({
   children,
   source,
   contextConnector,
+  canEdit,
 }: {
   initialActor: OSEActor;
   source: OSEActor;
   children: ReactNode;
   contextConnector?: ContextConnector<OscContext>;
+  canEdit: boolean;
 }) {
   const [actor, setActor] = useState<OSEActor>(initialActor);
   const [actorData, setActorData] = useState(initialActor.system);
@@ -66,6 +68,7 @@ function OscSheetProvider({
     currentTab,
     setCurrentTab,
     updateActor,
+    canEdit,
   };
 
   return (

--- a/src/OscSheet/app/OscSheetProvider.tsx
+++ b/src/OscSheet/app/OscSheetProvider.tsx
@@ -34,6 +34,10 @@ function OscSheetProvider({
   async function updateActor(updateData: {
     [key: string]: string | number;
   }): Promise<OSEActor | void> {
+    // Read-only sheets short-circuit the actor write layer: a defence-in-depth
+    // backstop so any UI path that slips the per-control canEdit gating still
+    // can't mutate (Foundry also rejects it server-side for non-owners).
+    if (!canEdit) return;
     if (actor.update) {
       return await actor.update(updateData).then((updatedActor) => {
         if (updatedActor) {

--- a/src/OscSheet/app/SheetShell.tsx
+++ b/src/OscSheet/app/SheetShell.tsx
@@ -44,6 +44,7 @@ export default function SheetShell() {
     setCurrentTab,
     updateActor,
     optimisticUpdate,
+    canEdit,
   } = useOscSheetContext();
   const toast = useToast();
   const [editOpen, setEditOpen] = useState(false);
@@ -74,7 +75,8 @@ export default function SheetShell() {
       travel: movement.overland,
     },
   };
-  const onSetHp = (value: number) => {
+  // Read-only sheets get no HP stepper/input (undefined onSetHp → static value).
+  const onSetHp = !canEdit ? undefined : (value: number) => {
     const next = Math.max(0, Math.min(vitals.hp.max, value));
     if (next === vitals.hp.value) return;
     const update = { "system.hp.value": next };
@@ -264,7 +266,7 @@ export default function SheetShell() {
 
   return (
     <>
-      <EditModal open={editOpen} onClose={() => setEditOpen(false)} />
+      <EditModal open={editOpen && canEdit} onClose={() => setEditOpen(false)} />
       <Frame
         tabs={items}
         active={activeTab.id}
@@ -275,6 +277,7 @@ export default function SheetShell() {
         topbar={
           <Topbar
             vm={selectTopbar(actor)}
+            canEdit={canEdit}
             onEdit={() => setEditOpen(true)}
             onLevelUp={() =>
               toast({
@@ -290,8 +293,12 @@ export default function SheetShell() {
             identity={identity}
             vitals={vitals}
             onSetHp={onSetHp}
-            onPortraitContextMenu={() => showTokenVariantsPortraitPicker(actor)}
-            canEditPortrait={actor.isOwner}
+            onPortraitContextMenu={
+              canEdit
+                ? () => showTokenVariantsPortraitPicker(actor)
+                : undefined
+            }
+            canEditPortrait={canEdit}
           />
         }
         minibar={

--- a/src/OscSheet/app/SheetShell.tsx
+++ b/src/OscSheet/app/SheetShell.tsx
@@ -293,6 +293,10 @@ export default function SheetShell() {
             identity={identity}
             vitals={vitals}
             onSetHp={onSetHp}
+            // Intentionally gated on canEdit (= Foundry `sheet.isEditable`), not
+            // raw actor.isOwner: a locked/compendium sheet legitimately shouldn't
+            // expose write affordances even to an owner. Same rationale for the
+            // inventory context-menu / Send gates.
             onPortraitContextMenu={
               canEdit
                 ? () => showTokenVariantsPortraitPicker(actor)

--- a/src/OscSheet/app/SheetShell.tsx
+++ b/src/OscSheet/app/SheetShell.tsx
@@ -87,6 +87,33 @@ export default function SheetShell() {
 
   const resolveItem = (id: string) =>
     (invItems as OseItem[]).find((i) => i._id === id);
+
+  // --- Item write layer (structural read-only gate) -------------------------
+  // Every item mutation funnels through these three primitives, which refuse the
+  // write when !canEdit. This keeps read-only STRUCTURAL: a new or ungated item
+  // control can never reach Foundry, independent of the per-control UI gating
+  // (kept as defense-in-depth). A refused write no-ops silently; Foundry also
+  // rejects it server-side for non-owners.
+  const writeItem = (
+    it: OseItem,
+    update: Record<string, unknown>,
+    optimisticKey?: string,
+  ) => {
+    if (!canEdit) return;
+    if (optimisticKey && optimisticUpdate)
+      optimisticUpdate(optimisticKey, update, () => it.update(update));
+    else void it.update(update);
+  };
+  const deleteItem = (it: OseItem) => {
+    if (!canEdit) return;
+    void it.delete();
+  };
+  const embedUpdate = (updates: object[]) => {
+    if (!canEdit) return;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    void (actor as any).updateEmbeddedDocuments("Item", updates);
+  };
+
   const onEquipItem = (id: string) => {
     const it = resolveItem(id);
     if (!it || !("equipped" in it.system)) return;
@@ -111,8 +138,7 @@ export default function SheetShell() {
       update[flagPath(FLAGS.equippedOrder)] = maxEq + 100;
     }
     // Optimistic: flip the hand instantly, reconcile when Foundry confirms.
-    if (optimisticUpdate) optimisticUpdate(id, update, () => it.update(update));
-    else void it.update(update);
+    writeItem(it, update, id);
     if (leftContainer) {
       const container = resolveItem(fromContainerId!);
       toast({
@@ -127,21 +153,16 @@ export default function SheetShell() {
   const onSetCoin = (id: string, value: number) => {
     const it = resolveItem(id);
     if (!it) return;
-    const update = { "system.quantity.value": value };
-    if (optimisticUpdate) optimisticUpdate(id, update, () => it.update(update));
-    else void it.update(update);
+    writeItem(it, { "system.quantity.value": value }, id);
   };
   // Consume one: decrement the item's quantity (floored at 0).
   const onConsume = (id: string) => {
     const it = resolveItem(id);
     const cur =
       (it?.system as { quantity?: { value: number } })?.quantity?.value ?? 0;
-    if (it && cur > 0) void it.update({ "system.quantity.value": cur - 1 });
+    if (it && cur > 0) writeItem(it, { "system.quantity.value": cur - 1 });
   };
 
-  const embedUpdate = (updates: object[]) =>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    void (actor as any).updateEmbeddedDocuments("Item", updates);
   // Manual order is stored in our own flag (not Foundry's `sort`, which the core
   // sheet and other modules also write).
   const onReorder = (u: { id: string; sort: number }[]) =>
@@ -180,13 +201,16 @@ export default function SheetShell() {
     );
     if (kids.length)
       embedUpdate(kids.map((k) => ({ _id: k._id, "system.containerId": "" })));
-    void it.delete();
+    deleteItem(it);
   };
 
   // Send an item to another actor. Direct apply when I own the target; otherwise
   // relay the whole op through the active GM. Pure plan/route logic lives in
   // sendItem.ts; the socket + apply routine in sendItemSocket.ts.
   const onSend = (itemId: string, target: SendTargetVM, qty: number) => {
+    // Send mutates the SOURCE actor (delete/decrement), so it's part of the write
+    // layer — refuse it read-only (both the local applySend and the GM relay).
+    if (!canEdit) return;
     const it = resolveItem(itemId);
     if (!it) return;
     // Resolve the picked token's actor by UUID (fromUuidSync handles linked and

--- a/src/OscSheet/app/writeGate.test.tsx
+++ b/src/OscSheet/app/writeGate.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+// Structural read-only gate: the write layer (provider updateActor +
+// OptimisticProvider optimisticUpdate) must refuse to reach Foundry when
+// canEdit=false, and still write when true — independent of any per-control UI.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import OscSheetProvider from "./OscSheetProvider";
+import { OptimisticProvider } from "./OptimisticProvider";
+import { useOscSheetContext } from "./context";
+import type { OSEActor, OscSheetContextValue } from "@domain/types";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Minimal Foundry globals the provider touches.
+(globalThis as { foundry?: unknown }).foundry = {
+  utils: { debounce: (fn: unknown) => fn },
+};
+const connector = { onUpdate: vi.fn(), tearDown: vi.fn() } as never;
+
+let container: HTMLDivElement;
+let root: Root;
+let ctx: OscSheetContextValue;
+
+function Capture() {
+  ctx = useOscSheetContext();
+  return null;
+}
+
+function makeActor() {
+  return {
+    name: "Test",
+    system: { hp: { value: 5, max: 10 } },
+    items: { contents: [] },
+    update: vi.fn().mockResolvedValue({ system: { hp: { value: 5, max: 10 } } }),
+  } as unknown as OSEActor & { update: ReturnType<typeof vi.fn> };
+}
+
+function render(actor: OSEActor, canEdit: boolean, optimistic = false) {
+  const inner = <Capture />;
+  act(() =>
+    root.render(
+      <OscSheetProvider
+        initialActor={actor}
+        source={actor}
+        contextConnector={connector}
+        canEdit={canEdit}
+      >
+        {optimistic ? <OptimisticProvider>{inner}</OptimisticProvider> : inner}
+      </OscSheetProvider>,
+    ),
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("write layer — read-only gate", () => {
+  it("updateActor refuses to write when canEdit=false", async () => {
+    const actor = makeActor();
+    render(actor, false);
+    await act(async () => {
+      await ctx.updateActor({ "system.hp.value": 7 });
+    });
+    expect((actor as unknown as { update: ReturnType<typeof vi.fn> }).update).not.toHaveBeenCalled();
+  });
+
+  it("updateActor writes through when canEdit=true", async () => {
+    const actor = makeActor();
+    render(actor, true);
+    await act(async () => {
+      await ctx.updateActor({ "system.hp.value": 7 });
+    });
+    expect((actor as unknown as { update: ReturnType<typeof vi.fn> }).update).toHaveBeenCalledWith({
+      "system.hp.value": 7,
+    });
+  });
+
+  it("optimisticUpdate no-ops (no commit) when canEdit=false", async () => {
+    const actor = makeActor();
+    render(actor, false, true);
+    const commit = vi.fn().mockResolvedValue(undefined);
+    await act(async () => {
+      ctx.optimisticUpdate?.("actor", { "system.hp.value": 7 }, commit, 0);
+      await new Promise((r) => setTimeout(r, 5));
+    });
+    expect(commit).not.toHaveBeenCalled();
+  });
+
+  it("optimisticUpdate commits when canEdit=true", async () => {
+    const actor = makeActor();
+    render(actor, true, true);
+    const commit = vi.fn().mockResolvedValue(undefined);
+    await act(async () => {
+      ctx.optimisticUpdate?.("actor", { "system.hp.value": 7 }, commit, 0);
+      await new Promise((r) => setTimeout(r, 5));
+    });
+    expect(commit).toHaveBeenCalledOnce();
+  });
+});

--- a/src/OscSheet/domain/types.ts
+++ b/src/OscSheet/domain/types.ts
@@ -15,6 +15,9 @@ export type OscSheetAppProps = {
   actor?: OSEActor;
   source?: OSEActor;
   contextConnector: ContextConnector<OscContext>;
+  /** Foundry's `sheet.isEditable`. When omitted, edit gating falls back to
+   *  `actor.isOwner` (e.g. Storybook / tests that mount the app directly). */
+  isEditable?: boolean;
 };
 
 // Define the shape of your context value here
@@ -25,6 +28,9 @@ export interface OscSheetContextValue {
   actorData: OSEActor["_source"]["system"];
   currentTab: TabIds;
   setCurrentTab: (tabId: TabIds) => void;
+  /** Global edit gate: true for owners, false for observers/limited (read-only
+   *  sheet). Components hide/disable write affordances when false. */
+  canEdit: boolean;
   updateActor: (updateData: {
     [key: string]: string | number | string[];
   }) => Promise<OSEActor | void>;

--- a/src/OscSheet/features/abilities/AbilitiesView.tsx
+++ b/src/OscSheet/features/abilities/AbilitiesView.tsx
@@ -7,7 +7,7 @@ import { FeatureCard } from "@features/abilities/FeatureCard";
 import { LanguagesSection } from "@features/abilities/LanguagesSection";
 
 export default function Abilities() {
-  const { actor } = useOscSheetContext();
+  const { actor, canEdit } = useOscSheetContext();
   const features = selectFeatures(actor);
 
   // New abilities seed their requirements from the actor's class so they sort in
@@ -20,14 +20,16 @@ export default function Abilities() {
         <SectionHeader
           title="Abilities"
           controls={
-            <IconButton
-              variant="accent"
-              title="Add ability"
-              aria-label="Add ability"
-              onClick={onAdd}
-            >
-              <i className="fas fa-plus" aria-hidden="true" />
-            </IconButton>
+            canEdit ? (
+              <IconButton
+                variant="accent"
+                title="Add ability"
+                aria-label="Add ability"
+                onClick={onAdd}
+              >
+                <i className="fas fa-plus" aria-hidden="true" />
+              </IconButton>
+            ) : undefined
           }
         />
         {features.length === 0 ? (

--- a/src/OscSheet/features/abilities/FeatureCard.tsx
+++ b/src/OscSheet/features/abilities/FeatureCard.tsx
@@ -34,6 +34,7 @@ function useEnriched(html: string): string {
  * click anywhere else on the header) expands the description.
  */
 export function FeatureCard({ feature }: { feature: FeatureVM }) {
+  const { canEdit } = useOscSheetContext();
   const [open, setOpen] = useState(false);
   const desc = useEnriched(feature.description);
   const monogram = feature.name.charAt(0).toUpperCase();
@@ -93,16 +94,18 @@ export function FeatureCard({ feature }: { feature: FeatureVM }) {
             className="ft-desc"
             dangerouslySetInnerHTML={{ __html: desc }}
           />
-          <div className="ft-actions">
-            <IconButton
-              variant="danger"
-              title="Delete ability"
-              aria-label="Delete ability"
-              onClick={feature.onDelete}
-            >
-              <i className="fas fa-trash" aria-hidden="true" />
-            </IconButton>
-          </div>
+          {canEdit && (
+            <div className="ft-actions">
+              <IconButton
+                variant="danger"
+                title="Delete ability"
+                aria-label="Delete ability"
+                onClick={feature.onDelete}
+              >
+                <i className="fas fa-trash" aria-hidden="true" />
+              </IconButton>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/OscSheet/features/abilities/LanguagesSection.tsx
+++ b/src/OscSheet/features/abilities/LanguagesSection.tsx
@@ -24,10 +24,11 @@ function useFlavour(): string | null {
  * present, or type a custom language. Persists to `system.languages.value`.
  */
 export function LanguagesSection({ editing: forced }: { editing?: boolean }) {
-  const { actor, updateActor } = useOscSheetContext();
+  const { actor, updateActor, canEdit } = useOscSheetContext();
   const [localEditing, setLocalEditing] = useState(false);
   const [draft, setDraft] = useState("");
-  const editing = forced || localEditing;
+  // Read-only sheets can never enter edit mode (chips stay static, no add/remove).
+  const editing = canEdit && (forced || localEditing);
 
   const current = actor.system.languages.value;
   const flavour = useFlavour();
@@ -55,7 +56,7 @@ export function LanguagesSection({ editing: forced }: { editing?: boolean }) {
       <SectionHeader
         title="Languages"
         controls={
-          !forced && (
+          !forced && canEdit && (
             <IconButton
               variant="accent"
               on={editing}

--- a/src/OscSheet/features/actions/ActionsView.tsx
+++ b/src/OscSheet/features/actions/ActionsView.tsx
@@ -11,6 +11,7 @@ import { AttacksTable } from "@features/actions/AttacksTable";
 import { MemorizedSpells } from "@features/actions/MemorizedSpells";
 import { SavesGrid, ExplorationGrid } from "@features/actions/SavesExploration";
 import { SectionTitle } from "@ui/SectionTitle";
+import { useOscSheetContext } from "@app/context";
 
 type Props = { actor: OSEActor };
 
@@ -18,6 +19,10 @@ type Props = { actor: OSEActor };
  *  md Saves/Exploration). At lg, Saves/Exploration live in the left rail instead,
  *  so they carry .actions-only (hidden at lg — see SheetShell/shell.scss). */
 export function ActionsView({ actor }: Props) {
+  // Chat-only rolls (ability/save/exploration/hit/dmg post a card, no actor write)
+  // stay available even read-only; the composite Attack can write (missile ammo
+  // decrement), so it's gated on the global edit permission.
+  const { canEdit } = useOscSheetContext();
   const onAbility = (key: string) => actor.rollCheck(key, {});
   // Hit/Damage are custom formula rolls (OSE has no separate hit/damage roll). The
   // Vellum card is target-aware: a hit roll shows HIT/MISS vs the current target's AC,
@@ -41,7 +46,7 @@ export function ActionsView({ actor }: Props) {
   return (
     <>
       <AbilityPlaques abilities={selectAbilities(actor)} onRoll={onAbility} />
-      <AttacksTable attacks={attacks} onRoll={onRoll} onAttack={onAttack} onOpen={onOpenWeapon} dragData={dragData} />
+      <AttacksTable attacks={attacks} onRoll={onRoll} onAttack={canEdit ? onAttack : undefined} onOpen={onOpenWeapon} dragData={dragData} canAttack={canEdit} />
       <MemorizedSpells actor={actor} />
       {/* .actions-only: hidden at lg (Saves/Exploration live in the rail there). */}
       <section className="osc-section actions-only">

--- a/src/OscSheet/features/actions/AttacksTable.tsx
+++ b/src/OscSheet/features/actions/AttacksTable.tsx
@@ -16,6 +16,9 @@ type Props = {
   /** Foundry item drag-data for a weapon, so its card drops onto the macro hotbar
    *  to create an attack macro (same as an inventory row). undefined = not draggable. */
   dragData?: (itemId: string) => string | undefined;
+  /** The composite Attack roll can write to the actor/item (e.g. missile ammo
+   *  decrement), so it's owner-only. false hides the Attack button. Default true. */
+  canAttack?: boolean;
 };
 
 /** Monogram glyph for the ink-stamp weapon icon (first letter, Title-case). */
@@ -27,7 +30,7 @@ const kindIcon = (kind: "melee" | "missile") => (kind === "melee" ? "fa-sword" :
 
 /** One weapon card. A melee+missile weapon shows both kind tags as a toggle
  *  (melee active by default); the active mode drives Hit/Dmg. */
-function WeaponRow({ a, onRoll, onAttack, onOpen, dragData }: { a: AttackVM; onRoll?: Props["onRoll"]; onAttack?: Props["onAttack"]; onOpen?: Props["onOpen"]; dragData?: Props["dragData"] }) {
+function WeaponRow({ a, onRoll, onAttack, onOpen, dragData, canAttack = true }: { a: AttackVM; onRoll?: Props["onRoll"]; onAttack?: Props["onAttack"]; onOpen?: Props["onOpen"]; dragData?: Props["dragData"]; canAttack?: boolean }) {
   const [active, setActive] = useState(0); // index into a.modes (melee = 0)
   const mode = a.modes[active] ?? a.modes[0];
   const dual = a.modes.length > 1;
@@ -151,19 +154,21 @@ function WeaponRow({ a, onRoll, onAttack, onOpen, dragData }: { a: AttackVM; onR
         <span className="tag-pop" role="tooltip">{mode.dmgTip}</span>
       </button>
 
-      <button
-        type="button"
-        className="fvtt-atk"
-        data-testid={`weapon-attack-${a.itemId}`}
-        {...macroDrag}
-        disabled={!onAttack}
-        onClick={() => onAttack?.(a.itemId)}
-        title="Attack roll (hit + damage)"
-        aria-label={`Attack with ${a.name}`}
-      >
-        <i className="fa-solid fa-dice-d20" aria-hidden="true" />
-        <span>Attack</span>
-      </button>
+      {canAttack && (
+        <button
+          type="button"
+          className="fvtt-atk"
+          data-testid={`weapon-attack-${a.itemId}`}
+          {...macroDrag}
+          disabled={!onAttack}
+          onClick={() => onAttack?.(a.itemId)}
+          title="Attack roll (hit + damage)"
+          aria-label={`Attack with ${a.name}`}
+        >
+          <i className="fa-solid fa-dice-d20" aria-hidden="true" />
+          <span>Attack</span>
+        </button>
+      )}
     </div>
   );
 }
@@ -171,13 +176,13 @@ function WeaponRow({ a, onRoll, onAttack, onOpen, dragData }: { a: AttackVM; onR
 /** Equipped-weapon attacks as woodcut weapon cards: ink-stamp monogram, name +
  *  melee/missile + quality tags, clickable HIT/DMG stat cells (FA dice), and a
  *  tall brass Attack button (full hit + damage via the OSE weapon dialog). */
-export function AttacksTable({ attacks, onRoll, onAttack, onOpen, dragData }: Props) {
+export function AttacksTable({ attacks, onRoll, onAttack, onOpen, dragData, canAttack = true }: Props) {
   return (
     <section className="osc-section osc-atk">
       <SectionTitle hint="click to roll">Attacks</SectionTitle>
       <div className="osc-wtable">
         {attacks.map((a) => (
-          <WeaponRow key={a.id} a={a} onRoll={onRoll} onAttack={onAttack} onOpen={onOpen} dragData={dragData} />
+          <WeaponRow key={a.id} a={a} onRoll={onRoll} onAttack={onAttack} onOpen={onOpen} dragData={dragData} canAttack={canAttack} />
         ))}
       </div>
     </section>

--- a/src/OscSheet/features/actions/MemorizedSpells.tsx
+++ b/src/OscSheet/features/actions/MemorizedSpells.tsx
@@ -1,4 +1,5 @@
 import type { OSEActor, OseSpell } from "@domain/types";
+import { useOscSheetContext } from "@app/context";
 import { SectionTitle } from "@ui/SectionTitle";
 import { SpellCastRow } from "@features/spells/SpellCastRow";
 import { spellMeta } from "@features/spells/spells";
@@ -14,6 +15,7 @@ type Props = { actor: OSEActor };
  * fully-spent ones (memorized persists). Cast → `spendSpell`.
  */
 export function MemorizedSpells({ actor }: Props) {
+  const { canEdit } = useOscSheetContext();
   // Same flatten + path as the Spells tab: spellList is Record<level, OseSpell[]>.
   const spells: OseSpell[] = Object.values(actor.system.spells?.spellList ?? {})
     .flat()
@@ -36,6 +38,7 @@ export function MemorizedSpells({ actor }: Props) {
                 {p.text}
               </span>
             ))}
+            canCast={canEdit}
             onCast={() => spell.spendSpell({ skipDialog: false })}
             onOpenName={() => spell.sheet.render(true)}
           />

--- a/src/OscSheet/features/inventory/EquippedTray.tsx
+++ b/src/OscSheet/features/inventory/EquippedTray.tsx
@@ -4,10 +4,13 @@ import { useState } from "react";
 import type { InventoryItemVM } from "@domain/vm-types";
 import { weightLabel, EQUIPPED } from "@features/inventory/groups";
 import type { Dnd, ItemDragData, OnContext } from "@features/inventory/types";
+import { useOscSheetContext } from "@app/context";
 import { Monogram } from "@ui/Monogram";
 import { cx } from "@ui/cx";
 
-// Equip toggle: outlined hand = unequipped, filled hand = equipped.
+// Equip toggle: outlined hand = unequipped, filled hand = equipped. Read-only
+// sheets (non-owners) get a static, non-interactive equipped indicator instead
+// of a toggle button — equipped items stay readable, but can't be toggled.
 export function RowEquip({
   item,
   onEquip,
@@ -15,8 +18,21 @@ export function RowEquip({
   item: InventoryItemVM;
   onEquip: (id: string) => void;
 }) {
+  const { canEdit } = useOscSheetContext();
   if (item.equipped === null)
     return <span className="osc-inv-equip-spacer" aria-hidden="true" />;
+  if (!canEdit)
+    return item.equipped ? (
+      <span
+        className="osc-inv-equip is-on is-static"
+        aria-label="Equipped"
+        title="Equipped"
+      >
+        <i className="fa-solid fa-hand" aria-hidden="true" />
+      </span>
+    ) : (
+      <span className="osc-inv-equip-spacer" aria-hidden="true" />
+    );
   return (
     <button
       type="button"

--- a/src/OscSheet/features/inventory/ItemContextMenu.tsx
+++ b/src/OscSheet/features/inventory/ItemContextMenu.tsx
@@ -15,7 +15,8 @@ export function ItemContextMenu({
   onSend,
 }: {
   menu: MenuState;
-  /** Whether the current user owns this actor. Non-owners get view-only. */
+  /** Global edit gate (see useOscSheetContext().canEdit). Non-owners get a
+   *  view-only menu — only "View Item" remains. */
   canEdit: boolean;
   onClose: () => void;
   onOpen: (id: string) => void;

--- a/src/OscSheet/features/inventory/WealthSection.tsx
+++ b/src/OscSheet/features/inventory/WealthSection.tsx
@@ -8,6 +8,7 @@ import { useDragReorder } from "@features/inventory/useDragReorder";
 import { ItemImage } from "@features/inventory/ItemImage";
 import { SortHeader } from "@features/inventory/SortHeader";
 import type { OnContext } from "@features/inventory/types";
+import { useOscSheetContext } from "@app/context";
 import { Button } from "@ui/Button";
 import { cx } from "@ui/cx";
 
@@ -36,6 +37,8 @@ export function WealthSection({
   /** Right-click a coin row → the shared item context menu (View / Delete). */
   onContext: OnContext;
 }) {
+  // Read-only sheets (non-owners): coin qty is view-only, no drag-reorder.
+  const { canEdit } = useOscSheetContext();
   const [open, setOpen] = useState(false);
   const [order, setOrder] = useState<string[]>([]);
   const [sort, setSort] = useState<{ key: CoinSortKey; dir: SortDir }>({ key: "manual", dir: "asc" });
@@ -72,6 +75,7 @@ export function WealthSection({
       });
 
   const dnd = useDragReorder({
+    enabled: canEdit,
     onReorder: ({ from, to }) => {
       // Bake the current (possibly sorted) order, then drop to manual so the drag shows.
       const next = [...rows];
@@ -184,7 +188,7 @@ export function WealthSection({
                 <span
                   className="osc-inv-drag"
                   title="Drag to reorder"
-                  draggable
+                  draggable={canEdit}
                   onDragStart={rp.onDragStart}
                   onDragEnd={rp.onDragEnd}
                 >
@@ -207,6 +211,9 @@ export function WealthSection({
                   data-testid={`coin-qty-${c.denom.toLowerCase()}`}
                   value={draft[c.denom] ?? String(c.value)}
                   aria-label={`${c.name} quantity`}
+                  // Read-only sheets: coin qty is view-only.
+                  readOnly={!canEdit}
+                  disabled={!canEdit}
                   onChange={(e) => setDraft((d) => ({ ...d, [c.denom]: e.target.value }))}
                   onFocus={(e) => e.currentTarget.select()}
                   onKeyDown={(e) => { if (e.key === "Enter") { commit(c); setOpen(false); } }}

--- a/src/OscSheet/features/inventory/index.tsx
+++ b/src/OscSheet/features/inventory/index.tsx
@@ -92,7 +92,7 @@ export function InventoryView({
 
   // Foundry items by id — source for the hotbar drag payload. Dragging a row onto
   // the macro bar creates an item macro (OSE's hotbarDrop hook), like the stock sheet.
-  const { actor, items } = useOscSheetContext();
+  const { actor, items, canEdit } = useOscSheetContext();
   const itemsById = new Map<string, OseItem>(items.map((it) => [it._id, it]));
   const itemDragData: ItemDragData = (id) => {
     const it = itemsById.get(id);
@@ -177,6 +177,8 @@ export function InventoryView({
   // Commit handlers for the drag hook. Each mutates the local order immediately
   // (so the dropped item re-renders in place at once) then persists the diff.
   const dnd = useDragReorder({
+    // Read-only sheets (non-owners) get no drag-reorder / drag-to-nest / equip-by-drop.
+    enabled: canEdit,
     onReorder: ({ group, from, to }) => {
       // Tray tiles reorder in their own group → persist the equippedOrder flag.
       if (group === EQUIPPED) {
@@ -379,14 +381,14 @@ export function InventoryView({
       {menu && (
         <ItemContextMenu
           menu={menu}
-          canEdit={actor.isOwner}
+          canEdit={canEdit}
           onClose={() => setMenu(null)}
           onOpen={onOpen}
           onEquip={onEquip}
           onConsume={onConsume}
           onDelete={onDelete}
           onSend={
-            actor.isOwner && byId.has(menu.item.id) && isGmConnected()
+            canEdit && byId.has(menu.item.id) && isGmConnected()
               ? openSend
               : undefined
           }

--- a/src/OscSheet/features/inventory/useDragReorder.ts
+++ b/src/OscSheet/features/inventory/useDragReorder.ts
@@ -46,15 +46,18 @@ type Handlers = {
   draggable?: boolean;
   onDragStart?: (e: DragEvent<HTMLElement>) => void;
   onDragEnd?: (e: DragEvent<HTMLElement>) => void;
-  onDragOver: (e: DragEvent<HTMLElement>) => void;
-  onDrop: (e: DragEvent<HTMLElement>) => void;
+  onDragOver?: (e: DragEvent<HTMLElement>) => void;
+  onDrop?: (e: DragEvent<HTMLElement>) => void;
 };
 
 export function useDragReorder(opts: {
   onReorder?: (a: ReorderArgs) => void;
   onNest?: (a: NestArgs) => void;
+  /** When false (read-only sheet), the whole hook is inert: rows aren't
+   *  draggable and reject drops, so no reorder/nest can fire. Default true. */
+  enabled?: boolean;
 } = {}) {
-  const { onReorder, onNest } = opts;
+  const { onReorder, onNest, enabled = true } = opts;
   const [drag, setDrag] = useState<DragState | null>(null);
   const [over, setOver] = useState<OverState | null>(null);
   const clear = () => { setDrag(null); setOver(null); };
@@ -71,8 +74,10 @@ export function useDragReorder(opts: {
   const accepts = (o: RowOpts, fromGroup: string): boolean =>
     typeof o.acceptCrossGroup === "function" ? o.acceptCrossGroup(fromGroup) : !!o.acceptCrossGroup;
 
-  // Draggable + droppable row.
-  const rowProps = (group: string, idx: number, o: RowOpts = {}): Handlers => ({
+  // Draggable + droppable row. Inert (non-draggable, drop-rejecting) when disabled.
+  const rowProps = (group: string, idx: number, o: RowOpts = {}): Handlers => {
+    if (!enabled) return { draggable: false };
+    return ({
     draggable: true,
     onDragStart: (e) => {
       setDrag({ group, idx });
@@ -120,9 +125,13 @@ export function useDragReorder(opts: {
       clear();
     },
   });
+  };
 
   // Drop target for an empty container body (nest with no sibling rows to hover).
-  const nestProps = (group: string, idx: number, zone: string | null): Pick<Handlers, "onDragOver" | "onDrop"> => ({
+  // Inert (no drop handlers) when disabled.
+  const nestProps = (group: string, idx: number, zone: string | null): Pick<Handlers, "onDragOver" | "onDrop"> => {
+    if (!enabled) return {};
+    return ({
     onDragOver: (e) => {
       if (!drag) return;
       e.preventDefault();
@@ -137,6 +146,7 @@ export function useDragReorder(opts: {
       clear();
     },
   });
+  };
 
   // " dragging" on the source + " drop-before|after|into" on the hovered target.
   const rowClass = (group: string, idx: number): string => {

--- a/src/OscSheet/features/inventory/useDragReorder.ts
+++ b/src/OscSheet/features/inventory/useDragReorder.ts
@@ -77,75 +77,75 @@ export function useDragReorder(opts: {
   // Draggable + droppable row. Inert (non-draggable, drop-rejecting) when disabled.
   const rowProps = (group: string, idx: number, o: RowOpts = {}): Handlers => {
     if (!enabled) return { draggable: false };
-    return ({
-    draggable: true,
-    onDragStart: (e) => {
-      setDrag({ group, idx });
-      e.dataTransfer.effectAllowed = "move";
-      const payload = o.dragPayload?.() ?? `${group}:${idx}`;
-      try { e.dataTransfer.setData("text/plain", payload); } catch { /* IE guard */ }
-      o.onStart?.();
-    },
-    onDragEnd: () => { clear(); o.onEnd?.(); },
-    onDragOver: (e) => {
-      if (!drag) return;
-      const isSelf = drag.group === group && drag.idx === idx;
-      const into = !!o.container && !isSelf; // a container accepts any item except itself
-      const crossGroup = !into && drag.group !== group;
-      // Reorder only within the same group, unless this row accepts a cross-group
-      // drop (un-nest): then show a before/after line and route through onNest.
-      if (crossGroup && !accepts(o, drag.group)) return;
-      e.preventDefault();
-      e.dataTransfer.dropEffect = "move";
-      const where: DropWhere = into ? "into" : edgeWhere(e, o.axis ?? "y");
-      if (!over || over.group !== group || over.idx !== idx || over.where !== where)
-        setOver({ group, idx, where });
-    },
-    onDrop: (e) => {
-      if (!drag) { clear(); return; }
-      const isSelf = drag.group === group && drag.idx === idx;
-      const into = !!o.container && !isSelf;
-      const crossGroup = !into && drag.group !== group;
-      if (crossGroup && !accepts(o, drag.group)) { clear(); return; }
-      e.preventDefault();
-      if (into) {
-        onNest?.({ fromGroup: drag.group, from: drag.idx, targetIdx: idx, zone: o.containerZone ?? null });
-      } else if (crossGroup) {
-        // Un-nest: drop the foreign row among this group's rows at the drop edge.
-        // No self-shift — the item leaves a different group, so `to` isn't perturbed.
-        const where: DropWhere = over ? over.where : "after";
-        const to = where === "after" ? idx + 1 : idx;
-        onNest?.({ fromGroup: drag.group, from: drag.idx, targetIdx: to, zone: null });
-      } else {
-        const where: DropWhere = over ? over.where : "after";
-        let to = where === "after" ? idx + 1 : idx;
-        if (drag.idx < to) to -= 1; // account for the gap the removed item leaves
-        onReorder?.({ group, from: drag.idx, to, where, targetIdx: idx, zone: o.ownZone });
-      }
-      clear();
-    },
-  });
+    return {
+      draggable: true,
+      onDragStart: (e) => {
+        setDrag({ group, idx });
+        e.dataTransfer.effectAllowed = "move";
+        const payload = o.dragPayload?.() ?? `${group}:${idx}`;
+        try { e.dataTransfer.setData("text/plain", payload); } catch { /* IE guard */ }
+        o.onStart?.();
+      },
+      onDragEnd: () => { clear(); o.onEnd?.(); },
+      onDragOver: (e) => {
+        if (!drag) return;
+        const isSelf = drag.group === group && drag.idx === idx;
+        const into = !!o.container && !isSelf; // a container accepts any item except itself
+        const crossGroup = !into && drag.group !== group;
+        // Reorder only within the same group, unless this row accepts a cross-group
+        // drop (un-nest): then show a before/after line and route through onNest.
+        if (crossGroup && !accepts(o, drag.group)) return;
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "move";
+        const where: DropWhere = into ? "into" : edgeWhere(e, o.axis ?? "y");
+        if (!over || over.group !== group || over.idx !== idx || over.where !== where)
+          setOver({ group, idx, where });
+      },
+      onDrop: (e) => {
+        if (!drag) { clear(); return; }
+        const isSelf = drag.group === group && drag.idx === idx;
+        const into = !!o.container && !isSelf;
+        const crossGroup = !into && drag.group !== group;
+        if (crossGroup && !accepts(o, drag.group)) { clear(); return; }
+        e.preventDefault();
+        if (into) {
+          onNest?.({ fromGroup: drag.group, from: drag.idx, targetIdx: idx, zone: o.containerZone ?? null });
+        } else if (crossGroup) {
+          // Un-nest: drop the foreign row among this group's rows at the drop edge.
+          // No self-shift — the item leaves a different group, so `to` isn't perturbed.
+          const where: DropWhere = over ? over.where : "after";
+          const to = where === "after" ? idx + 1 : idx;
+          onNest?.({ fromGroup: drag.group, from: drag.idx, targetIdx: to, zone: null });
+        } else {
+          const where: DropWhere = over ? over.where : "after";
+          let to = where === "after" ? idx + 1 : idx;
+          if (drag.idx < to) to -= 1; // account for the gap the removed item leaves
+          onReorder?.({ group, from: drag.idx, to, where, targetIdx: idx, zone: o.ownZone });
+        }
+        clear();
+      },
+    };
   };
 
   // Drop target for an empty container body (nest with no sibling rows to hover).
   // Inert (no drop handlers) when disabled.
   const nestProps = (group: string, idx: number, zone: string | null): Pick<Handlers, "onDragOver" | "onDrop"> => {
     if (!enabled) return {};
-    return ({
-    onDragOver: (e) => {
-      if (!drag) return;
-      e.preventDefault();
-      e.dataTransfer.dropEffect = "move";
-      if (!over || over.group !== group || over.idx !== idx || over.where !== "into")
-        setOver({ group, idx, where: "into" });
-    },
-    onDrop: (e) => {
-      if (!drag) return;
-      e.preventDefault();
-      onNest?.({ fromGroup: drag.group, from: drag.idx, targetIdx: idx, zone });
-      clear();
-    },
-  });
+    return {
+      onDragOver: (e) => {
+        if (!drag) return;
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "move";
+        if (!over || over.group !== group || over.idx !== idx || over.where !== "into")
+          setOver({ group, idx, where: "into" });
+      },
+      onDrop: (e) => {
+        if (!drag) return;
+        e.preventDefault();
+        onNest?.({ fromGroup: drag.group, from: drag.idx, targetIdx: idx, zone });
+        clear();
+      },
+    };
   };
 
   // " dragging" on the source + " drop-before|after|into" on the hovered target.

--- a/src/OscSheet/features/notes/EditableContent.tsx
+++ b/src/OscSheet/features/notes/EditableContent.tsx
@@ -14,9 +14,11 @@ export default function EditableContent({
   name: string;
   value: string;
 }) {
-  const { actor, updateActor } = useOscSheetContext();
+  const { actor, updateActor, canEdit } = useOscSheetContext();
   const [enriched, setEnriched] = useState<string>("");
-  const [editing, setEditing] = useState(false);
+  const [editing, setEditingState] = useState(false);
+  // Read-only sheets never enter edit mode.
+  const setEditing = (v: boolean) => setEditingState(v && canEdit);
 
   // Foundry's content-links/editor resolve colours from its OWN theme scope
   // (`.themed.theme-{light,dark}`), independent of our sheet theme — so a cream
@@ -64,15 +66,17 @@ export default function EditableContent({
         </div>
       ) : (
         <div className={`osc-rt themed ${fdTheme}`}>
-          <IconButton
-            variant="accent"
-            className="osc-rt-edit"
-            title={`Edit ${title}`}
-            aria-label={`Edit ${title}`}
-            onClick={() => setEditing(true)}
-          >
-            <i className="fa-solid fa-pen-to-square" aria-hidden="true" />
-          </IconButton>
+          {canEdit && (
+            <IconButton
+              variant="accent"
+              className="osc-rt-edit"
+              title={`Edit ${title}`}
+              aria-label={`Edit ${title}`}
+              onClick={() => setEditing(true)}
+            >
+              <i className="fa-solid fa-pen-to-square" aria-hidden="true" />
+            </IconButton>
+          )}
           {enriched.trim() ? (
             <div className="osc-rt-body" dangerouslySetInnerHTML={{ __html: enriched }} />
           ) : (

--- a/src/OscSheet/features/notes/EditableContent.tsx
+++ b/src/OscSheet/features/notes/EditableContent.tsx
@@ -16,9 +16,7 @@ export default function EditableContent({
 }) {
   const { actor, updateActor, canEdit } = useOscSheetContext();
   const [enriched, setEnriched] = useState<string>("");
-  const [editing, setEditingState] = useState(false);
-  // Read-only sheets never enter edit mode.
-  const setEditing = (v: boolean) => setEditingState(v && canEdit);
+  const [editing, setEditing] = useState(false);
 
   // Foundry's content-links/editor resolve colours from its OWN theme scope
   // (`.themed.theme-{light,dark}`), independent of our sheet theme — so a cream

--- a/src/OscSheet/features/spells/SpellCastRow.tsx
+++ b/src/OscSheet/features/spells/SpellCastRow.tsx
@@ -16,6 +16,8 @@ type Props = {
   onOpenName?: () => void;
   /** Row wrapper class — "osc-spell" (Spells tab + Actions quick-cast). */
   rowClass: string;
+  /** Read-only sheets hide the cast button (casting spends a slot). Default true. */
+  canCast?: boolean;
 };
 
 /**
@@ -26,7 +28,7 @@ type Props = {
  *
  * `total` slots = max(memorized, cast); `cast` of them are still ready.
  */
-export function SpellCastRow({ spell, meta, onCast, onUnprepare, onOpenName, rowClass }: Props) {
+export function SpellCastRow({ spell, meta, onCast, onUnprepare, onOpenName, rowClass, canCast = true }: Props) {
   const left = spell.system.cast ?? 0;
   const total = Math.max(spell.system.memorized ?? 0, left);
   const spent = left <= 0;
@@ -72,18 +74,20 @@ export function SpellCastRow({ spell, meta, onCast, onUnprepare, onOpenName, row
         </span>
         <span className="spm">{meta}</span>
       </div>
-      <span className="sp-actions">
-        <button
-          type="button"
-          className="sp-cast"
-          disabled={spent || casting}
-          aria-busy={casting}
-          onClick={handleCast}
-          title={spent ? `${spell.name} — spent (Rest to recover)` : `Cast ${spell.name}`}
-        >
-          {casting ? <i className="fa-solid fa-spinner fa-spin" aria-hidden="true" /> : spent ? "spent" : "cast"}
-        </button>
-      </span>
+      {canCast && (
+        <span className="sp-actions">
+          <button
+            type="button"
+            className="sp-cast"
+            disabled={spent || casting}
+            aria-busy={casting}
+            onClick={handleCast}
+            title={spent ? `${spell.name} — spent (Rest to recover)` : `Cast ${spell.name}`}
+          >
+            {casting ? <i className="fa-solid fa-spinner fa-spin" aria-hidden="true" /> : spent ? "spent" : "cast"}
+          </button>
+        </span>
+      )}
     </div>
   );
 }

--- a/src/OscSheet/features/spells/SpellLevel.tsx
+++ b/src/OscSheet/features/spells/SpellLevel.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useOscSheetContext } from "@app/context";
 import type { OseSpell } from "@domain/types";
 import type { SpellLevelVM } from "@domain/vm-types";
 import { spellMeta } from "@features/spells/spells";
@@ -11,6 +12,7 @@ import { Pips } from "@ui/Pips";
  * the prepared-spell cast rows, and an expandable spellbook of all known spells.
  */
 export default function SpellLevel({ vm }: { vm: SpellLevelVM }) {
+  const { canEdit } = useOscSheetContext();
   const { level, slots, occupied, prepared, spellbook } = vm;
   const [bookOpen, setBookOpen] = useState(false);
 
@@ -68,8 +70,9 @@ export default function SpellLevel({ vm }: { vm: SpellLevelVM }) {
                 {p.text}
               </span>
             ))}
+            canCast={canEdit}
             onCast={() => cast(spell)}
-            onUnprepare={() => unprepare(spell)}
+            onUnprepare={canEdit ? () => unprepare(spell) : undefined}
             onOpenName={() => spell.sheet.render(true)}
           />
         ))
@@ -90,6 +93,14 @@ export default function SpellLevel({ vm }: { vm: SpellLevelVM }) {
             <div className="osc-book-empty">No spells known at this level.</div>
           ) : (
             spellbook.map((spell) => {
+              // Read-only: list known spells as static rows (no memorise action).
+              if (!canEdit) {
+                return (
+                  <span key={spell._id as string} className="osc-bookspell is-static">
+                    <span className="bn">{spell.name}</span>
+                  </span>
+                );
+              }
               // Spellbook always MEMORISES (adds a copy) up to the level's free
               // slots — always a "+", never a checkmark, and no "prepared"
               // highlight (adding one is reflected in the prepared rows above).

--- a/src/OscSheet/features/spells/SpellsView.tsx
+++ b/src/OscSheet/features/spells/SpellsView.tsx
@@ -10,7 +10,7 @@ import SpellLevel from "@features/spells/SpellLevel";
  * spellbook). Rest re-memorises every spell (restores `cast` to `memorized`).
  */
 export default function Spells() {
-  const { actor } = useOscSheetContext();
+  const { actor, canEdit } = useOscSheetContext();
   const levels = selectSpellLevels(actor);
   const [resting, setResting] = useState(false);
 
@@ -37,20 +37,22 @@ export default function Spells() {
       <SectionTitle className="osc-spells-title">
         Spells
         <span className="hint">memorised slots</span>
-        <button
-          type="button"
-          className="osc-rest"
-          onClick={rest}
-          disabled={resting}
-          aria-busy={resting}
-          title="Re-memorise all spells"
-        >
-          <i
-            className={cx("fa-solid", resting ? "fa-spinner fa-spin" : "fa-campground")}
-            aria-hidden="true"
-          />{" "}
-          Rest
-        </button>
+        {canEdit && (
+          <button
+            type="button"
+            className="osc-rest"
+            onClick={rest}
+            disabled={resting}
+            aria-busy={resting}
+            title="Re-memorise all spells"
+          >
+            <i
+              className={cx("fa-solid", resting ? "fa-spinner fa-spin" : "fa-campground")}
+              aria-hidden="true"
+            />{" "}
+            Rest
+          </button>
+        )}
       </SectionTitle>
       {levels.map((vm) => (
         <SpellLevel key={vm.level} vm={vm} />

--- a/src/OscSheet/index.tsx
+++ b/src/OscSheet/index.tsx
@@ -15,7 +15,13 @@ import { useEffect, useRef, type ReactNode } from "react";
 /** App root element. Theme is owned by the window (osc-sheet.js `_onRender`
  *  sets data-theme on this.element from the client setting), so this only stops
  *  mousedown bubbling into Foundry. */
-function ThemedRoot({ children }: { children: ReactNode }) {
+function ThemedRoot({
+  children,
+  canEdit,
+}: {
+  children: ReactNode;
+  canEdit: boolean;
+}) {
   const appRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -27,8 +33,14 @@ function ThemedRoot({ children }: { children: ReactNode }) {
     return () => el.removeEventListener("mousedown", stopPropagation);
   }, []);
 
+  // Read-only mode marker for non-owners: a broad CSS hook + a11y signal that
+  // rides alongside the per-control React gating below.
   return (
-    <div className="osc-sheet-app" ref={appRef}>
+    <div
+      className={`osc-sheet-app${canEdit ? "" : " is-readonly"}`}
+      aria-readonly={canEdit ? undefined : true}
+      ref={appRef}
+    >
       {children}
     </div>
   );
@@ -38,15 +50,20 @@ function OscSheetApp({
   actor,
   source,
   contextConnector,
+  isEditable,
 }: OscSheetAppProps) {
+  // Prefer Foundry's authoritative `sheet.isEditable`; fall back to ownership
+  // when mounted outside a Foundry sheet (Storybook / tests).
+  const canEdit = isEditable ?? actor?.isOwner ?? false;
   return (
-    <ThemedRoot>
+    <ThemedRoot canEdit={canEdit}>
       <SheetErrorBoundary actor={actor}>
         <ToastProvider>
           <OscSheetProvider
             initialActor={actor!}
             source={source!}
             contextConnector={contextConnector}
+            canEdit={canEdit}
           >
             <OptimisticProvider>
               <SheetShell />

--- a/src/OscSheet/index.tsx
+++ b/src/OscSheet/index.tsx
@@ -33,12 +33,12 @@ function ThemedRoot({
     return () => el.removeEventListener("mousedown", stopPropagation);
   }, []);
 
-  // Read-only mode marker for non-owners: a broad CSS hook + a11y signal that
-  // rides alongside the per-control React gating below.
+  // Read-only mode marker for non-owners: a broad CSS hook that rides alongside
+  // the per-control React gating below. (No aria-readonly — it's inert on a
+  // role-less div; the individual controls carry their own a11y state.)
   return (
     <div
       className={`osc-sheet-app${canEdit ? "" : " is-readonly"}`}
-      aria-readonly={canEdit ? undefined : true}
       ref={appRef}
     >
       {children}

--- a/src/OscSheet/layout/Topbar.tsx
+++ b/src/OscSheet/layout/Topbar.tsx
@@ -3,13 +3,19 @@ import type { TopbarVM } from "@domain/vm-types";
 import { toggleTheme } from "@src/OscSheet/theme";
 import { FEATURES } from "@app/features";
 
-type Props = { vm: TopbarVM; onEdit: () => void; onLevelUp: () => void };
+type Props = {
+  vm: TopbarVM;
+  onEdit: () => void;
+  onLevelUp: () => void;
+  /** When false (read-only sheet) the character-editing actions are omitted. */
+  canEdit?: boolean;
+};
 
 /** Persistent topbar: level, XP, and sheet controls. The bar stays dark in both
  *  themes (--ink). Rest and Level Up are gated behind FEATURES until implemented;
  *  Edit opens the Edit Character modal; the theme toggle is live. At XS the
  *  action buttons collapse into a ⋮ overflow menu. */
-export function Topbar({ vm, onEdit, onLevelUp }: Props) {
+export function Topbar({ vm, onEdit, onLevelUp, canEdit = true }: Props) {
   const pct = vm.pct;
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -26,7 +32,9 @@ export function Topbar({ vm, onEdit, onLevelUp }: Props) {
     return () => document.removeEventListener("mousedown", onDown);
   }, [menuOpen]);
 
-  const actionButtons = (
+  // Character-editing actions (Rest/Level Up/Edit) are owner-only; the theme
+  // toggle below stays available to everyone (client-side setting).
+  const actionButtons = canEdit ? (
     <>
       {FEATURES.rest && (
         <button type="button" className="osc-tb-btn" disabled>
@@ -45,7 +53,7 @@ export function Topbar({ vm, onEdit, onLevelUp }: Props) {
         <span className="lbl">Edit</span>
       </button>
     </>
-  );
+  ) : null;
 
   return (
     <div className="osc-topbar-inner">
@@ -65,18 +73,21 @@ export function Topbar({ vm, onEdit, onLevelUp }: Props) {
       </div>
       {/* Inline actions (hidden at XS via .osc-tb-actions display:none) */}
       <div className="osc-tb-actions">{actionButtons}</div>
-      {/* XS overflow ⋮ (hidden above XS via .osc-tb-overflow display:none) */}
-      <div className="osc-tb-menu-wrap" ref={menuRef}>
-        <button
-          type="button"
-          className="osc-tb-btn osc-tb-overflow"
-          aria-label="More actions"
-          onClick={() => setMenuOpen((o) => !o)}
-        >
-          <span className="i" aria-hidden="true">⋮</span>
-        </button>
-        {menuOpen && <div className="osc-tb-menu">{actionButtons}</div>}
-      </div>
+      {/* XS overflow ⋮ (hidden above XS via .osc-tb-overflow display:none). Only
+          shown when there are owner actions to collapse into it. */}
+      {actionButtons && (
+        <div className="osc-tb-menu-wrap" ref={menuRef}>
+          <button
+            type="button"
+            className="osc-tb-btn osc-tb-overflow"
+            aria-label="More actions"
+            onClick={() => setMenuOpen((o) => !o)}
+          >
+            <span className="i" aria-hidden="true">⋮</span>
+          </button>
+          {menuOpen && <div className="osc-tb-menu">{actionButtons}</div>}
+        </div>
+      )}
       <button
         type="button"
         className="osc-tb-btn icon"

--- a/src/OscSheet/styles/styles.scss
+++ b/src/OscSheet/styles/styles.scss
@@ -172,14 +172,8 @@
 
 // Read-only mode (observers / non-owners): the sheet renders view-only. Write
 // affordances are gated out per-control in React; this class is the broad,
-// consistent signal plus a defensive net. `[data-owner-only]` is the CSS-only
-// escape hatch for owner-only controls not yet React-gated (e.g. inventory,
-// pending the OLD-40 follow-up) — mark such a control and it stays hidden here.
+// consistent CSS signal for the residual static bits.
 .osc-sheet-app.is-readonly {
-  [data-owner-only] {
-    display: none !important;
-  }
-
   // Inventory: drag handles are meaningless without drag (disabled for non-owners),
   // so hide them; the equipped indicator renders as a static, non-interactive glyph.
   .osc-inv-drag {

--- a/src/OscSheet/styles/styles.scss
+++ b/src/OscSheet/styles/styles.scss
@@ -169,3 +169,14 @@
     text-decoration: none;
   }
 }
+
+// Read-only mode (observers / non-owners): the sheet renders view-only. Write
+// affordances are gated out per-control in React; this class is the broad,
+// consistent signal plus a defensive net. `[data-owner-only]` is the CSS-only
+// escape hatch for owner-only controls not yet React-gated (e.g. inventory,
+// pending the OLD-40 follow-up) — mark such a control and it stays hidden here.
+.osc-sheet-app.is-readonly {
+  [data-owner-only] {
+    display: none !important;
+  }
+}

--- a/src/OscSheet/styles/styles.scss
+++ b/src/OscSheet/styles/styles.scss
@@ -179,4 +179,14 @@
   [data-owner-only] {
     display: none !important;
   }
+
+  // Inventory: drag handles are meaningless without drag (disabled for non-owners),
+  // so hide them; the equipped indicator renders as a static, non-interactive glyph.
+  .osc-inv-drag {
+    display: none;
+  }
+  .osc-inv-equip.is-static {
+    cursor: default;
+    pointer-events: none;
+  }
 }

--- a/src/applications/osc-sheet.js
+++ b/src/applications/osc-sheet.js
@@ -162,6 +162,9 @@ class OscSheet extends ReactActorSheetV2 {
       actor: context.document,
       source: context.source,
       contextConnector: this.contextConnector,
+      // Foundry's authoritative edit gate (ownership + lock/compendium state).
+      // React falls back to actor.isOwner when this is absent (Storybook/tests).
+      isEditable: this.isEditable,
     };
     return context;
   }

--- a/tools/e2e/README.md
+++ b/tools/e2e/README.md
@@ -32,11 +32,11 @@ PRs run automatically; fork PRs need a maintainer's `safe-to-test` label.
 
 ### Read-only (non-owner) coverage
 
-`specs/readonly.spec.ts` drives the sheet as `observerPage` and asserts the
-NON-INVENTORY tabs expose no edit affordances (HP steppers, editable portrait,
-Edit modal, per-tab edit controls). Inventory read-only gating is deferred to a
-follow-up after OLD-40 restructures the inventory view — the spec carries a
-clearly-marked `TODO(OLD-40 follow-up)` where those assertions will go.
+`specs/readonly.spec.ts` drives the sheet as `observerPage` and asserts every tab
+exposes no edit affordances: HP steppers, editable portrait, Edit modal, and
+per-tab edit controls (abilities/notes), plus the inventory tab — no equip
+toggles, no draggable rows/tray tiles/coin grips, disabled coin qty, and a
+view-only item context menu (only "View Item").
 
 ## Running locally
 

--- a/tools/e2e/README.md
+++ b/tools/e2e/README.md
@@ -25,9 +25,18 @@ PRs run automatically; fork PRs need a maintainer's `safe-to-test` label.
 | --- | --- |
 | `setup-data-dir.sh` | Assembles a Foundry `/data` dir: the pinned OSE release (`OSE_VERSION`, default 2.2.2; `compatibility.verified` bumped to `14` for CI), the freshly-built osc-character-sheet module (`module.json` + `dist` + `lang`), and the minimal `e2e` world fixture. |
 | `activate-world.mjs` | First-boot activation: `--phase eula` accepts the EULA (generates the host-bound license signature), the caller restarts the container so felddy's `FOUNDRY_WORLD` auto-launches the world, `--phase await` polls `/api/status` until active. |
-| `global-setup.ts` | Joins as Gamemaster, enables the osc-character-sheet module + reloads, and seeds the `E2E Fighter` character (weapon/armor/coins) pinned to the OSC sheet. Runs once before the specs. |
-| `helpers.ts` | `joinAsGM`, `openCharacterSheet` (forces the wide layout), chat/item readers. |
-| `specs/*.spec.ts` | One spec per core flow: smoke, tabs, ability, save, attack, equip, coin. |
+| `global-setup.ts` | Joins as Gamemaster, enables the osc-character-sheet module + reloads, seeds the `E2E Fighter` character (weapon/armor/coins) pinned to the OSC sheet, and seeds a passwordless `E2E Observer` PLAYER user with OBSERVER (view-only) permission on that actor. Runs once before the specs. |
+| `helpers.ts` | `joinAsUser` / `joinAsGM`, `openCharacterSheet` (forces the wide layout), chat/item readers. |
+| `fixtures.ts` | Worker-scoped `gamePage` (Gamemaster) and `observerPage` (the `E2E Observer` view-only player) — each its own browser context against the one shared server. |
+| `specs/*.spec.ts` | One spec per core flow: smoke, tabs, ability, save, attack, equip, coin, and `readonly` (non-owner view-only sheet). |
+
+### Read-only (non-owner) coverage
+
+`specs/readonly.spec.ts` drives the sheet as `observerPage` and asserts the
+NON-INVENTORY tabs expose no edit affordances (HP steppers, editable portrait,
+Edit modal, per-tab edit controls). Inventory read-only gating is deferred to a
+follow-up after OLD-40 restructures the inventory view — the spec carries a
+clearly-marked `TODO(OLD-40 follow-up)` where those assertions will go.
 
 ## Running locally
 

--- a/tools/e2e/fixtures.ts
+++ b/tools/e2e/fixtures.ts
@@ -1,5 +1,5 @@
 import { test as base, expect, type Page } from "@playwright/test";
-import { joinAsGM, closeDialogs } from "./helpers";
+import { joinAsGM, joinAsUser, closeDialogs, OBSERVER_NAME } from "./helpers";
 
 /**
  * Foundry's `game.ready` boot (~40s on a 2-core CI runner under software WebGL)
@@ -12,10 +12,12 @@ import { joinAsGM, closeDialogs } from "./helpers";
  * and one seeded actor, and their assertions are written relatively
  * (before/after counts, !wasEquipped), so order independence holds.
  *
- * A second user (player-vs-GM permission tests) would add its own context/page
- * fixture — not needed yet.
+ * `observerPage` is the second user: its own context/page joined as the seeded
+ * passwordless OBSERVER player (view-only permission on the fixture actor). It
+ * drives the read-only-sheet spec. Kept worker-scoped for the same boot-cost
+ * reason as `gamePage`.
  */
-export const test = base.extend<object, { gamePage: Page }>({
+export const test = base.extend<object, { gamePage: Page; observerPage: Page }>({
   gamePage: [
     async ({ browser }, use) => {
       const context = await browser.newContext({
@@ -23,6 +25,18 @@ export const test = base.extend<object, { gamePage: Page }>({
       });
       const page = await context.newPage();
       await joinAsGM(page);
+      await use(page);
+      await context.close();
+    },
+    { scope: "worker" },
+  ],
+  observerPage: [
+    async ({ browser }, use) => {
+      const context = await browser.newContext({
+        viewport: { width: 1920, height: 1080 },
+      });
+      const page = await context.newPage();
+      await joinAsUser(page, OBSERVER_NAME);
       await use(page);
       await context.close();
     },

--- a/tools/e2e/global-setup.ts
+++ b/tools/e2e/global-setup.ts
@@ -1,5 +1,5 @@
 import { chromium, type FullConfig } from "@playwright/test";
-import { joinAsGM, ACTOR_NAME } from "./helpers";
+import { joinAsGM, ACTOR_NAME, OBSERVER_NAME } from "./helpers";
 
 const URL = (process.env.FOUNDRY_URL || "http://localhost:30000").replace(/\/$/, "");
 const MODULE_ID = "osc-character-sheet";
@@ -75,6 +75,27 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
         await actor.setFlag("core", "sheetClass", sheetClass);
       },
       { name: ACTOR_NAME, sheetClass: SHEET_CLASS },
+    );
+
+    // Seed a passwordless PLAYER user with OBSERVER (view-only) permission on the
+    // fixture actor — drives the read-only-sheet spec (a non-owner opening a
+    // character they don't own). Idempotent: recreate the user each run.
+    await page.evaluate(
+      async ({ actorName, userName }) => {
+        const g = globalThis as any;
+        const existing = g.game.users.getName(userName);
+        if (existing) await existing.delete();
+        const user = await g.User.create({
+          name: userName,
+          role: g.CONST.USER_ROLES.PLAYER, // 1
+        });
+        const actor = g.game.actors.getName(actorName);
+        // OBSERVER (2): can view the sheet, cannot edit. Owner (GM) stays intact.
+        await actor.update({
+          [`ownership.${user.id}`]: g.CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER,
+        });
+      },
+      { actorName: ACTOR_NAME, userName: OBSERVER_NAME },
     );
 
     // Sanity: actor exists and resolves the OSC sheet class.

--- a/tools/e2e/helpers.ts
+++ b/tools/e2e/helpers.ts
@@ -1,14 +1,17 @@
 import type { Page, Locator } from "@playwright/test";
 
 export const ACTOR_NAME = "E2E Fighter";
+/** Passwordless player user seeded by global-setup with OBSERVER (view-only)
+ *  permission on ACTOR_NAME — drives the read-only sheet spec. */
+export const OBSERVER_NAME = "E2E Observer";
 const URL = (process.env.FOUNDRY_URL || "http://localhost:30000").replace(/\/$/, "");
 
 declare const game: any;
 declare const foundry: any;
 declare const Actor: any;
 
-/** Join the running world as the passwordless Gamemaster and wait for game.ready. */
-export async function joinAsGM(page: Page): Promise<void> {
+/** Join the running world as a named passwordless user and wait for game.ready. */
+export async function joinAsUser(page: Page, label: string): Promise<void> {
   await page.goto(`${URL}/join`, { waitUntil: "domcontentloaded" });
   const userSelect = page.locator('select[name="userid"]');
   await userSelect.waitFor({ timeout: 30_000 });
@@ -17,11 +20,16 @@ export async function joinAsGM(page: Page): Promise<void> {
     for (const o of document.querySelectorAll('select[name="userid"] option'))
       (o as HTMLOptionElement).disabled = false;
   });
-  await userSelect.selectOption({ label: "Gamemaster" });
+  await userSelect.selectOption({ label });
   await page.click('button[name="join"]');
   await page.waitForFunction(() => (globalThis as any).game?.ready === true, null, {
     timeout: 120_000,
   });
+}
+
+/** Join the running world as the passwordless Gamemaster and wait for game.ready. */
+export async function joinAsGM(page: Page): Promise<void> {
+  await joinAsUser(page, "Gamemaster");
 }
 
 /**

--- a/tools/e2e/specs/readonly.spec.ts
+++ b/tools/e2e/specs/readonly.spec.ts
@@ -1,19 +1,44 @@
 import { test, expect } from "../fixtures";
-import { openCharacterSheet } from "../helpers";
+import { openCharacterSheet, closeDialogs } from "../helpers";
 
 /**
  * Read-only sheet for non-owners (OLD-41). Logs in as the seeded OBSERVER player
  * (view-only permission on the fixture actor — see global-setup) and asserts the
  * whole sheet — every tab, including inventory — exposes no way to mutate the
  * character: no HP steppers, no editable portrait, no Edit modal, no per-tab edit
- * controls, and (inventory) no drag, no equip toggle, no coin edit, no mutating
- * context-menu items. The sheet must stay fully readable throughout.
+ * controls, no writing Attack roll, and (inventory) no drag, no equip toggle, no
+ * coin edit, no mutating context-menu items. The sheet must stay fully readable.
+ *
+ * Chat-only rolls (ability/save/exploration/hit/dmg — post a card, no actor write)
+ * intentionally stay available; only affordances that WRITE the actor are gated.
  */
 
 // Fighter (non-caster) tabs minus inventory; spells is hidden (not a caster).
 const NON_INVENTORY_TABS = ["actions", "abilities", "notes"] as const;
 
+// Await the tab body's stable anchor before running negative (toHaveCount(0))
+// assertions, so they can't pass vacuously by racing the async tab-body render.
+const TAB_ANCHOR: Record<(typeof NON_INVENTORY_TABS)[number], string> = {
+  actions: ".osc-atk",
+  abilities: ".osc-abilities-tab",
+  notes: ".osc-notes-tab",
+};
+
 test.describe("read-only sheet (non-owner)", () => {
+  // observerPage is worker-scoped + shared, so tidy up anything this spec opened
+  // (context menu, dialogs) and capture the observer sheet on failure — the global
+  // afterEach only covers gamePage.
+  test.afterEach(async ({ observerPage }, testInfo) => {
+    await observerPage.keyboard.press("Escape").catch(() => {});
+    if (testInfo.status !== testInfo.expectedStatus) {
+      await observerPage
+        .screenshot({ path: testInfo.outputPath("observer-failure.png"), fullPage: true })
+        .then((buf) => testInfo.attach("observer-failure", { body: buf, contentType: "image/png" }))
+        .catch(() => {});
+    }
+    await closeDialogs(observerPage);
+  });
+
   test("observer sees a view-only sheet with no edit affordances", async ({
     observerPage,
   }) => {
@@ -45,10 +70,17 @@ test.describe("read-only sheet (non-owner)", () => {
       const tab = sheet.locator(`[data-testid="tab-${id}"]`);
       await tab.click();
       await expect(tab).toHaveAttribute("aria-selected", "true");
+      // Wait for the tab body to actually render before the negative assertions.
+      await expect(sheet.locator(TAB_ANCHOR[id])).toBeVisible();
 
+      if (id === "actions") {
+        // The equipped Dagger renders a weapon row (so its Attack button WOULD be
+        // here if not gated) — but the writing Attack affordance is owner-only.
+        await expect(sheet.locator('[data-testid^="weapon-row-"]').first()).toBeVisible();
+        await expect(sheet.locator('[data-testid^="weapon-attack-"]')).toHaveCount(0);
+      }
       if (id === "abilities") {
         await expect(sheet.locator('[aria-label="Add ability"]')).toHaveCount(0);
-        await expect(sheet.locator('[aria-label="Delete ability"]')).toHaveCount(0);
         await expect(sheet.locator('[aria-label="Edit languages"]')).toHaveCount(0);
       }
       if (id === "notes") {
@@ -61,9 +93,10 @@ test.describe("read-only sheet (non-owner)", () => {
     await inventoryTab.click();
     await expect(inventoryTab).toHaveAttribute("aria-selected", "true");
 
-    // Readable: the wealth toggle + at least one item row render.
+    // Wait for a REAL item row (not the sticky sort-header) before negatives.
+    const itemRow = sheet.locator(".osc-inv-row:not(.osc-inv-headrow)").first();
+    await expect(itemRow).toBeVisible();
     await expect(sheet.locator('[data-testid="wealth-toggle"]')).toBeVisible();
-    await expect(sheet.locator(".osc-inv-row").first()).toBeVisible();
 
     // No equip toggle buttons (owner-only; observers get a static indicator).
     await expect(sheet.locator('[data-testid^="equip-"]')).toHaveCount(0);
@@ -79,12 +112,35 @@ test.describe("read-only sheet (non-owner)", () => {
     await expect(coinQty).toBeDisabled();
 
     // Item context menu is view-only: only "View Item", no Send/Unequip/Consume/Delete.
-    await sheet.locator(".osc-inv-row").first().click({ button: "right" });
+    await itemRow.click({ button: "right" });
     const menu = sheet.locator(".osc-ctx");
     await expect(menu).toBeVisible();
     await expect(menu.locator(".osc-ctx-item")).toHaveCount(1);
     await expect(menu.locator(".osc-ctx-item")).toHaveText(/View Item/);
     await expect(menu.locator(".osc-ctx-item.is-danger")).toHaveCount(0);
-    await observerPage.keyboard.press("Escape");
+  });
+
+  // Control: the OWNER (GM) sheet renders the very affordances the observer lacks,
+  // so the observer's toHaveCount(0) checks above aren't passing vacuously.
+  test("owner sheet exposes the affordances the observer is denied", async ({
+    gamePage,
+  }) => {
+    const sheet = await openCharacterSheet(gamePage);
+    // Owner sheet is editable → no read-only marker.
+    await expect(sheet.locator(".osc-sheet-app.is-readonly")).toHaveCount(0);
+
+    // Owner keeps HP steppers + the Edit action.
+    await expect(sheet.locator(".vv-step").first()).toBeVisible();
+    await expect(sheet.locator(".osc-tb-actions .osc-tb-btn")).not.toHaveCount(0);
+
+    // Actions tab: the writing Attack button is present for the owner.
+    await sheet.locator('[data-testid="tab-actions"]').click();
+    await expect(sheet.locator('[data-testid^="weapon-attack-"]').first()).toBeVisible();
+
+    // Inventory tab: equip toggle buttons + draggable rows are present for the owner.
+    await sheet.locator('[data-testid="tab-inventory"]').click();
+    await expect(sheet.locator('.osc-inv-row:not(.osc-inv-headrow)').first()).toBeVisible();
+    await expect(sheet.locator('[data-testid^="equip-"]').first()).toBeVisible();
+    await expect(sheet.locator('.osc-inv-row[draggable="true"]')).not.toHaveCount(0);
   });
 });

--- a/tools/e2e/specs/readonly.spec.ts
+++ b/tools/e2e/specs/readonly.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "../fixtures";
+import { openCharacterSheet } from "../helpers";
+
+/**
+ * Read-only sheet for non-owners (OLD-41). Logs in as the seeded OBSERVER player
+ * (view-only permission on the fixture actor — see global-setup) and asserts the
+ * NON-INVENTORY tabs expose no way to mutate the character: no HP steppers, no
+ * editable portrait, no Edit modal, no per-tab edit controls. The sheet must stay
+ * fully readable throughout.
+ *
+ * NOTE: the inventory tab is intentionally NOT asserted here — its read-only
+ * gating (drag-reorder/nest, equip toggles, quantity steppers, coin edits) lands
+ * as a follow-up after OLD-40 restructures the inventory. See the TODO below.
+ */
+
+// Fighter (non-caster) tabs minus inventory; spells is hidden (not a caster).
+const NON_INVENTORY_TABS = ["actions", "abilities", "notes"] as const;
+
+test.describe("read-only sheet (non-owner)", () => {
+  test("observer sees a view-only sheet with no edit affordances", async ({
+    observerPage,
+  }) => {
+    const sheet = await openCharacterSheet(observerPage);
+    await expect(sheet).toBeVisible();
+
+    // Root affordance suppression marker is present (owner sheets omit it).
+    await expect(observerPage.locator(".osc-sheet-app.is-readonly")).toHaveCount(1);
+
+    // --- Persistent header + topbar: no character-edit affordances ---
+    // HP steppers / editable HP input (owner-only; static value stays).
+    await expect(sheet.locator(".vv-step")).toHaveCount(0);
+    await expect(sheet.locator("input.vv-input")).toHaveCount(0);
+    await expect(sheet.locator(".osc-mb-hp-btn")).toHaveCount(0);
+    await expect(sheet.locator("input.osc-mb-hp-input")).toHaveCount(0);
+    // Portrait click-to-edit action is not wired for non-owners.
+    await expect(sheet.locator('img[data-action="editImage"]')).toHaveCount(0);
+    // Topbar character actions (Rest / Level Up / Edit + overflow) are gone;
+    // the theme toggle (.osc-tb-btn.icon) stays for everyone.
+    await expect(sheet.locator(".osc-tb-actions .osc-tb-btn")).toHaveCount(0);
+    await expect(sheet.locator(".osc-tb-menu-wrap")).toHaveCount(0);
+
+    // Sheet is still readable: HP value + AC render.
+    await expect(sheet.locator(".vv-value").first()).toBeVisible();
+    await expect(sheet.locator('[data-testid="ac-value"]')).toBeVisible();
+
+    // --- Each non-inventory tab: readable, no edit controls ---
+    for (const id of NON_INVENTORY_TABS) {
+      const tab = sheet.locator(`[data-testid="tab-${id}"]`);
+      await tab.click();
+      await expect(tab).toHaveAttribute("aria-selected", "true");
+
+      if (id === "abilities") {
+        await expect(sheet.locator('[aria-label="Add ability"]')).toHaveCount(0);
+        await expect(sheet.locator('[aria-label="Delete ability"]')).toHaveCount(0);
+        await expect(sheet.locator('[aria-label="Edit languages"]')).toHaveCount(0);
+      }
+      if (id === "notes") {
+        await expect(sheet.locator(".osc-rt-edit")).toHaveCount(0);
+      }
+    }
+
+    // TODO(OLD-40 follow-up): switch to the inventory tab and assert its
+    // read-only gating — no drag handles, no equip toggles, no quantity/coin
+    // steppers, no delete/send controls. Deferred until OLD-40 restructures the
+    // inventory view (owned by that PR; do not touch its files here).
+  });
+});

--- a/tools/e2e/specs/readonly.spec.ts
+++ b/tools/e2e/specs/readonly.spec.ts
@@ -4,13 +4,10 @@ import { openCharacterSheet } from "../helpers";
 /**
  * Read-only sheet for non-owners (OLD-41). Logs in as the seeded OBSERVER player
  * (view-only permission on the fixture actor — see global-setup) and asserts the
- * NON-INVENTORY tabs expose no way to mutate the character: no HP steppers, no
- * editable portrait, no Edit modal, no per-tab edit controls. The sheet must stay
- * fully readable throughout.
- *
- * NOTE: the inventory tab is intentionally NOT asserted here — its read-only
- * gating (drag-reorder/nest, equip toggles, quantity steppers, coin edits) lands
- * as a follow-up after OLD-40 restructures the inventory. See the TODO below.
+ * whole sheet — every tab, including inventory — exposes no way to mutate the
+ * character: no HP steppers, no editable portrait, no Edit modal, no per-tab edit
+ * controls, and (inventory) no drag, no equip toggle, no coin edit, no mutating
+ * context-menu items. The sheet must stay fully readable throughout.
  */
 
 // Fighter (non-caster) tabs minus inventory; spells is hidden (not a caster).
@@ -59,9 +56,35 @@ test.describe("read-only sheet (non-owner)", () => {
       }
     }
 
-    // TODO(OLD-40 follow-up): switch to the inventory tab and assert its
-    // read-only gating — no drag handles, no equip toggles, no quantity/coin
-    // steppers, no delete/send controls. Deferred until OLD-40 restructures the
-    // inventory view (owned by that PR; do not touch its files here).
+    // --- Inventory tab: fully view-only ---
+    const inventoryTab = sheet.locator('[data-testid="tab-inventory"]');
+    await inventoryTab.click();
+    await expect(inventoryTab).toHaveAttribute("aria-selected", "true");
+
+    // Readable: the wealth toggle + at least one item row render.
+    await expect(sheet.locator('[data-testid="wealth-toggle"]')).toBeVisible();
+    await expect(sheet.locator(".osc-inv-row").first()).toBeVisible();
+
+    // No equip toggle buttons (owner-only; observers get a static indicator).
+    await expect(sheet.locator('[data-testid^="equip-"]')).toHaveCount(0);
+    // No draggable rows / tray tiles / coin grips (drag disabled for non-owners).
+    await expect(sheet.locator('.osc-inv-row[draggable="true"]')).toHaveCount(0);
+    await expect(sheet.locator('.osc-equip-tcard[draggable="true"]')).toHaveCount(0);
+    await expect(sheet.locator('.osc-inv-drag[draggable="true"]')).toHaveCount(0);
+
+    // Coin quantity is view-only (open the wealth table first).
+    await sheet.locator('[data-testid="wealth-toggle"]').click();
+    const coinQty = sheet.locator('[data-testid="coin-qty-gp"]');
+    await expect(coinQty).toBeVisible();
+    await expect(coinQty).toBeDisabled();
+
+    // Item context menu is view-only: only "View Item", no Send/Unequip/Consume/Delete.
+    await sheet.locator(".osc-inv-row").first().click({ button: "right" });
+    const menu = sheet.locator(".osc-ctx");
+    await expect(menu).toBeVisible();
+    await expect(menu.locator(".osc-ctx-item")).toHaveCount(1);
+    await expect(menu.locator(".osc-ctx-item")).toHaveText(/View Item/);
+    await expect(menu.locator(".osc-ctx-item.is-danger")).toHaveCount(0);
+    await observerPage.keyboard.press("Escape");
   });
 });


### PR DESCRIPTION
## What

Global read-only mode so non-owners (observer/limited) get a view-only character sheet.

- **`canEdit` gate** on the sheet context. Derived from Foundry's authoritative `sheet.isEditable` (threaded through `_prepareContext` → `initialProps`), falling back to `actor.isOwner` when mounted outside a Foundry sheet (Storybook/tests). Exposed via `useOscSheetContext()`.
- **`is-readonly` root class** on `.osc-sheet-app` when `!canEdit`, plus minimal CSS (defensive `[data-owner-only]` suppression hook) as a broad, consistent signal.
- **Gated non-inventory write surfaces**: portrait click-to-edit, header/minibar HP steppers, Topbar Edit/Level Up (+ overflow), notes edit, ability add/delete, languages edit, spell rest/prepare/cast. Everything stays readable.
- **E2E**: seeds a passwordless `E2E Observer` player with OBSERVER permission on the fixture actor; new `observerPage` fixture + `readonly.spec.ts` walks each non-inventory tab asserting no edit affordances.

## Deferred to post-OLD-40 (do not block on this PR)

OLD-40 concurrently restructures the inventory, so its files are untouched here. Landing after it merges:

- **Inventory read-only gating**: drag-reorder/nest, equip toggles, quantity steppers, coin edits, delete/send.
- **Inventory e2e coverage**: the inventory-tab assertions — marked with a `TODO(OLD-40 follow-up)` in `readonly.spec.ts`.

## Gate

`pnpm lint && pnpm test && pnpm build` all green (134 tests). E2E requires a live Foundry server (CI/local harness), not part of the unit gate.