### PR TITLE
fix(manifest): title/description match Foundry listing

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,7 +1,7 @@
 {
   "id": "osc-character-sheet",
-  "title": "Old-School Chronicle: Character Sheet",
-  "description": "A fresh, responsive character sheet for Old School Essentials (OSE) in Foundry VTT, rebuilt in React.",
+  "title": "Enhanced OSE Character Sheet",
+  "description": "An alternative character sheet for the Old School Essentials system in Foundry VTT. Part of the Old-School Chronicle tool set.",
   "version": "0.4.1",
   "authors": [
     {


### PR DESCRIPTION
Manifest title was `Old-School Chronicle: Character Sheet` but the Foundry shop listing is **Enhanced OSE Character Sheet**. Installed modules display the *manifest* title in Manage Modules — so a user who installs "Enhanced OSE Character Sheet" and searches the world's module list for "enhanced" finds nothing (likely Sol's report).

Aligns `title` + `description` to the listing. The Foundry release API can't carry title/description (only id/version/manifest/notes/compatibility), so the manifest is the only lever for the in-Foundry name.

https://claude.ai/code/session_01CxCjkvnrXJZwbJPUAkGgH9