### PR TITLE
feat: beta release channel — rolling beta/module.json (OLD-42)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,12 @@
 # never becomes what releases/latest/download (i.e. Foundry auto-update)
 # resolves to. They are also NOT pushed to the registry.
 #
+# Beta channel (OLD-42): on EVERY published release we re-stamp module.json with
+# the beta variant (manifest self-references releases/download/beta/module.json)
+# and clobber module.json + module.zip onto a fixed, prerelease `beta` release.
+# An instance installed from releases/download/beta/module.json thus rolls
+# through every build, prereleases included, without ever becoming "latest".
+#
 # The Sentry endpoint comes from the repo Actions variable VITE_SENTRY_DSN
 # (crash reports are only ever sent when a user presses the button — see
 # README). No DSN variable ⇒ the build ships with reporting compiled out.
@@ -78,6 +84,25 @@ jobs:
       # time (avoids an asset gap); these CI-built ones are canonical.
       - name: Attach assets to the release
         run: gh release upload "$TAG" build/module.zip module.json --clobber
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      # Rolling beta channel (OLD-42): runs on every published release, prerelease
+      # or not. Re-stamp the beta variant of module.json (self-referential manifest
+      # → releases/download/beta/module.json) and re-zip so module.zip embeds it —
+      # reuses this run's dist/, no rebuild. Then clobber both assets onto a fixed
+      # `beta` release, creating it (marked prerelease so it never becomes "latest")
+      # the first time. Idempotent on re-runs: create is guarded by a view check and
+      # --clobber overwrites existing assets.
+      - name: Update rolling beta channel
+        run: |
+          VERSION="${TAG#v}"
+          node tools/package.mjs "$VERSION" "$TAG" --beta
+          gh release view beta >/dev/null 2>&1 \
+            || gh release create beta --prerelease --target "$TAG" \
+                 --title "Beta channel (rolling)" \
+                 --notes "Rolling beta channel — always the newest build (prereleases included). Install once from releases/download/beta/module.json and Foundry auto-updates through every release."
+          gh release upload beta build/module.zip module.json --clobber
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/tools/package.mjs
+++ b/tools/package.mjs
@@ -41,6 +41,7 @@ const tag = tagArg || version;
 const manifest = JSON.parse(readFileSync("./module.json", "utf8"));
 manifest.version = version;
 if (beta) {
+  manifest.title = `${manifest.title} [Beta]`;
   manifest.manifest = `${manifest.url}/releases/download/beta/module.json`;
   manifest.download = `${manifest.url}/releases/download/beta/module.zip`;
 } else {

--- a/tools/package.mjs
+++ b/tools/package.mjs
@@ -2,35 +2,55 @@
 // Single source for the packaged file list + release-URL conventions — used
 // by CI (.github/workflows/release.yml) and the local release script.
 //
-// Usage: node tools/package.mjs <version> [tag]
+// Usage: node tools/package.mjs <version> [tag] [--beta]
 //   version — semver stamped into module.json (no leading v)
 //   tag     — the git/release tag the download URL points at (defaults to
 //             version; this repo tags bare versions, but a v-prefixed tag
 //             still yields a working URL)
+//   --beta  — stamp the BETA-channel variant (see below). Off by default; the
+//             default stable stamping is byte-for-byte unchanged.
 //
 // URL conventions (Foundry auto-update):
-//   manifest → releases/latest/download/module.json — a STABLE url; GitHub's
-//              "latest" is the newest non-prerelease, non-draft release, so
-//              prereleases never become what updaters resolve.
-//   download → releases/download/<tag>/module.zip — pinned to THIS release.
+//   Default (stable):
+//     manifest → releases/latest/download/module.json — a STABLE url; GitHub's
+//                "latest" is the newest non-prerelease, non-draft release, so
+//                prereleases never become what updaters resolve.
+//     download → releases/download/<tag>/module.zip — pinned to THIS release.
+//   --beta (rolling beta channel, OLD-42):
+//     manifest → releases/download/beta/module.json — SELF-REFERENTIAL, points
+//                at the fixed `beta` tag whose assets CI re-clobbers on every
+//                published release, so a beta install keeps polling beta (not
+//                latest) and rides every build, prereleases included.
+//     download → releases/download/beta/module.zip — the rolling beta zip.
+//   version is the plain X.Y.Z from the tag in both modes (no -beta labels;
+//   Foundry's isNewerVersion mishandles prerelease labels).
 
 import { execSync } from "child_process";
 import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 
-const [version, tagArg] = process.argv.slice(2);
+const args = process.argv.slice(2);
+const beta = args.includes("--beta");
+const [version, tagArg] = args.filter((a) => a !== "--beta");
 if (!/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(version ?? "")) {
-  console.error("Usage: node tools/package.mjs <semver-version> [tag]");
+  console.error("Usage: node tools/package.mjs <semver-version> [tag] [--beta]");
   process.exit(1);
 }
 const tag = tagArg || version;
 
 const manifest = JSON.parse(readFileSync("./module.json", "utf8"));
 manifest.version = version;
-manifest.manifest = `${manifest.url}/releases/latest/download/module.json`;
-manifest.download = `${manifest.url}/releases/download/${tag}/module.zip`;
+if (beta) {
+  manifest.manifest = `${manifest.url}/releases/download/beta/module.json`;
+  manifest.download = `${manifest.url}/releases/download/beta/module.zip`;
+} else {
+  manifest.manifest = `${manifest.url}/releases/latest/download/module.json`;
+  manifest.download = `${manifest.url}/releases/download/${tag}/module.zip`;
+}
 writeFileSync("./module.json", JSON.stringify(manifest, null, 2) + "\n");
-console.log(`Stamped module.json ${version} (download → ${manifest.download})`);
+console.log(
+  `Stamped module.json ${version}${beta ? " [beta]" : ""} (download → ${manifest.download})`,
+);
 
 // Maps live in Sentry, not the zip — strip the refs so DevTools doesn't chase 404s.
 for (const file of readdirSync("dist", { recursive: true })) {


### PR DESCRIPTION
## What

Adds a rolling **beta** release channel: a fixed-tag GitHub release whose `module.json` self-references, so a Foundry instance subscribed to it auto-updates through *every* published release, prereleases included. No new server — the fixed `beta` release is the whole mechanism.

Foundry has no package-level channels; auto-update just polls a manifest URL and compares versions with `isNewerVersion` (which mishandles `-beta` labels). So the channel is a stable URL that always resolves to the newest build, and versions stay plain `X.Y.Z`. `releases/latest/...` can't serve this because GitHub's `latest` excludes prereleases.

## Changes

- **`tools/package.mjs`** — opt-in `--beta` flag. Stamps `manifest → releases/download/beta/module.json` (self-referential, so a beta install keeps polling beta) and `download → releases/download/beta/module.zip`. Version stays the plain tag version. Default (stable) stamping is byte-for-byte unchanged.
- **`.github/workflows/release.yml`** — new step on *every* published release, after the stable stamp+attach: re-stamps the beta variant (reusing this run's `dist/`, no rebuild), then `gh release upload --clobber`s `module.json` + `module.zip` onto a fixed `beta` release — created (marked prerelease, so it never becomes `latest`) if absent, guarded by a `gh release view` check for idempotency. Existing per-tag attach, `latest`, and stable-only registry push untouched.

No `-beta` version labeling — the prerelease distinction stays on the GitHub Release flag only.

## Subscribe

Install once from `https://github.com/tasandberg/osc-character-sheet/releases/download/beta/module.json`; Foundry auto-updates through every release thereafter.

## Verify

`pnpm lint`, `pnpm test` (134 passed), `pnpm build` all green. Exercised `package.mjs` both ways: default → `manifest: releases/latest/...`; `--beta` → `manifest`/`download: releases/download/beta/...`; version correct in both. `module.json` restored (CI stamps it at release time).

Fixes OSC-42