### PR TITLE
docs(level-up): OSE advancement rules spec + calc fixtures (OSC-25)

### DIFF
--- a/docs/level-up-rules.md
+++ b/docs/level-up-rules.md
@@ -1,0 +1,211 @@
+# OSE Level-Up Rules & Computed-vs-Stored Decisions (OSC-25)
+
+Spec foundation for the Level Up project. Blocks OSC-46 (wizard UX), OSC-47
+(`classRules`→`oseRules`), OSC-48 (calc module). This doc + the fixture table at
+`src/OscSheet/domain/oseRules/__fixtures__/levelUp.fixtures.ts` are the contract the
+OSC-48 calc must satisfy. **No app UI here** — advancement rules and the
+computed-vs-stored map only.
+
+## Source data
+
+All progression ships as data in the `ose` system and is surfaced at runtime as
+`CONFIG.OSE.classes.classic`:
+
+- `ose-foundry-core/src/module/classes/classic-fantasy-classes.ts` — the 7 classic classes
+  (Cleric, Dwarf, Elf, Fighter, Halfling, Magic-User, Thief).
+- `ose-foundry-core/src/module/classes/types.ts` — the `OseClass` shape. Each
+  `levels[level-1]` row = `{ xp, hd, thac0, saves[5], spells?[] }`.
+- Saves array order is `[death, wand, paralysis, breath, spell]`
+  (`src/OscSheet/domain/classRules.ts` `SAVE_ORDER`).
+
+**Confirmed: the system ships NO `CONFIG.OSE.classes.advanced`.** `config.ts:41-43`
+registers only `classic`. `classRules.ts` probes `advanced` defensively (for the Advanced
+Fantasy tome, if ever installed) but it is absent today. Max level and all progression come
+from `classic` only.
+
+## Advancement model (settled — do not relitigate)
+
+- **Class drives ALL progression** — XP thresholds, HD, saves, THAC0, prime-req, spell slots.
+- **Max level = class table length** (`levels.length`). NO racial level limits, NO
+  multiclass. (Halfling caps at 8, Elf at 10, Dwarf at 12, the rest at 14 — purely because
+  that's how many rows each table ships.)
+- **Prime-requisite XP bonus is DEFERRED to Character Creation.** `system.details.xp.bonus`
+  stays a manual %. The wizard does not touch it.
+- A thin `domain/oseRules/resolveAdvancementSource` stays CC/Rest-agnostic (collapses to
+  "use the class") for reuse.
+
+## The system automates nothing
+
+`level`, `xp.*`, `hp.max/hd`, `saves.*`, `thac0.*`, `spells.<lvl>.max` are all **stored,
+hand-typed** fields on `actor.system`. `prepareDerivedData` rebuilds only
+scores/encumbrance/movement/ac and reshapes spells — never advancement stats
+(`data-model-character.js`). The system's `rollHP()` (`entity.js:181`) re-rolls the *entire*
+HD string and overwrites max, with no CON and no min-1 — the wrong primitive for a level-up
+delta. So the wizard/calc owns the advancement math and writes the results.
+
+## Fields the wizard writes (computed → stored)
+
+One atomic `updateActor` diff (flat dot-paths). All are **source** paths (what you write);
+some read back through derived data under a different shape (noted).
+
+| Computed value | Write path | Source | Notes |
+|---|---|---|---|
+| New level | `system.details.level` | = `toLevel` | |
+| XP-to-next | `system.details.xp.next` | `levels[toLevel].xp` | threshold for `toLevel+1`; **null/omit at max level** (`levels[toLevel]` undefined) |
+| Hit-dice formula | `system.hp.hd` | `levels[toLevel-1].hd` | e.g. `"5d6"`, `"9d8+2"` |
+| Max HP | `system.hp.max` | prev max + HP delta | delta rules below |
+| Saves (×5) | `system.saves.{death,wand,paralysis,breath,spell}.value` | `levels[toLevel-1].saves[i]` | order `[death,wand,paralysis,breath,spell]` |
+| THAC0 (descending) | `system.thac0.value` | `levels[toLevel-1].thac0` | |
+| Base attack bonus (ascending) | `system.thac0.bba` | `19 - thac0` | canonical OSE relation, `entity.js:57,156` |
+| Spell slots | `system.spells.<lvl>.max` | `levels[toLevel-1].spells[lvl-1]` | see spell-slot sourcing below |
+
+**Not written:** `system.hp.value` (current HP — advancement raises max, not current, unless
+the sheet chooses to also heal-to-full; that is a wizard UX call, not a rule),
+`system.details.xp.value` (XP is awarded, not spent), `system.details.xp.bonus` (prime-req,
+deferred to CC).
+
+### THAC0 / bba
+
+The table's `thac0` is the descending THAC0. The OSE actor stores both the descending value
+and the ascending `bba`, always related by `bba = 19 - thac0` (`entity.js:57`, `:156`;
+verified in `entity-actor.test.ts`). Write both from the single table value.
+
+### Spell-slot sourcing
+
+`levels[].spells` is an array indexed by spell level − 1: `spells[0]` = level-1 slots,
+`spells[1]` = level-2 slots, … Magic-User rows carry **6** entries (spell levels 1-6);
+Cleric and Elf carry **5** (levels 1-5). Map each entry to `system.spells.<lvl>.max`
+(`lvl = index + 1`).
+
+**Storage vs read shape:** you *write* `system.spells.<lvl>.max` (numeric level key at the
+`spells` root — the source shape in `template.json` `spellcaster.spells`). The data model
+rebuilds a *derived* `system.spells.slots.<n>.{used,max}` for display
+(`data-model-character-spells.ts`); never write to `slots`. Non-casters (Fighter, Dwarf,
+Halfling, Thief) have no `spells` array — write nothing.
+
+Info-only: newly-available spell *levels* (a slot count going 0→N) can be surfaced as "new
+at level N" text, but the wizard does **not** auto-add spell/ability Items — those live in
+`classicfantasycompendium` and are added manually (settled scope).
+
+## HP delta model
+
+A level-up adds HP; it never re-rolls existing HD. Two regimes, split at the **name-level
+threshold** (the last level at which the class gains a *new* full hit die).
+
+**Below/at name level** (`toLevel <= nameLevel`, HD count increases):
+- Gain **one new die** of the class's HD type + the character's **CON modifier**
+  (`system.scores.con.mod`).
+- **Minimum 1 HP per level** (OSE rulebook): `delta = max(1, dieResult + conMod)`. The floor
+  matters only for negative CON. NOTE: the *system* does not enforce this (its `rollHP`
+  has no floor) — it is a rulebook rule the calc applies. Flagged for Tim below.
+- HP mode is a UX choice: **roll** the die, or take its **average**. Averaging rounding is
+  an OSC-48 decision (flagged below) — this spec pins the roll path and the min-1 floor;
+  fixtures cover roll + the flat path.
+
+**Above name level** (`toLevel > nameLevel`, HD count capped):
+- Gain a **flat** amount per level, **CON no longer applies**.
+- The flat amount is the per-level increment of the HD string's constant term (e.g. Fighter
+  `9d8` → `9d8+2` → `9d8+4` = +2/level). Enumerated per class below.
+
+CON modifier thresholds (OSE `standardAttributeMods`,
+`data-model-character-scores.ts:47`): 3→−3, 4-5→−2, 6-8→−1, 9-12→0, 13-15→+1, 16-17→+2,
+18→+3.
+
+### Per-class name-level thresholds (derived, NOT in `OseClass`)
+
+`OseClass` does not carry a name-level field, so the sheet hardcodes this small table.
+Derived directly from where each `hd` string stops adding dice and starts adding a flat pip:
+
+| Class | HD | Name level (last die) | Max level | Flat HP/level after name level |
+|---|---|:--:|:--:|:--:|
+| Cleric | d6 | 9 | 14 | +1 |
+| Dwarf | d8 | 9 | 12 | +3 |
+| Elf | d6 | 9 | 10 | +2 |
+| Fighter | d8 | 9 | 14 | +2 |
+| Halfling | d6 | 8 | 8 | — (no flat region; name = max) |
+| Magic-User | d4 | 9 | 14 | +1 |
+| Thief | d4 | 9 | 14 | +2 |
+
+Derivation (from `classic-fantasy-classes.ts`):
+- Every class reaches `9d…` at level 9 except **Halfling**, whose table ends at `8d6`
+  (level 8) — so Halfling never enters the flat regime; it gains a die every level up to its
+  max. Its name level (8) equals its max level.
+- Flat/level = constant-term increment past the cap: Cleric `9d6→9d6+1` (+1), Dwarf
+  `9d8→9d8+3` (+3), Elf `9d6→9d6+2` (+2, single step to L10), Fighter `9d8→9d8+2` (+2),
+  Magic-User `9d4→9d4+1` (+1), Thief `9d4→9d4+2` (+2).
+
+**Suggested shape for the hardcoded table** (OSC-47/OSC-48 to place under `oseRules/`):
+
+```ts
+// keyed by canonical class name
+const NAME_LEVELS: Record<string, { nameLevel: number; flatHpPerLevel: number }> = {
+  Cleric:       { nameLevel: 9, flatHpPerLevel: 1 },
+  Dwarf:        { nameLevel: 9, flatHpPerLevel: 3 },
+  Elf:          { nameLevel: 9, flatHpPerLevel: 2 },
+  Fighter:      { nameLevel: 9, flatHpPerLevel: 2 },
+  Halfling:     { nameLevel: 8, flatHpPerLevel: 0 }, // no flat region within cap
+  "Magic-User": { nameLevel: 9, flatHpPerLevel: 1 },
+  Thief:        { nameLevel: 9, flatHpPerLevel: 2 },
+};
+```
+
+The flat amount is also recoverable from the table at runtime (diff the constant terms of
+`levels[toLevel-1].hd` vs `levels[toLevel-2].hd`), so OSC-48 may compute it instead of
+hardcoding — but `nameLevel` is not derivable without inspecting the whole HD column, so at
+minimum `nameLevel` is hardcoded. Recommendation: hardcode both for clarity; the fixtures
+assert the flat values regardless of source.
+
+## XP thresholds
+
+- `xp.next` after leveling = `levels[toLevel].xp` (the row *after* the new level = XP to
+  reach `toLevel+1`). Matches `classRules.selectClassDefaults` (`nextRow = def.levels[level]`)
+  and `EditModal`'s `nextXp`.
+- At **max level** (`toLevel === levels.length`), `levels[toLevel]` is undefined → `xp.next`
+  has no meaningful value. The calc should leave it unchanged or clear it (represented as
+  `null` in fixtures). Flagged below.
+
+## Unmatched free-text class → manual HP-only degradation
+
+`system.details.class` is free text; there is no class Item. `classRules.findClass` fuzzy-
+matches (canonicalized, hyphen/space-insensitive) against `CONFIG.OSE.classes.*`. On **no
+match** (`matched: false`):
+
+- The calc **cannot** source HD/saves/THAC0/spells. It degrades to **HP-only, manual**: the
+  wizard writes `system.details.level` (incremented) and `system.hp.max` (a value the user
+  enters — no die is known), and writes nothing else.
+- `hd`, `saves.*`, `thac0.*`, `spells.*` are left untouched.
+- Fixture `mu → unmatched (Bard)` documents this contract.
+
+## Open OSE-rules ambiguities (flagged for Tim)
+
+1. **Min-1-HP-per-level floor.** OSE rulebook grants at least 1 HP per level regardless of
+   CON penalty; the *system* does not enforce it (`rollHP` has no floor). Spec applies the
+   floor (`delta = max(1, die + conMod)`), fixture `mu-neg-con` asserts it. Confirm you want
+   the floor.
+2. **Average-HP rounding.** If the wizard offers "take average" instead of rolling, the
+   average of a dN (e.g. d6 → 3.5) needs a rounding rule (round up? standard B/X uses
+   round-down-with-min? OSE tables sometimes assume `(max/2)+1`). Left to OSC-48; fixtures
+   only pin the **roll** and **flat** paths to avoid prejudging. Pick a rule when OSC-48
+   lands.
+3. **`xp.next` at max level.** Represented `null` here. Confirm whether the calc should clear
+   the field, leave the last threshold in place, or write the max XP — cosmetic, affects the
+   topbar XP bar at cap.
+4. **Elf single flat step.** Elf's table has exactly one post-name-level row (`9d6+2` at
+   L10, its max). +2 is asserted from that single step; there is no second row to confirm the
+   per-level cadence. Consistent with the class's design (max 10).
+5. **Current HP on level-up.** Rules raise `hp.max` only. Whether to also bump
+   `hp.value` (heal the new HP, or heal to full) is a wizard UX choice, not a rule — left to
+   OSC-46. Fixtures assert `hp.max` only.
+
+## References
+
+- `ose-foundry-core/src/module/classes/classic-fantasy-classes.ts` — class tables
+- `ose-foundry-core/src/module/classes/types.ts` — `OseClass` shape
+- `ose-foundry-core/src/module/config.ts:41-43` — only `classic` registered
+- `ose-foundry-core/src/module/actor/entity.js:57,156,181` — `bba = 19 - thac0`; `rollHP`
+- `ose-foundry-core/src/module/actor/data-model-classes/data-model-character-spells.ts` — derived slots shape
+- `ose-foundry-core/src/module/actor/data-model-classes/data-model-character-scores.ts:47` — CON mod table
+- `src/OscSheet/domain/classRules.ts` — fuzzy match, `SAVE_ORDER`, `selectClassDefaults`
+- `src/OscSheet/features/edit/EditModal.tsx` — default/override UX the wizard extends
+- `src/OscSheet/domain/types.ts` — `OSEActor.system` field shapes
+- Fixtures: `src/OscSheet/domain/oseRules/__fixtures__/levelUp.fixtures.ts`

--- a/docs/level-up-rules.md
+++ b/docs/level-up-rules.md
@@ -94,13 +94,12 @@ threshold** (the last level at which the class gains a *new* full hit die).
 
 **Below/at name level** (`toLevel <= nameLevel`, HD count increases):
 - Gain **one new die** of the class's HD type + the character's **CON modifier**
-  (`system.scores.con.mod`).
-- **Minimum 1 HP per level** (OSE rulebook): `delta = max(1, dieResult + conMod)`. The floor
-  matters only for negative CON. NOTE: the *system* does not enforce this (its `rollHP`
-  has no floor) — it is a rulebook rule the calc applies. Flagged for Tim below.
+  (`system.scores.con.mod`): `delta = dieResult + conMod`. **No min-per-level floor** —
+  matches OSE system behavior (`rollHP` enforces none); a penalty CON can yield a small or
+  negative delta.
 - HP mode is a UX choice: **roll** the die, or take its **average**. Averaging rounding is
-  an OSC-48 decision (flagged below) — this spec pins the roll path and the min-1 floor;
-  fixtures cover roll + the flat path.
+  an OSC-48 decision (flagged below) — this spec pins the roll path; fixtures cover roll +
+  the flat path.
 
 **Above name level** (`toLevel > nameLevel`, HD count capped):
 - Gain a **flat** amount per level, **CON no longer applies**.
@@ -176,24 +175,22 @@ match** (`matched: false`):
 - `hd`, `saves.*`, `thac0.*`, `spells.*` are left untouched.
 - Fixture `mu → unmatched (Bard)` documents this contract.
 
-## Open OSE-rules ambiguities (flagged for Tim)
+## OSE-rules decisions & open questions
 
-1. **Min-1-HP-per-level floor.** OSE rulebook grants at least 1 HP per level regardless of
-   CON penalty; the *system* does not enforce it (`rollHP` has no floor). Spec applies the
-   floor (`delta = max(1, die + conMod)`), fixture `mu-neg-con` asserts it. Confirm you want
-   the floor.
-2. **Average-HP rounding.** If the wizard offers "take average" instead of rolling, the
-   average of a dN (e.g. d6 → 3.5) needs a rounding rule (round up? standard B/X uses
+1. **Min-per-level HP floor — SETTLED: none.** No min-per-level floor — matches OSE system
+   behavior (`rollHP` enforces none). Delta is raw `die + conMod`, which a penalty CON can
+   drive small or negative. Fixture `mu-2-3-neg-con` exercises a negative-CON delta.
+2. **`xp.next` at max level — SETTLED: `null`.** `levels[toLevel]` is undefined at max level
+   → write/represent `null`.
+3. **Average-HP rounding (open).** If the wizard offers "take average" instead of rolling,
+   the average of a dN (e.g. d6 → 3.5) needs a rounding rule (round up? standard B/X uses
    round-down-with-min? OSE tables sometimes assume `(max/2)+1`). Left to OSC-48; fixtures
    only pin the **roll** and **flat** paths to avoid prejudging. Pick a rule when OSC-48
    lands.
-3. **`xp.next` at max level.** Represented `null` here. Confirm whether the calc should clear
-   the field, leave the last threshold in place, or write the max XP — cosmetic, affects the
-   topbar XP bar at cap.
-4. **Elf single flat step.** Elf's table has exactly one post-name-level row (`9d6+2` at
+4. **Elf single flat step (noted).** Elf's table has exactly one post-name-level row (`9d6+2` at
    L10, its max). +2 is asserted from that single step; there is no second row to confirm the
    per-level cadence. Consistent with the class's design (max 10).
-5. **Current HP on level-up.** Rules raise `hp.max` only. Whether to also bump
+5. **Current HP on level-up (noted).** Rules raise `hp.max` only. Whether to also bump
    `hp.value` (heal the new HP, or heal to full) is a wizard UX choice, not a rule — left to
    OSC-46. Fixtures assert `hp.max` only.
 

--- a/src/OscSheet/domain/oseRules/__fixtures__/levelUp.fixtures.ts
+++ b/src/OscSheet/domain/oseRules/__fixtures__/levelUp.fixtures.ts
@@ -107,7 +107,7 @@ export const LEVEL_UP_CASES: LevelUpCase[] = [
   },
   {
     id: "mu-2-3-neg-con",
-    name: "Magic-User L2→L3 — negative CON floors HP delta at min-1-per-level",
+    name: "Magic-User L2→L3 — penalty CON yields raw (negative) delta, no min-per-level floor",
     className: "Magic-User",
     matched: true,
     fromLevel: 2,
@@ -115,14 +115,14 @@ export const LEVEL_UP_CASES: LevelUpCase[] = [
     con: 3,
     conMod: -3,
     hpMode: "roll",
-    rolledHd: 1, // d4; 1 + (-3) = -2 → clamped to 1
+    rolledHd: 1, // d4; 1 + (-3) = -2, applied raw (no floor — matches OSE system)
     before: { hpMax: 5, hd: "2d4" },
     expected: {
       level: 3,
       xpNext: 10_000, // levels[3].xp = level-4 threshold
       hd: "3d4",
-      hpMax: 6, // 5 + max(1, 1 + (-3)) = 5 + 1
-      hpDelta: 1,
+      hpMax: 3, // 5 + (1 + (-3)) = 5 + (-2)
+      hpDelta: -2,
       conApplied: true,
       saves: { death: 13, wand: 14, paralysis: 13, breath: 16, spell: 15 },
       thac0: 19,

--- a/src/OscSheet/domain/oseRules/__fixtures__/levelUp.fixtures.ts
+++ b/src/OscSheet/domain/oseRules/__fixtures__/levelUp.fixtures.ts
@@ -1,0 +1,305 @@
+/**
+ * @file Level-up calc fixtures (OSC-25) — the contract OSC-48's `computeLevelUp` must satisfy.
+ *
+ * Each case is a representative before→after advancement, sourced directly from the OSE
+ * classic-fantasy class tables (`CONFIG.OSE.classes.classic`, i.e.
+ * `ose-foundry-core/src/module/classes/classic-fantasy-classes.ts`). Values are hand-verified
+ * against those tables; see `docs/level-up-rules.md` for the rules and field-write map.
+ *
+ * This file defines fixtures + types ONLY — no calc logic (that is OSC-48). It typechecks under
+ * `pnpm build` so the calc module can import these cases straight into its unit tests.
+ */
+
+import type { OSESave } from "@domain/types";
+
+/** Saving throws, in the OSE `[death, wand, paralysis, breath, spell]` order. */
+export type Saves = Record<OSESave, number>;
+
+/** Spell slots keyed by spell level (1-based) → max slots. Written as `system.spells.<lvl>.max`. */
+export type SpellSlots = Record<number, number>;
+
+/**
+ * How the new level's HP was gained (deterministic inputs so the fixture is reproducible):
+ * - `roll`   — one new die was rolled; `rolledHd` gives the natural die result (CON applies).
+ * - `flat`   — past name level; fixed HP/level, CON does not apply, no die.
+ * - `manual` — unmatched class; the user typed the HP, nothing is derivable.
+ */
+export type HpMode = "roll" | "flat" | "manual";
+
+/** The computed after-state the calc should produce (maps 1:1 to the write paths in the doc). */
+export interface LevelUpExpected {
+  /** `system.details.level` */
+  level: number;
+  /** `system.details.xp.next` — `null` at max level (no further threshold). */
+  xpNext: number | null;
+  /** `system.hp.hd` — `null` for unmatched (not auto-written). */
+  hd: string | null;
+  /** `system.hp.max` after applying the delta. */
+  hpMax: number;
+  /** Convenience: `hpMax - before.hpMax`. */
+  hpDelta: number;
+  /** Whether the CON modifier was added to this level's HP (false in the flat/manual regime). */
+  conApplied: boolean;
+  /** `system.saves.*.value` — `null` for unmatched (not auto-written). */
+  saves: Saves | null;
+  /** `system.thac0.value` (descending) — `null` for unmatched. */
+  thac0: number | null;
+  /** `system.thac0.bba` (ascending) = `19 - thac0` — `null` for unmatched. */
+  bba: number | null;
+  /** `system.spells.<lvl>.max` — `null` for non-casters and unmatched. */
+  spells: SpellSlots | null;
+}
+
+export interface LevelUpCase {
+  /** Stable id for `it.each` / failure output. */
+  id: string;
+  /** Human-readable description. */
+  name: string;
+  /** Free-text class as stored on `system.details.class`. */
+  className: string;
+  /** Did the class fuzzy-match a `CONFIG.OSE.classes.*` entry? */
+  matched: boolean;
+  fromLevel: number;
+  toLevel: number;
+  /** CON score; `conMod` is the derived HP modifier (OSE `standardAttributeMods`). */
+  con: number;
+  conMod: number;
+  hpMode: HpMode;
+  /** Natural die result of the new HD, when `hpMode === "roll"`. */
+  rolledHd?: number;
+  /** Manual HP entered by the user, when `hpMode === "manual"`. */
+  manualHp?: number;
+  before: { hpMax: number; hd: string | null };
+  expected: LevelUpExpected;
+}
+
+/**
+ * bba is always `19 - thac0`; helper keeps the fixtures honest and self-documenting.
+ * (See `ose-foundry-core/src/module/actor/entity.js:57`.)
+ */
+const bba = (thac0: number) => 19 - thac0;
+
+export const LEVEL_UP_CASES: LevelUpCase[] = [
+  {
+    id: "mu-1-2",
+    name: "Magic-User L1→L2 — spellcaster gains a die (+CON), first slot bump",
+    className: "Magic-User",
+    matched: true,
+    fromLevel: 1,
+    toLevel: 2,
+    con: 13,
+    conMod: 1,
+    hpMode: "roll",
+    rolledHd: 3, // d4
+    before: { hpMax: 4, hd: "1d4" },
+    expected: {
+      level: 2,
+      xpNext: 5000, // levels[2].xp = level-3 threshold
+      hd: "2d4",
+      hpMax: 8, // 4 + max(1, 3 + 1)
+      hpDelta: 4,
+      conApplied: true,
+      saves: { death: 13, wand: 14, paralysis: 13, breath: 16, spell: 15 },
+      thac0: 19,
+      bba: bba(19), // 0
+      spells: { 1: 2, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0 },
+    },
+  },
+  {
+    id: "mu-2-3-neg-con",
+    name: "Magic-User L2→L3 — negative CON floors HP delta at min-1-per-level",
+    className: "Magic-User",
+    matched: true,
+    fromLevel: 2,
+    toLevel: 3,
+    con: 3,
+    conMod: -3,
+    hpMode: "roll",
+    rolledHd: 1, // d4; 1 + (-3) = -2 → clamped to 1
+    before: { hpMax: 5, hd: "2d4" },
+    expected: {
+      level: 3,
+      xpNext: 10_000, // levels[3].xp = level-4 threshold
+      hd: "3d4",
+      hpMax: 6, // 5 + max(1, 1 + (-3)) = 5 + 1
+      hpDelta: 1,
+      conApplied: true,
+      saves: { death: 13, wand: 14, paralysis: 13, breath: 16, spell: 15 },
+      thac0: 19,
+      bba: bba(19),
+      spells: { 1: 2, 2: 1, 3: 0, 4: 0, 5: 0, 6: 0 },
+    },
+  },
+  {
+    id: "cleric-4-5",
+    name: "Cleric L4→L5 — THAC0 & saves step, slot bump (zero-CON delta)",
+    className: "Cleric",
+    matched: true,
+    fromLevel: 4,
+    toLevel: 5,
+    con: 9,
+    conMod: 0,
+    hpMode: "roll",
+    rolledHd: 4, // d6
+    before: { hpMax: 14, hd: "4d6" },
+    expected: {
+      level: 5,
+      xpNext: 25_000, // levels[5].xp = level-6 threshold
+      hd: "5d6",
+      hpMax: 18, // 14 + max(1, 4 + 0)
+      hpDelta: 4,
+      conApplied: true,
+      saves: { death: 9, wand: 10, paralysis: 12, breath: 14, spell: 12 },
+      thac0: 17,
+      bba: bba(17), // 2
+      spells: { 1: 2, 2: 2, 3: 0, 4: 0, 5: 0 },
+    },
+  },
+  {
+    id: "cleric-8-9-boundary",
+    name: "Cleric L8→L9 — last die gain at the name-level boundary (+CON still applies)",
+    className: "Cleric",
+    matched: true,
+    fromLevel: 8,
+    toLevel: 9, // == nameLevel(9): still a die + CON
+    con: 15,
+    conMod: 1,
+    hpMode: "roll",
+    rolledHd: 6, // d6
+    before: { hpMax: 30, hd: "8d6" },
+    expected: {
+      level: 9,
+      xpNext: 300_000, // levels[9].xp = level-10 threshold
+      hd: "9d6",
+      hpMax: 37, // 30 + max(1, 6 + 1)
+      hpDelta: 7,
+      conApplied: true,
+      saves: { death: 6, wand: 7, paralysis: 9, breath: 11, spell: 9 },
+      thac0: 14,
+      bba: bba(14), // 5
+      spells: { 1: 3, 2: 3, 3: 3, 4: 2, 5: 2 },
+    },
+  },
+  {
+    id: "fighter-2-3",
+    name: "Fighter L2→L3 — pure fighter, +CON die, no spells",
+    className: "Fighter",
+    matched: true,
+    fromLevel: 2,
+    toLevel: 3,
+    con: 16,
+    conMod: 2,
+    hpMode: "roll",
+    rolledHd: 5, // d8
+    before: { hpMax: 12, hd: "2d8" },
+    expected: {
+      level: 3,
+      xpNext: 8000, // levels[3].xp = level-4 threshold
+      hd: "3d8",
+      hpMax: 19, // 12 + max(1, 5 + 2)
+      hpDelta: 7,
+      conApplied: true,
+      saves: { death: 12, wand: 13, paralysis: 14, breath: 15, spell: 16 },
+      thac0: 19,
+      bba: bba(19),
+      spells: null,
+    },
+  },
+  {
+    id: "fighter-9-10-flat",
+    name: "Fighter L9→L10 — crosses name level: flat +2, CON no longer applies",
+    className: "Fighter",
+    matched: true,
+    fromLevel: 9,
+    toLevel: 10, // > nameLevel(9): flat regime
+    con: 18,
+    conMod: 3, // ignored — flat regime drops CON
+    hpMode: "flat",
+    before: { hpMax: 45, hd: "9d8" },
+    expected: {
+      level: 10,
+      xpNext: 480_000, // levels[10].xp = level-11 threshold
+      hd: "9d8+2",
+      hpMax: 47, // 45 + 2 (flat), CON ignored
+      hpDelta: 2,
+      conApplied: false,
+      saves: { death: 6, wand: 7, paralysis: 8, breath: 8, spell: 10 },
+      thac0: 19,
+      bba: bba(19),
+      spells: null,
+    },
+  },
+  {
+    id: "mu-9-10-flat",
+    name: "Magic-User L9→L10 — caster crosses name level: flat +1, slots still bump",
+    className: "Magic-User",
+    matched: true,
+    fromLevel: 9,
+    toLevel: 10, // > nameLevel(9)
+    con: 15,
+    conMod: 1, // ignored in flat regime
+    hpMode: "flat",
+    before: { hpMax: 22, hd: "9d4" },
+    expected: {
+      level: 10,
+      xpNext: 600_000, // levels[10].xp = level-11 threshold
+      hd: "9d4+1",
+      hpMax: 23, // 22 + 1 (flat)
+      hpDelta: 1,
+      conApplied: false,
+      saves: { death: 11, wand: 12, paralysis: 11, breath: 14, spell: 12 },
+      thac0: 17,
+      bba: bba(17), // 2
+      spells: { 1: 3, 2: 3, 3: 3, 4: 3, 5: 2, 6: 0 },
+    },
+  },
+  {
+    id: "thief-13-14-max",
+    name: "Thief L13→L14 — max level: flat +2, no next XP threshold",
+    className: "Thief",
+    matched: true,
+    fromLevel: 13,
+    toLevel: 14, // == levels.length → max level
+    con: 12,
+    conMod: 0, // flat regime anyway
+    hpMode: "flat",
+    before: { hpMax: 40, hd: "9d4+8" },
+    expected: {
+      level: 14,
+      xpNext: null, // levels[14] is undefined at max level
+      hd: "9d4+10",
+      hpMax: 42, // 40 + 2 (flat)
+      hpDelta: 2,
+      conApplied: false,
+      saves: { death: 8, wand: 9, paralysis: 7, breath: 10, spell: 8 },
+      thac0: 12,
+      bba: bba(12), // 7
+      spells: null,
+    },
+  },
+  {
+    id: "unmatched-bard",
+    name: "Bard L3→L4 — unmatched free-text class: degrade to manual HP-only",
+    className: "Bard", // no CONFIG.OSE.classes match
+    matched: false,
+    fromLevel: 3,
+    toLevel: 4,
+    con: 13,
+    conMod: 1, // no HD known → CON can't be auto-applied; user types the HP
+    hpMode: "manual",
+    manualHp: 6,
+    before: { hpMax: 14, hd: null },
+    expected: {
+      level: 4, // only level + hp.max are written
+      xpNext: null, // no table → no threshold
+      hd: null, // not auto-written
+      hpMax: 20, // 14 + manualHp(6)
+      hpDelta: 6,
+      conApplied: false,
+      saves: null, // not auto-written
+      thac0: null, // not auto-written
+      bba: null,
+      spells: null,
+    },
+  },
+];

--- a/src/OscSheet/domain/oseRules/__fixtures__/levelUp.fixtures.ts
+++ b/src/OscSheet/domain/oseRules/__fixtures__/levelUp.fixtures.ts
@@ -1,14 +1,4 @@
-/**
- * @file Level-up calc fixtures (OSC-25) — the contract OSC-48's `computeLevelUp` must satisfy.
- *
- * Each case is a representative before→after advancement, sourced directly from the OSE
- * classic-fantasy class tables (`CONFIG.OSE.classes.classic`, i.e.
- * `ose-foundry-core/src/module/classes/classic-fantasy-classes.ts`). Values are hand-verified
- * against those tables; see `docs/level-up-rules.md` for the rules and field-write map.
- *
- * This file defines fixtures + types ONLY — no calc logic (that is OSC-48). It typechecks under
- * `pnpm build` so the calc module can import these cases straight into its unit tests.
- */
+// Level-up calc fixtures. Cases hand-verified against CONFIG.OSE.classes.classic; see docs/level-up-rules.md.
 
 import type { OSESave } from "@domain/types";
 


### PR DESCRIPTION
Spec + fixtures foundation for the Level Up project. Blocks OSC-46 (wizard UX), OSC-47 (classRules→oseRules), OSC-48 (calc module). No app/calc code — rules + the contract OSC-48 must satisfy.

## What's here
- `docs/level-up-rules.md` — advancement model, computed→stored field-write map, per-class **name-level HP thresholds** (derived from the OSE class tables; not in `OseClass`), flat-after-cap HP behavior (CON stops applying), spell-slot sourcing (`system.spells.<lvl>.max`), THAC0/`bba = 19 - thac0`, and unmatched-class → manual HP-only degradation. Cites source data throughout.
- `src/OscSheet/domain/oseRules/__fixtures__/levelUp.fixtures.ts` — 9 typed before/after cases (caster: Magic-User + Cleric; pure Fighter; name-level-crossing flat HP; max-level; min-1-per-level CON floor; unmatched degradation). Import-ready for OSC-48's tests.

## Confirmed against the data
- OSE system ships **no** `CONFIG.OSE.classes.advanced` — only `classic`.
- `bba = 19 - thac0` (verified in the system).
- Name level = last level gaining a full die: 9 for all classes except Halfling (8 = its max).

## Flagged for review (see doc "Open ambiguities")
- Min-1-HP-per-level floor (rulebook rule; system doesn't enforce) — spec applies it.
- Average-HP rounding left to OSC-48 (fixtures pin roll + flat paths only).
- `xp.next` at max level represented as `null`.

## Checks
- `pnpm build` passes (fixtures typecheck).
- `pnpm lint` clean.
- Calc tests intentionally not run (no calc module yet — that's OSC-48).