### PR TITLE
style(notes): sans body + accent blockquote for rich-text prose (OSC-45)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,13 @@ React OSE character sheet for Foundry v13/v14. Consumes `foundry-vtt-react`; ren
 `ose` system's data model. Manifest is `module.json`. Workspace-level cross-project context
 lives in `../CLAUDE.md`.
 
+## Code comments (hard rule)
+
+- Default to NO comment. Add one ONLY for a constraint the code can't show.
+- If you must: ONE short line. Never multi-line blocks or paragraphs.
+- NEVER reference Linear tickets (OSC-##) in code comments — that context lives in the PR/commit.
+- No rationale / tool-choice / background prose in source; it goes in the PR or commit message.
+
 ## Dev
 
 - pnpm. `pnpm dev` (vite, serves into local Foundry), `pnpm build` (`tsc -b && vite build`),

--- a/src/OscSheet/components/ui/RichText.tsx
+++ b/src/OscSheet/components/ui/RichText.tsx
@@ -1,15 +1,7 @@
 import { getThemeSetting } from "@src/OscSheet/theme";
 import { cx } from "@ui/cx";
 
-/**
- * Canonical long-form prose renderer for enriched rich-text HTML (Notes,
- * ability descriptions, …). Single source of truth for rendered prose.
- *
- * Wraps content in Foundry's theme scope (`.themed.theme-{light,dark}`) so the
- * enricher's content-link / prose colours resolve against OUR sheet theme —
- * without it, content inherits Foundry's light-theme dark text (black-on-dark).
- * Applies the shared `.osc-rich-text-body` prose style. Pass already-enriched HTML.
- */
+// Renders enriched HTML in Foundry's theme scope so content colours resolve against our theme.
 export function RichText({ html, className }: { html: string; className?: string }) {
   const fdTheme = getThemeSetting() === "cream" ? "theme-light" : "theme-dark";
   return (

--- a/src/OscSheet/components/ui/RichText.tsx
+++ b/src/OscSheet/components/ui/RichText.tsx
@@ -1,0 +1,21 @@
+import { getThemeSetting } from "@src/OscSheet/theme";
+import { cx } from "@ui/cx";
+
+/**
+ * Canonical long-form prose renderer for enriched rich-text HTML (Notes,
+ * ability descriptions, …). Single source of truth for rendered prose.
+ *
+ * Wraps content in Foundry's theme scope (`.themed.theme-{light,dark}`) so the
+ * enricher's content-link / prose colours resolve against OUR sheet theme —
+ * without it, content inherits Foundry's light-theme dark text (black-on-dark).
+ * Applies the shared `.osc-rich-text-body` prose style. Pass already-enriched HTML.
+ */
+export function RichText({ html, className }: { html: string; className?: string }) {
+  const fdTheme = getThemeSetting() === "cream" ? "theme-light" : "theme-dark";
+  return (
+    <div
+      className={cx("osc-rich-text-body", "themed", fdTheme, className)}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/src/OscSheet/components/ui/index.ts
+++ b/src/OscSheet/components/ui/index.ts
@@ -13,6 +13,7 @@ export { Field, Input } from "./Field";
 export { ValidatedInput } from "./ValidatedInput";
 export { Textarea } from "./Textarea";
 export { ProseMirrorEditor } from "./ProseMirrorEditor";
+export { RichText } from "./RichText";
 export { Select } from "./Select";
 export { Stepper } from "./Stepper";
 export { Toggle } from "./Toggle";

--- a/src/OscSheet/features/abilities/FeatureCard.tsx
+++ b/src/OscSheet/features/abilities/FeatureCard.tsx
@@ -4,6 +4,7 @@ import { useOscSheetContext } from "@app/context";
 import { cx } from "@ui/cx";
 import { IconButton } from "@ui/IconButton";
 import { Monogram } from "@ui/Monogram";
+import { RichText } from "@ui/RichText";
 
 /** Enrich raw HTML once via Foundry's TextEditor (links, inline rolls, embeds). */
 function useEnriched(html: string): string {
@@ -90,10 +91,7 @@ export function FeatureCard({ feature }: { feature: FeatureVM }) {
       </div>
       {open && (
         <div className="ft-body">
-          <div
-            className="osc-rich-text-body"
-            dangerouslySetInnerHTML={{ __html: desc }}
-          />
+          <RichText html={desc} />
           {canEdit && (
             <div className="ft-actions">
               <IconButton

--- a/src/OscSheet/features/abilities/FeatureCard.tsx
+++ b/src/OscSheet/features/abilities/FeatureCard.tsx
@@ -91,7 +91,7 @@ export function FeatureCard({ feature }: { feature: FeatureVM }) {
       {open && (
         <div className="ft-body">
           <div
-            className="osc-rt-body"
+            className="osc-rich-text-body"
             dangerouslySetInnerHTML={{ __html: desc }}
           />
           {canEdit && (

--- a/src/OscSheet/features/abilities/FeatureCard.tsx
+++ b/src/OscSheet/features/abilities/FeatureCard.tsx
@@ -91,7 +91,7 @@ export function FeatureCard({ feature }: { feature: FeatureVM }) {
       {open && (
         <div className="ft-body">
           <div
-            className="ft-desc"
+            className="osc-rt-body"
             dangerouslySetInnerHTML={{ __html: desc }}
           />
           {canEdit && (

--- a/src/OscSheet/features/notes/EditableContent.tsx
+++ b/src/OscSheet/features/notes/EditableContent.tsx
@@ -3,6 +3,7 @@ import { useOscSheetContext } from "@app/context";
 import { SectionTitle } from "@ui/SectionTitle";
 import { IconButton } from "@ui/IconButton";
 import { ProseMirrorEditor } from "@ui/ProseMirrorEditor";
+import { RichText } from "@ui/RichText";
 import { getThemeSetting } from "@src/OscSheet/theme";
 
 export default function EditableContent({
@@ -63,7 +64,7 @@ export default function EditableContent({
           />
         </div>
       ) : (
-        <div className={`osc-rich-text themed ${fdTheme}`}>
+        <div className="osc-rich-text">
           {canEdit && (
             <IconButton
               variant="accent"
@@ -76,7 +77,7 @@ export default function EditableContent({
             </IconButton>
           )}
           {enriched.trim() ? (
-            <div className="osc-rich-text-body" dangerouslySetInnerHTML={{ __html: enriched }} />
+            <RichText html={enriched} />
           ) : (
             <p className="osc-rich-text-empty">No {title.toLowerCase()} yet.</p>
           )}

--- a/src/OscSheet/features/notes/EditableContent.tsx
+++ b/src/OscSheet/features/notes/EditableContent.tsx
@@ -63,11 +63,11 @@ export default function EditableContent({
           />
         </div>
       ) : (
-        <div className={`osc-rt themed ${fdTheme}`}>
+        <div className={`osc-rich-text themed ${fdTheme}`}>
           {canEdit && (
             <IconButton
               variant="accent"
-              className="osc-rt-edit"
+              className="osc-rich-text-edit"
               title={`Edit ${title}`}
               aria-label={`Edit ${title}`}
               onClick={() => setEditing(true)}
@@ -76,9 +76,9 @@ export default function EditableContent({
             </IconButton>
           )}
           {enriched.trim() ? (
-            <div className="osc-rt-body" dangerouslySetInnerHTML={{ __html: enriched }} />
+            <div className="osc-rich-text-body" dangerouslySetInnerHTML={{ __html: enriched }} />
           ) : (
-            <p className="osc-rt-empty">No {title.toLowerCase()} yet.</p>
+            <p className="osc-rich-text-empty">No {title.toLowerCase()} yet.</p>
           )}
         </div>
       )}

--- a/src/OscSheet/styles/features.scss
+++ b/src/OscSheet/styles/features.scss
@@ -74,7 +74,7 @@
 
 // Body indented under the title (past the 40px stamp + gap).
 .ft-body { padding: 0 var(--spacer-3) var(--spacer-3) 62px; }
-// Ability descriptions render the canonical `.osc-rt-body` long-form prose style
+// Ability descriptions render the canonical `.osc-rich-text-body` long-form prose style
 // (see notes.scss) — single source of truth for all enriched text blocks.
 .ft-actions {
   display: flex; align-items: center; justify-content: flex-end;

--- a/src/OscSheet/styles/features.scss
+++ b/src/OscSheet/styles/features.scss
@@ -74,8 +74,6 @@
 
 // Body indented under the title (past the 40px stamp + gap).
 .ft-body { padding: 0 var(--spacer-3) var(--spacer-3) 62px; }
-// Ability descriptions render the canonical `.osc-rich-text-body` long-form prose style
-// (see notes.scss) — single source of truth for all enriched text blocks.
 .ft-actions {
   display: flex; align-items: center; justify-content: flex-end;
   gap: var(--spacer-3);

--- a/src/OscSheet/styles/features.scss
+++ b/src/OscSheet/styles/features.scss
@@ -74,13 +74,8 @@
 
 // Body indented under the title (past the 40px stamp + gap).
 .ft-body { padding: 0 var(--spacer-3) var(--spacer-3) 62px; }
-.ft-desc {
-  font-family: "IM Fell English", Georgia, serif;
-  font-size: var(--fs-sm, 13px); color: var(--text-dim, #b5ad97); line-height: 1.45;
-  // enriched HTML may carry its own block elements
-  p { margin: 0 0 var(--spacer-2); }
-  p:last-child { margin-bottom: 0; }
-}
+// Ability descriptions render the canonical `.osc-rt-body` long-form prose style
+// (see notes.scss) — single source of truth for all enriched text blocks.
 .ft-actions {
   display: flex; align-items: center; justify-content: flex-end;
   gap: var(--spacer-3);

--- a/src/OscSheet/styles/notes.scss
+++ b/src/OscSheet/styles/notes.scss
@@ -9,7 +9,7 @@
 }
 
 // ── Static view card ───────────────────────────────────────────────────────
-.osc-rt {
+.osc-rich-text {
   position: relative;
   max-width: 640px; // comfortable reading measure, not the full tab width
   background: var(--bg-2, #1f1c17); // subtle: barely lifted off the page
@@ -17,33 +17,33 @@
   border-radius: var(--r-md, 6px);
   padding: var(--spacer-2, 8px) var(--spacer-3, 12px);
 }
-// Edit pencil, pinned top-right. Qualified with .osc-rt (0,2,0) so `position`
+// Edit pencil, pinned top-right. Qualified with .osc-rich-text (0,2,0) so `position`
 // beats the `.osc-sheet-app :is(button,…) { all: unset }` reset (0,1,1) —
 // otherwise it resets to static and drops into normal flow above the text.
-.osc-rt .osc-rt-edit { position: absolute; top: var(--spacer-2, 8px); right: var(--spacer-2, 8px); z-index: 2; }
+.osc-rich-text .osc-rich-text-edit { position: absolute; top: var(--spacer-2, 8px); right: var(--spacer-2, 8px); z-index: 2; }
 // Render prose in the readable UI sans; headings in the display face. Foundry's
 // enricher leaves headings a near-white colour — re-anchor to body.
-.osc-rt-body {
+.osc-rich-text-body {
   color: var(--text, #e7e0cc);
   font-family: var(--sans);
   font-size: var(--fs-lg, 16px);
   line-height: 1.55;
 }
-.osc-rt-body :is(h1, h2, h3, h4, h5, h6) { font-family: var(--display); color: var(--text, #e7e0cc); }
+.osc-rich-text-body :is(h1, h2, h3, h4, h5, h6) { font-family: var(--display); color: var(--text, #e7e0cc); }
 // Link/roll chips already inherit the sans body font.
-.osc-rt-body :is(a.content-link, a.inline-roll) { font-family: var(--sans); }
+.osc-rich-text-body :is(a.content-link, a.inline-roll) { font-family: var(--sans); }
 // Blockquote: no italic; a left accent bar that follows the sheet's active accent
 // (brass for PCs, teal for retainers — the --gold chain flips by data-kind, see
 // styles.scss), dimmed via color-mix so it reads as a rule. Left padding clears
 // the bar; default browser quote margins dropped for our own vertical rhythm.
-.osc-rt-body blockquote {
+.osc-rich-text-body blockquote {
   margin: var(--spacer-3, 12px) 0;
   padding-left: var(--spacer-3, 12px);
   border-left: 3px solid color-mix(in srgb, var(--gold) 55%, transparent);
 }
-.osc-rt-body :first-child { margin-top: 0; }
-.osc-rt-body :last-child { margin-bottom: 0; }
-.osc-rt-empty { margin: 0; color: var(--text-faint, #8a8270); font-style: italic; }
+.osc-rich-text-body :first-child { margin-top: 0; }
+.osc-rich-text-body :last-child { margin-bottom: 0; }
+.osc-rich-text-empty { margin: 0; color: var(--text-faint, #8a8270); font-style: italic; }
 
 // ── Edit mode (Foundry <prose-mirror>) ─────────────────────────────────────
 .osc-prosemirror { max-width: 640px; }

--- a/src/OscSheet/styles/notes.scss
+++ b/src/OscSheet/styles/notes.scss
@@ -40,7 +40,6 @@
   margin: var(--spacer-3, 12px) 0;
   padding-left: var(--spacer-3, 12px);
   border-left: 3px solid color-mix(in srgb, var(--gold) 55%, transparent);
-  font-style: normal;
 }
 .osc-rt-body :first-child { margin-top: 0; }
 .osc-rt-body :last-child { margin-bottom: 0; }

--- a/src/OscSheet/styles/notes.scss
+++ b/src/OscSheet/styles/notes.scss
@@ -21,28 +21,7 @@
 // beats the `.osc-sheet-app :is(button,…) { all: unset }` reset (0,1,1) —
 // otherwise it resets to static and drops into normal flow above the text.
 .osc-rich-text .osc-rich-text-edit { position: absolute; top: var(--spacer-2, 8px); right: var(--spacer-2, 8px); z-index: 2; }
-// Render prose in the readable UI sans; headings in the display face. Foundry's
-// enricher leaves headings a near-white colour — re-anchor to body.
-.osc-rich-text-body {
-  color: var(--text, #e7e0cc);
-  font-family: var(--sans);
-  font-size: var(--fs-lg, 16px);
-  line-height: 1.55;
-}
-.osc-rich-text-body :is(h1, h2, h3, h4, h5, h6) { font-family: var(--display); color: var(--text, #e7e0cc); }
-// Link/roll chips already inherit the sans body font.
-.osc-rich-text-body :is(a.content-link, a.inline-roll) { font-family: var(--sans); }
-// Blockquote: no italic; a left accent bar that follows the sheet's active accent
-// (brass for PCs, teal for retainers — the --gold chain flips by data-kind, see
-// styles.scss), dimmed via color-mix so it reads as a rule. Left padding clears
-// the bar; default browser quote margins dropped for our own vertical rhythm.
-.osc-rich-text-body blockquote {
-  margin: var(--spacer-3, 12px) 0;
-  padding-left: var(--spacer-3, 12px);
-  border-left: 3px solid color-mix(in srgb, var(--gold) 55%, transparent);
-}
-.osc-rich-text-body :first-child { margin-top: 0; }
-.osc-rich-text-body :last-child { margin-bottom: 0; }
+// Shared prose typography (.osc-rich-text-body) lives in rich-text.scss.
 .osc-rich-text-empty { margin: 0; color: var(--text-faint, #8a8270); font-style: italic; }
 
 // ── Edit mode (Foundry <prose-mirror>) ─────────────────────────────────────

--- a/src/OscSheet/styles/notes.scss
+++ b/src/OscSheet/styles/notes.scss
@@ -21,17 +21,27 @@
 // beats the `.osc-sheet-app :is(button,…) { all: unset }` reset (0,1,1) —
 // otherwise it resets to static and drops into normal flow above the text.
 .osc-rt .osc-rt-edit { position: absolute; top: var(--spacer-2, 8px); right: var(--spacer-2, 8px); z-index: 2; }
-// Render in the sheet's reading serif; headings in the display face. Foundry's
+// Render prose in the readable UI sans; headings in the display face. Foundry's
 // enricher leaves headings a near-white colour — re-anchor to body.
 .osc-rt-body {
   color: var(--text, #e7e0cc);
-  font-family: var(--serif);
+  font-family: var(--sans);
   font-size: var(--fs-lg, 16px);
   line-height: 1.55;
 }
 .osc-rt-body :is(h1, h2, h3, h4, h5, h6) { font-family: var(--display); color: var(--text, #e7e0cc); }
-// Keep Foundry's link/roll chips in the UI sans so they stay crisp in the serif prose.
+// Link/roll chips already inherit the sans body font.
 .osc-rt-body :is(a.content-link, a.inline-roll) { font-family: var(--sans); }
+// Blockquote: no italic; a left accent bar that follows the sheet's active accent
+// (brass for PCs, teal for retainers — the --gold chain flips by data-kind, see
+// styles.scss), dimmed via color-mix so it reads as a rule. Left padding clears
+// the bar; default browser quote margins dropped for our own vertical rhythm.
+.osc-rt-body blockquote {
+  margin: var(--spacer-3, 12px) 0;
+  padding-left: var(--spacer-3, 12px);
+  border-left: 3px solid color-mix(in srgb, var(--gold) 55%, transparent);
+  font-style: normal;
+}
 .osc-rt-body :first-child { margin-top: 0; }
 .osc-rt-body :last-child { margin-bottom: 0; }
 .osc-rt-empty { margin: 0; color: var(--text-faint, #8a8270); font-style: italic; }

--- a/src/OscSheet/styles/rich-text.scss
+++ b/src/OscSheet/styles/rich-text.scss
@@ -1,12 +1,4 @@
-// Canonical long-form prose style for Foundry-enriched rich text — the single
-// source of truth shared by Notes and ability descriptions (see the RichText
-// component). LOCAL, not vellum: it styles Foundry's enricher output
-// (`.content-link`, `.inline-roll`) and pairs with the Foundry `.themed` scope
-// the RichText component applies, so it's a Foundry-integration concern that
-// deliberately stays out of the pure design system.
-
-// Render prose in the readable UI sans; headings in the display face. Foundry's
-// enricher leaves headings a near-white colour — re-anchor to body.
+// Shared prose style for Foundry-enriched rich text (RichText component). Local, not vellum.
 .osc-rich-text-body {
   color: var(--text, #e7e0cc);
   font-family: var(--sans);
@@ -14,12 +6,8 @@
   line-height: 1.55;
 }
 .osc-rich-text-body :is(h1, h2, h3, h4, h5, h6) { font-family: var(--display); color: var(--text, #e7e0cc); }
-// Link/roll chips already inherit the sans body font.
 .osc-rich-text-body :is(a.content-link, a.inline-roll) { font-family: var(--sans); }
-// Blockquote: keep the default italic; a left accent bar that follows the sheet's
-// active accent (brass for PCs, teal for retainers — the --gold chain flips by
-// data-kind, see styles.scss), dimmed via color-mix so it reads as a rule. Left
-// padding clears the bar; default browser quote margins dropped for our rhythm.
+// Accent bar follows the active --gold (flips teal by data-kind).
 .osc-rich-text-body blockquote {
   margin: var(--spacer-3, 12px) 0;
   padding-left: var(--spacer-3, 12px);

--- a/src/OscSheet/styles/rich-text.scss
+++ b/src/OscSheet/styles/rich-text.scss
@@ -1,0 +1,29 @@
+// Canonical long-form prose style for Foundry-enriched rich text — the single
+// source of truth shared by Notes and ability descriptions (see the RichText
+// component). LOCAL, not vellum: it styles Foundry's enricher output
+// (`.content-link`, `.inline-roll`) and pairs with the Foundry `.themed` scope
+// the RichText component applies, so it's a Foundry-integration concern that
+// deliberately stays out of the pure design system.
+
+// Render prose in the readable UI sans; headings in the display face. Foundry's
+// enricher leaves headings a near-white colour — re-anchor to body.
+.osc-rich-text-body {
+  color: var(--text, #e7e0cc);
+  font-family: var(--sans);
+  font-size: var(--fs-lg, 16px);
+  line-height: 1.55;
+}
+.osc-rich-text-body :is(h1, h2, h3, h4, h5, h6) { font-family: var(--display); color: var(--text, #e7e0cc); }
+// Link/roll chips already inherit the sans body font.
+.osc-rich-text-body :is(a.content-link, a.inline-roll) { font-family: var(--sans); }
+// Blockquote: keep the default italic; a left accent bar that follows the sheet's
+// active accent (brass for PCs, teal for retainers — the --gold chain flips by
+// data-kind, see styles.scss), dimmed via color-mix so it reads as a rule. Left
+// padding clears the bar; default browser quote margins dropped for our rhythm.
+.osc-rich-text-body blockquote {
+  margin: var(--spacer-3, 12px) 0;
+  padding-left: var(--spacer-3, 12px);
+  border-left: 3px solid color-mix(in srgb, var(--gold) 55%, transparent);
+}
+.osc-rich-text-body :first-child { margin-top: 0; }
+.osc-rich-text-body :last-child { margin-bottom: 0; }

--- a/src/OscSheet/styles/styles.scss
+++ b/src/OscSheet/styles/styles.scss
@@ -5,6 +5,7 @@
 @use "features";
 @use "spells";
 @use "notes";
+@use "rich-text";
 @use "chat";
 
 /** Purely for namespacing default style overrides */


### PR DESCRIPTION
Styling pass on enriched rich-text prose in `.osc-rt-body` (character Notes/Biography).

- **Body font → sans.** Prose now renders in `--sans` (readable content font) instead of `--serif`. Headings keep `--display`.
- **Blockquotes.** Drop the browser-default italic; add a left accent bar that follows the sheet's active accent (the `--gold` chain — brass for PCs, teal for retainers, flipped by `data-kind`), dimmed via `color-mix`. Left padding clears the bar; default quote margins dropped for our own vertical rhythm.

Note: the ticket assumed feature/item descriptions also use `.osc-rt-body`, but `FeatureCard` renders into `.ft-desc` (its own serif rule), so only Notes/Biography are affected here. Flagged for follow-up if unifying is wanted.