### PR TITLE
fix(ci): beta release create + promote prereleases to the registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,20 @@
-# Publish release → attach artifacts, push registry (stable only), roll beta channel.
-# Tag = version; prereleases never become "latest". See OLD-42 for the beta channel.
+# On publish: attach artifacts + roll the beta channel (every release, prereleases
+# included — OLD-42). On `released` (stable publish OR a prerelease promoted to full):
+# push the registry. Split because `released` never fires for prereleases, and the
+# registry only ever wants full releases. Tag = version.
 name: Release
 
 on:
   release:
-    types: [published]
+    types: [published, released]
 
 permissions:
   contents: write # gh release upload
 
 jobs:
   attach-artifacts:
+    # Publish only — a stable publish also fires `released`, which would double-run this.
+    if: github.event.action == 'published'
     runs-on: ubuntu-latest
     # Use tag_name, not GITHUB_REF (unreliable when the publish creates the tag).
     env:
@@ -63,19 +67,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      # Dry-run then POST; idempotent (already-released → 400 treated as success).
-      # Before the beta step so a beta failure can't block the stable publish.
-      - name: Publish to Foundry package registry
-        run: |
-          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
-            echo "Prerelease — skipping registry publish."
-            exit 0
-          fi
-          node tools/publish-registry.mjs "$TAG" --dry-run
-          node tools/publish-registry.mjs "$TAG"
-        env:
-          FOUNDRY_RELEASE_TOKEN: ${{ secrets.FOUNDRY_RELEASE_TOKEN }}
-
       # Re-stamp/zip the beta variant and clobber onto the fixed prerelease `beta`
       # release (created once). No --target: it needs a commitish, not a tag, and
       # the beta tag's commit is irrelevant — only its clobbered assets are used.
@@ -90,3 +81,27 @@ jobs:
           gh release upload beta build/module.zip module.json --clobber
         env:
           GH_TOKEN: ${{ github.token }}
+
+  # `released` fires on a stable publish and when a prerelease is promoted to full,
+  # but never for prereleases — so the registry only ever sees full releases here,
+  # no prerelease guard needed. No build: publish-registry reads the tag + static
+  # module.json fields (id/url/compatibility).
+  publish-registry:
+    if: github.event.action == 'released'
+    runs-on: ubuntu-latest
+    env:
+      TAG: ${{ github.event.release.tag_name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      # Dry-run then POST; idempotent (already-released → 400 treated as success).
+      - name: Publish to Foundry package registry
+        run: |
+          node tools/publish-registry.mjs "$TAG" --dry-run
+          node tools/publish-registry.mjs "$TAG"
+        env:
+          FOUNDRY_RELEASE_TOKEN: ${{ secrets.FOUNDRY_RELEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,29 +87,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      # Rolling beta channel (OLD-42): runs on every published release, prerelease
-      # or not. Re-stamp the beta variant of module.json (self-referential manifest
-      # → releases/download/beta/module.json) and re-zip so module.zip embeds it —
-      # reuses this run's dist/, no rebuild. Then clobber both assets onto a fixed
-      # `beta` release, creating it (marked prerelease so it never becomes "latest")
-      # the first time. Idempotent on re-runs: create is guarded by a view check and
-      # --clobber overwrites existing assets.
-      - name: Update rolling beta channel
-        run: |
-          VERSION="${TAG#v}"
-          node tools/package.mjs "$VERSION" "$TAG" --beta
-          gh release view beta >/dev/null 2>&1 \
-            || gh release create beta --prerelease --target "$TAG" \
-                 --title "Beta channel (rolling)" \
-                 --notes "Rolling beta channel — always the newest build (prereleases included). Install once from releases/download/beta/module.json and Foundry auto-updates through every release."
-          gh release upload beta build/module.zip module.json --clobber
-        env:
-          GH_TOKEN: ${{ github.token }}
-
       # Dry-run validates the payload registry-side without saving, then the
       # real POST publishes. Re-runs are idempotent: an already-released
       # version comes back 400 unique_together, which the script treats as
       # success; any other registry error fails the job.
+      # Runs BEFORE the rolling-beta step so a beta hiccup can never block the
+      # canonical stable publish (the beta channel is a convenience layer).
       - name: Publish to Foundry package registry
         run: |
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then
@@ -120,3 +103,25 @@ jobs:
           node tools/publish-registry.mjs "$TAG"
         env:
           FOUNDRY_RELEASE_TOKEN: ${{ secrets.FOUNDRY_RELEASE_TOKEN }}
+
+      # Rolling beta channel (OLD-42): runs on every published release, prerelease
+      # or not. Re-stamp the beta variant of module.json (self-referential manifest
+      # → releases/download/beta/module.json) and re-zip so module.zip embeds it —
+      # reuses this run's dist/, no rebuild. Then clobber both assets onto a fixed
+      # `beta` release, creating it (marked prerelease so it never becomes "latest")
+      # the first time. Idempotent on re-runs: create is guarded by a view check and
+      # --clobber overwrites existing assets.
+      # No --target: it takes a commitish, not a tag; letting it default to the
+      # repo's default branch always resolves, and the beta tag's commit is
+      # irrelevant since only its (clobbered) assets are consumed.
+      - name: Update rolling beta channel
+        run: |
+          VERSION="${TAG#v}"
+          node tools/package.mjs "$VERSION" "$TAG" --beta
+          gh release view beta >/dev/null 2>&1 \
+            || gh release create beta --prerelease \
+                 --title "Beta channel (rolling)" \
+                 --notes "Rolling beta channel — always the newest build (prereleases included). Install once from releases/download/beta/module.json and Foundry auto-updates through every release."
+          gh release upload beta build/module.zip module.json --clobber
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,5 @@
-# Attaches the Foundry module artifacts (module.json + module.zip) when a
-# GitHub Release is published. The release tag is the source of truth for the
-# version: tools/package.mjs stamps module.json from it in the runner (an
-# optional leading "v" is stripped, so both `0.5.0` and `v0.5.0` work) and
-# points `download` at THIS release's zip and `manifest` at
-# releases/latest/download/module.json.
-#
-# After the assets are attached, the version is pushed to the Foundry package
-# registry (tools/publish-registry.mjs) so the public listing updates.
-#
-# Prereleases: they get assets like any release, but GitHub's "latest" is the
-# newest non-prerelease, non-draft release — so a release marked prerelease
-# never becomes what releases/latest/download (i.e. Foundry auto-update)
-# resolves to. They are also NOT pushed to the registry.
-#
-# Beta channel (OLD-42): on EVERY published release we re-stamp module.json with
-# the beta variant (manifest self-references releases/download/beta/module.json)
-# and clobber module.json + module.zip onto a fixed, prerelease `beta` release.
-# An instance installed from releases/download/beta/module.json thus rolls
-# through every build, prereleases included, without ever becoming "latest".
-#
-# The Sentry endpoint comes from the repo Actions variable VITE_SENTRY_DSN
-# (crash reports are only ever sent when a user presses the button — see
-# README). No DSN variable ⇒ the build ships with reporting compiled out.
+# Publish release → attach artifacts, push registry (stable only), roll beta channel.
+# Tag = version; prereleases never become "latest". See OLD-42 for the beta channel.
 name: Release
 
 on:
@@ -34,8 +12,7 @@ permissions:
 jobs:
   attach-artifacts:
     runs-on: ubuntu-latest
-    # GITHUB_REF is unreliable here: publishing a release that creates its tag
-    # can fire the event with ref still on the target branch. tag_name is not.
+    # Use tag_name, not GITHUB_REF (unreliable when the publish creates the tag).
     env:
       TAG: ${{ github.event.release.tag_name }}
     steps:
@@ -63,7 +40,7 @@ jobs:
         env:
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
 
-      # Before the zip step (it strips dist map refs); release must match crashReporter.ts's tag.
+      # Before zip (strips map refs); release tag must match crashReporter.ts.
       - name: Upload source maps to Sentry
         run: |
           VERSION="${TAG#v}"
@@ -80,19 +57,14 @@ jobs:
           VERSION="${TAG#v}"
           node tools/package.mjs "$VERSION" "$TAG"
 
-      # --clobber: pnpm release already uploads locally built assets at create
-      # time (avoids an asset gap); these CI-built ones are canonical.
+      # --clobber: overwrite the local assets pnpm release uploaded at create time.
       - name: Attach assets to the release
         run: gh release upload "$TAG" build/module.zip module.json --clobber
         env:
           GH_TOKEN: ${{ github.token }}
 
-      # Dry-run validates the payload registry-side without saving, then the
-      # real POST publishes. Re-runs are idempotent: an already-released
-      # version comes back 400 unique_together, which the script treats as
-      # success; any other registry error fails the job.
-      # Runs BEFORE the rolling-beta step so a beta hiccup can never block the
-      # canonical stable publish (the beta channel is a convenience layer).
+      # Dry-run then POST; idempotent (already-released → 400 treated as success).
+      # Before the beta step so a beta failure can't block the stable publish.
       - name: Publish to Foundry package registry
         run: |
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then
@@ -104,16 +76,9 @@ jobs:
         env:
           FOUNDRY_RELEASE_TOKEN: ${{ secrets.FOUNDRY_RELEASE_TOKEN }}
 
-      # Rolling beta channel (OLD-42): runs on every published release, prerelease
-      # or not. Re-stamp the beta variant of module.json (self-referential manifest
-      # → releases/download/beta/module.json) and re-zip so module.zip embeds it —
-      # reuses this run's dist/, no rebuild. Then clobber both assets onto a fixed
-      # `beta` release, creating it (marked prerelease so it never becomes "latest")
-      # the first time. Idempotent on re-runs: create is guarded by a view check and
-      # --clobber overwrites existing assets.
-      # No --target: it takes a commitish, not a tag; letting it default to the
-      # repo's default branch always resolves, and the beta tag's commit is
-      # irrelevant since only its (clobbered) assets are consumed.
+      # Re-stamp/zip the beta variant and clobber onto the fixed prerelease `beta`
+      # release (created once). No --target: it needs a commitish, not a tag, and
+      # the beta tag's commit is irrelevant — only its clobbered assets are used.
       - name: Update rolling beta channel
         run: |
           VERSION="${TAG#v}"

--- a/tools/publish-registry.mjs
+++ b/tools/publish-registry.mjs
@@ -1,7 +1,8 @@
 // Push a release to the Foundry package registry
 // (https://foundryvtt.com/article/package-release-api/) so the public
-// listing updates. Reads id/version/compatibility from the stamped
-// module.json (run tools/package.mjs first). The registry wants a
+// listing updates. Version comes from the tag; id/compatibility/url are read
+// from the committed module.json (all static) — so this needs no build/stamp
+// and can run standalone (e.g. the promote job). The registry wants a
 // VERSION-PINNED manifest URL, so it's built from the tag
 // (releases/download/<tag>/module.json) — NOT module.json's stable
 // `manifest` field, which floats with releases/latest.
@@ -31,12 +32,13 @@ if (!token) {
   process.exit(1);
 }
 
+const version = tag.replace(/^v/, "");
 const manifest = JSON.parse(readFileSync("./module.json", "utf8"));
 const body = {
   id: manifest.id,
   ...(dryRun && { "dry-run": true }),
   release: {
-    version: manifest.version,
+    version,
     manifest: `${manifest.url}/releases/download/${tag}/module.json`,
     notes: `${manifest.url}/releases/tag/${tag}`,
     compatibility: manifest.compatibility,


### PR DESCRIPTION
PR #71's first release (`1.0.1`, a prerelease) failed at **Update rolling beta channel**: `gh release create beta --target "$TAG"` — `--target` needs a commitish, not a tag → `422 target_commitish invalid`, so the `beta` release never got created. Under `bash -e` that also halted the job before later steps.

## Changes
- **Fix the beta create**: drop `--target "$TAG"` (defaults to the default branch; the beta tag's commit is irrelevant — only its clobbered assets are used).
- **Promote prereleases automatically**: split the registry push into its own `publish-registry` job triggered on `released`. That event fires on a stable publish *and* when a prerelease is flipped to a full release, but **never** for prereleases — so unchecking "pre-release" on a prerelease now pushes it to the registry with no manual step.
  - `attach-artifacts` is gated to `action == 'published'` so a stable publish (which fires both `published` and `released`) doesn't double-run the build.
  - The registry job needs no build: `publish-registry.mjs` now takes the version from the tag and reads only static fields (id/url/compatibility) from `module.json`.
- Aggressively trimmed the workflow comments.

## Event → what runs
| Action | attach + beta (`published`) | registry (`released`) |
|---|---|---|
| Publish prerelease | ✓ | — |
| Publish stable | ✓ | ✓ |
| Promote prerelease → full | — | ✓ |

## Verify
`pnpm lint`, `pnpm test` (138) green. YAML validated. `publish-registry.mjs v1.2.3 --dry-run` → version `1.2.3`, manifest pinned to `releases/download/v1.2.3/module.json`.

## Follow-up (not in this PR)
`1.0.1` was a prerelease, so it correctly skipped the registry — nothing to push. Its only casualty was the `beta` release (never created due to the bug), which self-heals on the next published release after this merges. No manual step needed.
