### PR TITLE
feat(attack): ctrl/meta-click skips the OSE roll dialog (#79)

### DIFF
--- a/src/OscSheet/app/SheetShell.tsx
+++ b/src/OscSheet/app/SheetShell.tsx
@@ -336,8 +336,8 @@ export default function SheetShell() {
           <SavesExploration
             saves={selectSaves(actor)}
             exploration={selectExploration(actor)}
-            onRollSave={(key) => actor.rollSave(key, {})}
-            onRollExploration={(key) => rollExploration(actor, key)}
+            onRollSave={(key, event) => actor.rollSave(key, { event })}
+            onRollExploration={(key, event) => rollExploration(actor, key, event)}
             tabbed
           />
         }

--- a/src/OscSheet/components/ui/StatPlaque.tsx
+++ b/src/OscSheet/components/ui/StatPlaque.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { cx } from "./cx";
 import { Stamp } from "./Stamp";
-import { rollable } from "./rollable";
+import { rollable, type ActivateEvent } from "./rollable";
 
 /** An "ink-stamp key · big value · caption" stat cell, optionally wired to a
  *  roll. Two vellum variants (see `.plaque` in components.css):
@@ -24,7 +24,7 @@ export function StatPlaque({
   stampKey: ReactNode;
   value: ReactNode;
   caption?: ReactNode;
-  onActivate?: () => void;
+  onActivate?: (event: ActivateEvent) => void;
   className?: string;
   title?: string;
   "data-testid"?: string;

--- a/src/OscSheet/components/ui/rollable.ts
+++ b/src/OscSheet/components/ui/rollable.ts
@@ -1,17 +1,20 @@
-import type { KeyboardEvent } from "react";
+import type { KeyboardEvent, MouseEvent } from "react";
+
+/** Click or keyboard activation of a roll target; carries ctrl/meta for OSE's dialog check. */
+export type ActivateEvent = MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>;
 
 /** Props that turn any element into a keyboard-accessible click target.
  *  Returns nothing when there's no handler (read-only, e.g. Storybook stories). */
-export function rollable(onActivate?: () => void) {
+export function rollable(onActivate?: (event: ActivateEvent) => void) {
   if (!onActivate) return {};
   return {
     role: "button" as const,
     tabIndex: 0,
     onClick: onActivate,
-    onKeyDown: (e: KeyboardEvent) => {
+    onKeyDown: (e: KeyboardEvent<HTMLElement>) => {
       if (e.key === "Enter" || e.key === " ") {
         e.preventDefault();
-        onActivate();
+        onActivate(e);
       }
     },
   };

--- a/src/OscSheet/domain/rolls/skipRollDialog.test.ts
+++ b/src/OscSheet/domain/rolls/skipRollDialog.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { skipRollDialog } from "@domain/rolls/skipRollDialog";
+
+function stubGame(inverted: boolean) {
+  (globalThis as unknown as { game: unknown }).game = {
+    system: { id: "ose" },
+    settings: {
+      get: (ns: string, key: string) =>
+        ns === "ose" && key === "invertedCtrlBehavior" ? inverted : undefined,
+    },
+  };
+}
+
+const plain = { ctrlKey: false, metaKey: false };
+const ctrl = { ctrlKey: true, metaKey: false };
+const meta = { ctrlKey: false, metaKey: true };
+
+afterEach(() => {
+  delete (globalThis as unknown as { game?: unknown }).game;
+});
+
+describe("skipRollDialog", () => {
+  it("normal behavior: modifier held → skip", () => {
+    stubGame(false);
+    expect(skipRollDialog(ctrl)).toBe(true);
+    expect(skipRollDialog(meta)).toBe(true);
+  });
+
+  it("normal behavior: no modifier → show dialog", () => {
+    stubGame(false);
+    expect(skipRollDialog(plain)).toBe(false);
+    expect(skipRollDialog(undefined)).toBe(false);
+  });
+
+  it("inverted behavior: modifier held → show dialog", () => {
+    stubGame(true);
+    expect(skipRollDialog(ctrl)).toBe(false);
+    expect(skipRollDialog(meta)).toBe(false);
+  });
+
+  it("inverted behavior: no modifier → skip", () => {
+    stubGame(true);
+    expect(skipRollDialog(plain)).toBe(true);
+    expect(skipRollDialog(undefined)).toBe(true);
+  });
+
+  it("no game/settings available → falls back to non-inverted", () => {
+    expect(skipRollDialog(ctrl)).toBe(true);
+    expect(skipRollDialog(plain)).toBe(false);
+  });
+});

--- a/src/OscSheet/domain/rolls/skipRollDialog.ts
+++ b/src/OscSheet/domain/rolls/skipRollDialog.ts
@@ -1,0 +1,15 @@
+/** World setting: inverts ctrl/meta-click so the dialog is skipped by default. */
+function invertedCtrlBehavior(): boolean {
+  try {
+    const settings = game.settings as { get(ns: string, key: string): unknown };
+    return !!settings.get(game.system.id, "invertedCtrlBehavior");
+  } catch {
+    return false;
+  }
+}
+
+/** OSE parity: ctrl/meta-click skips the roll dialog, inverted by the world setting. */
+export function skipRollDialog(event?: { ctrlKey: boolean; metaKey: boolean }): boolean {
+  const held = !!event && (event.ctrlKey || event.metaKey);
+  return invertedCtrlBehavior() ? !held : held;
+}

--- a/src/OscSheet/domain/rolls/weaponAttack.test.ts
+++ b/src/OscSheet/domain/rolls/weaponAttack.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { buildWeaponAttack } from "@domain/rolls/weaponAttack";
+import type { OSEActor, OseWeapon } from "@domain/types";
+
+const weapon = {
+  _source: { _id: "bow", name: "Bow" },
+  system: { save: "death", melee: true, missile: true },
+} as unknown as OseWeapon;
+
+const makeActor = (type: string) => ({ type }) as unknown as OSEActor;
+
+describe("buildWeaponAttack", () => {
+  it("builds OSE's rollData shape from the item source", () => {
+    const actor = makeActor("character");
+    const { rollData } = buildWeaponAttack(actor, weapon, "melee");
+
+    expect(rollData.item).toBe(weapon._source);
+    expect(rollData.actor).toBe(actor);
+    expect(rollData.roll).toEqual({ save: "death", target: null });
+  });
+
+  it("uses the given kind for characters", () => {
+    expect(buildWeaponAttack(makeActor("character"), weapon, "missile").type).toBe("missile");
+    expect(buildWeaponAttack(makeActor("character"), weapon, "melee").type).toBe("melee");
+  });
+
+  it("falls back to 'attack' for non-characters", () => {
+    expect(buildWeaponAttack(makeActor("npc"), weapon, "missile").type).toBe("attack");
+  });
+
+  it("passes an absent save through as undefined", () => {
+    const plain = { _source: {}, system: {} } as unknown as OseWeapon;
+    expect(buildWeaponAttack(makeActor("character"), plain, "melee").rollData.roll.save).toBe(
+      undefined,
+    );
+  });
+});

--- a/src/OscSheet/domain/rolls/weaponAttack.ts
+++ b/src/OscSheet/domain/rolls/weaponAttack.ts
@@ -1,0 +1,24 @@
+import type { AttackKind, AttackType, OSEActor, OseWeapon } from "@domain/types";
+
+export type WeaponAttack = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  rollData: { item: any; actor: OSEActor; roll: { save?: string; target: null } };
+  type: AttackType;
+};
+
+/** Mirrors OseItem#rollWeapon's rollData, minus its melee/missile dialog — the
+ *  sheet's mode switch has already chosen the range. Non-characters roll "attack". */
+export function buildWeaponAttack(
+  actor: OSEActor,
+  weapon: OseWeapon,
+  kind: AttackKind,
+): WeaponAttack {
+  return {
+    rollData: {
+      item: weapon._source,
+      actor,
+      roll: { save: weapon.system.save, target: null },
+    },
+    type: (actor as { type?: string }).type === "character" ? kind : "attack",
+  };
+}

--- a/src/OscSheet/domain/types.ts
+++ b/src/OscSheet/domain/types.ts
@@ -6,6 +6,14 @@ import type { ContextConnector } from "foundry-vtt-react";
 /** Saving-throw category key, sourced from the OSE system's CONFIG (`saves_long`). */
 export type OSESave = Save;
 
+/** Structural shape OSE's roll dialog check reads — satisfied by DOM and React events. */
+export type RollEvent = { ctrlKey: boolean; metaKey: boolean };
+
+/** Attack range of a weapon mode. */
+export type AttackKind = "melee" | "missile";
+/** What OSE rolls as — non-characters have no melee/missile split. */
+export type AttackType = AttackKind | "attack";
+
 // Add props as needed
 export type OscContext = {
   document: OSEActor;
@@ -106,28 +114,23 @@ export type OSEActor = Actor & {
   targetAttack: (
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     roll: { [key: string]: any },
-    type: "melee" | "missile",
+    type: AttackType,
     options: {
-      type: "melee" | "missile";
+      type: AttackType;
       skipDialog?: boolean;
     }
   ) => void;
   rollCheck: (
     score: string,
-    {
-      event,
-    }: {
-      event?: Event | React.MouseEvent<HTMLElement | SVGTextElement>;
-      fastForward?: boolean;
-    }
+    options: { event?: RollEvent; fastForward?: boolean; chatMessage?: string }
   ) => void;
   rollExploration: (
     action: string,
-    options: { event?: Event; fastForward?: boolean; chatMessage?: string }
+    options: { event?: RollEvent; fastForward?: boolean; chatMessage?: string }
   ) => void;
   rollSave: (
     save: OSESave,
-    options: { event?: Event; fastForward?: boolean; chatMessage?: string }
+    options: { event?: RollEvent; fastForward?: boolean; chatMessage?: string }
   ) => void;
   update: (updateData: { [key: string]: string | number }) => Promise<OSEActor>;
 };
@@ -165,6 +168,8 @@ export type OseWeapon = OseItem & {
     melee: boolean;
     missile: boolean;
     equipped: boolean;
+    /** Save the target may roll against this weapon's attack. */
+    save?: string;
   };
   bonus: number;
 };

--- a/src/OscSheet/domain/vm-types.ts
+++ b/src/OscSheet/domain/vm-types.ts
@@ -1,4 +1,4 @@
-import type { OSESave, OseSpell } from "@domain/types";
+import type { AttackKind, OSESave, OseSpell } from "@domain/types";
 
 export interface IdentityVM {
   name: string;
@@ -44,7 +44,7 @@ export interface RollSpec {
 
 /** One attack mode (melee or missile) of a weapon: its hit/damage rolls + displays. */
 export interface AttackMode {
-  kind: "melee" | "missile";
+  kind: AttackKind;
   kindLabel: string;
   /** To-hit roll (1d20 + ability mod). */
   hit: RollSpec;

--- a/src/OscSheet/features/actions/AbilityPlaques.tsx
+++ b/src/OscSheet/features/actions/AbilityPlaques.tsx
@@ -1,7 +1,8 @@
 import type { AbilityVM } from "@domain/vm-types";
 import { StatPlaque } from "@ui/StatPlaque";
+import type { ActivateEvent } from "@ui/rollable";
 
-type Props = { abilities: AbilityVM[]; onRoll?: (key: string) => void };
+type Props = { abilities: AbilityVM[]; onRoll?: (key: string, event: ActivateEvent) => void };
 
 /** Six ability plaques (label · value · mod). Click rolls a roll-under check. */
 export function AbilityPlaques({ abilities, onRoll }: Props) {
@@ -15,7 +16,7 @@ export function AbilityPlaques({ abilities, onRoll }: Props) {
             stampKey={a.label}
             value={a.value}
             caption={a.modLabel}
-            onActivate={onRoll && (() => onRoll(a.key))}
+            onActivate={onRoll && ((e) => onRoll(a.key, e))}
             title={onRoll ? `Roll ${a.label} check` : undefined}
             data-testid={`ability-${a.key}`}
           />

--- a/src/OscSheet/features/actions/ActionsView.tsx
+++ b/src/OscSheet/features/actions/ActionsView.tsx
@@ -1,4 +1,6 @@
+import type { MouseEvent } from "react";
 import type { OSEActor, OSESave, OseItem } from "@domain/types";
+import { skipRollDialog } from "@domain/rolls/skipRollDialog";
 import type { RollSpec } from "@domain/vm-types";
 import { selectAbilities } from "@features/actions/abilities";
 import { selectAttacks } from "@features/actions/attacks";
@@ -29,8 +31,10 @@ export function ActionsView({ actor }: Props) {
   // a damage roll offers GMs an apply-damage button. No target → plain card.
   const onRoll = (spec: RollSpec) => void postRollCard(actor, spec);
   // The composite "Attack" uses OSE's own weapon roll dialog.
-  const onAttack = (itemId: string) =>
-    actor.system.weapons.find((w) => w._id === itemId)?.rollWeapon({ skipDialog: false });
+  const onAttack = (itemId: string, event: MouseEvent) =>
+    actor.system.weapons
+      .find((w) => w._id === itemId)
+      ?.rollWeapon({ skipDialog: skipRollDialog(event) });
   const onOpenWeapon = (itemId: string) => actor.items.get(itemId)?.sheet?.render(true);
   const onSave = (key: OSESave) => actor.rollSave(key, {});
   const onExploration = (key: string) => rollExploration(actor, key);

--- a/src/OscSheet/features/actions/ActionsView.tsx
+++ b/src/OscSheet/features/actions/ActionsView.tsx
@@ -1,6 +1,7 @@
 import type { MouseEvent } from "react";
-import type { OSEActor, OSESave, OseItem } from "@domain/types";
+import type { AttackKind, OSEActor, OSESave, OseItem } from "@domain/types";
 import { skipRollDialog } from "@domain/rolls/skipRollDialog";
+import { buildWeaponAttack } from "@domain/rolls/weaponAttack";
 import type { RollSpec } from "@domain/vm-types";
 import { selectAbilities } from "@features/actions/abilities";
 import { selectAttacks } from "@features/actions/attacks";
@@ -13,6 +14,7 @@ import { AttacksTable } from "@features/actions/AttacksTable";
 import { MemorizedSpells } from "@features/actions/MemorizedSpells";
 import { SavesGrid, ExplorationGrid } from "@features/actions/SavesExploration";
 import { SectionTitle } from "@ui/SectionTitle";
+import type { ActivateEvent } from "@ui/rollable";
 import { useOscSheetContext } from "@app/context";
 
 type Props = { actor: OSEActor };
@@ -25,19 +27,21 @@ export function ActionsView({ actor }: Props) {
   // stay available even read-only; the composite Attack can write (missile ammo
   // decrement), so it's gated on the global edit permission.
   const { canEdit } = useOscSheetContext();
-  const onAbility = (key: string) => actor.rollCheck(key, {});
+  const onAbility = (key: string, event: ActivateEvent) => actor.rollCheck(key, { event });
   // Hit/Damage are custom formula rolls (OSE has no separate hit/damage roll). The
   // Vellum card is target-aware: a hit roll shows HIT/MISS vs the current target's AC,
   // a damage roll offers GMs an apply-damage button. No target → plain card.
   const onRoll = (spec: RollSpec) => void postRollCard(actor, spec);
-  // The composite "Attack" uses OSE's own weapon roll dialog.
-  const onAttack = (itemId: string, event: MouseEvent) =>
-    actor.system.weapons
-      .find((w) => w._id === itemId)
-      ?.rollWeapon({ skipDialog: skipRollDialog(event) });
+  // Straight to OSE's attack roll — the row's mode switch replaces its range dialog.
+  const onAttack = (itemId: string, kind: AttackKind, event: MouseEvent) => {
+    const weapon = actor.system.weapons.find((w) => w._id === itemId);
+    if (!weapon) return;
+    const { rollData, type } = buildWeaponAttack(actor, weapon, kind);
+    actor.targetAttack(rollData, type, { type, skipDialog: skipRollDialog(event) });
+  };
   const onOpenWeapon = (itemId: string) => actor.items.get(itemId)?.sheet?.render(true);
-  const onSave = (key: OSESave) => actor.rollSave(key, {});
-  const onExploration = (key: string) => rollExploration(actor, key);
+  const onSave = (key: OSESave, event: ActivateEvent) => actor.rollSave(key, { event });
+  const onExploration = (key: string, event: ActivateEvent) => rollExploration(actor, key, event);
   // Drag a weapon card onto the macro hotbar → OSE's hotbarDrop creates an attack
   // macro, same as dragging the item's inventory row.
   const dragData = (itemId: string) => {

--- a/src/OscSheet/features/actions/AttacksTable.test.tsx
+++ b/src/OscSheet/features/actions/AttacksTable.test.tsx
@@ -27,6 +27,17 @@ const dagger: AttackVM = {
   qualities: [],
 };
 
+const sling: AttackVM = {
+  ...dagger,
+  id: "sling",
+  itemId: "sling",
+  name: "Sling",
+  modes: [
+    dagger.modes[0],
+    { ...dagger.modes[0], kind: "missile", kindLabel: "Missile" },
+  ],
+};
+
 let container: HTMLDivElement;
 let root: Root;
 
@@ -55,8 +66,26 @@ describe("AttacksTable", () => {
     });
 
     expect(onAttack).toHaveBeenCalledTimes(1);
-    const [itemId, event] = onAttack.mock.calls[0];
+    const [itemId, kind, event] = onAttack.mock.calls[0];
     expect(itemId).toBe("dagger");
+    expect(kind).toBe("melee");
     expect(event.ctrlKey).toBe(true);
+  });
+
+  it("passes the active mode's kind (switched to missile)", () => {
+    const onAttack = vi.fn();
+    act(() => root.render(<AttacksTable attacks={[sling]} onAttack={onAttack} />));
+
+    const click = (testid: string) => {
+      const el = container.querySelector<HTMLButtonElement>(`[data-testid="${testid}"]`)!;
+      act(() => {
+        el.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+      });
+    };
+
+    click("attack-mode-missile-sling");
+    click("weapon-attack-sling");
+
+    expect(onAttack.mock.calls[0][1]).toBe("missile");
   });
 });

--- a/src/OscSheet/features/actions/AttacksTable.test.tsx
+++ b/src/OscSheet/features/actions/AttacksTable.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { AttacksTable } from "@features/actions/AttacksTable";
+import type { AttackVM } from "@domain/vm-types";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const dagger: AttackVM = {
+  id: "dagger",
+  itemId: "dagger",
+  name: "Dagger",
+  img: "",
+  modes: [
+    {
+      kind: "melee",
+      kindLabel: "Melee",
+      hit: { label: "Dagger", formula: "1d20+1", flavor: "hit" },
+      hitDisplay: "+1",
+      hitTip: "d20+1",
+      dmg: { label: "Dagger", formula: "1d4", flavor: "damage" },
+      dmgDisplay: "1d4",
+      dmgTip: "1d4",
+    },
+  ],
+  qualities: [],
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("AttacksTable", () => {
+  it("passes the click event to onAttack (ctrl-click)", () => {
+    const onAttack = vi.fn();
+    act(() => root.render(<AttacksTable attacks={[dagger]} onAttack={onAttack} />));
+
+    const btn = container.querySelector<HTMLButtonElement>(
+      '[data-testid="weapon-attack-dagger"]',
+    )!;
+    act(() => {
+      btn.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true, ctrlKey: true }),
+      );
+    });
+
+    expect(onAttack).toHaveBeenCalledTimes(1);
+    const [itemId, event] = onAttack.mock.calls[0];
+    expect(itemId).toBe("dagger");
+    expect(event.ctrlKey).toBe(true);
+  });
+});

--- a/src/OscSheet/features/actions/AttacksTable.tsx
+++ b/src/OscSheet/features/actions/AttacksTable.tsx
@@ -1,4 +1,4 @@
-import { useState, type DragEvent } from "react";
+import { useState, type DragEvent, type MouseEvent } from "react";
 import type { AttackVM, RollSpec } from "@domain/vm-types";
 import { SectionTitle } from "@ui/SectionTitle";
 import { Tag } from "@ui/Tag";
@@ -10,8 +10,8 @@ type Props = {
   attacks: AttackVM[];
   /** Roll a hit/damage formula (custom roll). */
   onRoll?: (spec: RollSpec) => void;
-  /** Composite attack roll (OSE weapon dialog). */
-  onAttack?: (itemId: string) => void;
+  /** Composite attack roll (OSE weapon dialog). Event carries ctrl/meta (skip dialog). */
+  onAttack?: (itemId: string, event: MouseEvent<HTMLButtonElement>) => void;
   /** Open the weapon's item sheet (click the name). */
   onOpen?: (itemId: string) => void;
   /** Foundry item drag-data for a weapon, so its card drops onto the macro hotbar
@@ -202,7 +202,7 @@ function WeaponRow({
         data-testid={`weapon-attack-${a.itemId}`}
         {...(canAttack ? macroDrag : {})}
         disabled={!canAttack || !onAttack}
-        onClick={() => onAttack?.(a.itemId)}
+        onClick={(e) => onAttack?.(a.itemId, e)}
         title="Attack roll (hit + damage)"
         variant="outline"
         tone="brass"

--- a/src/OscSheet/features/actions/AttacksTable.tsx
+++ b/src/OscSheet/features/actions/AttacksTable.tsx
@@ -1,4 +1,5 @@
 import { useState, type DragEvent, type MouseEvent } from "react";
+import type { AttackKind } from "@domain/types";
 import type { AttackVM, RollSpec } from "@domain/vm-types";
 import { SectionTitle } from "@ui/SectionTitle";
 import { Tag } from "@ui/Tag";
@@ -10,8 +11,12 @@ type Props = {
   attacks: AttackVM[];
   /** Roll a hit/damage formula (custom roll). */
   onRoll?: (spec: RollSpec) => void;
-  /** Composite attack roll (OSE weapon dialog). Event carries ctrl/meta (skip dialog). */
-  onAttack?: (itemId: string, event: MouseEvent<HTMLButtonElement>) => void;
+  /** Composite attack roll for the active mode. Event carries ctrl/meta (skip dialog). */
+  onAttack?: (
+    itemId: string,
+    kind: AttackKind,
+    event: MouseEvent<HTMLButtonElement>,
+  ) => void;
   /** Open the weapon's item sheet (click the name). */
   onOpen?: (itemId: string) => void;
   /** Foundry item drag-data for a weapon, so its card drops onto the macro hotbar
@@ -28,7 +33,7 @@ function monogram(name: string): string {
   return (name.trim().charAt(0) || "?").toUpperCase();
 }
 
-const kindIcon = (kind: "melee" | "missile") =>
+const kindIcon = (kind: AttackKind) =>
   kind === "melee" ? "fa-sword" : "fa-bow-arrow";
 
 /** One weapon card. A melee+missile weapon shows both kind tags as a toggle
@@ -202,7 +207,7 @@ function WeaponRow({
         data-testid={`weapon-attack-${a.itemId}`}
         {...(canAttack ? macroDrag : {})}
         disabled={!canAttack || !onAttack}
-        onClick={(e) => onAttack?.(a.itemId, e)}
+        onClick={(e) => onAttack?.(a.itemId, mode.kind, e)}
         title="Attack roll (hit + damage)"
         variant="outline"
         tone="brass"
@@ -217,7 +222,7 @@ function WeaponRow({
 
 /** Equipped-weapon attacks as woodcut weapon cards: ink-stamp monogram, name +
  *  melee/missile + quality tags, clickable HIT/DMG stat cells (FA dice), and a
- *  tall brass Attack button (full hit + damage via the OSE weapon dialog). */
+ *  tall brass Attack button (full hit + damage for the active mode). */
 export function AttacksTable({
   attacks,
   onRoll,

--- a/src/OscSheet/features/actions/SavesExploration.test.tsx
+++ b/src/OscSheet/features/actions/SavesExploration.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { SavesGrid } from "@features/actions/SavesExploration";
+import type { SaveVM } from "@domain/vm-types";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const saves: SaveVM[] = [{ key: "death", label: "Death", icon: "", target: 12 }];
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("SavesGrid", () => {
+  it("passes the click event to onRoll (ctrl-click)", () => {
+    const onRoll = vi.fn();
+    act(() => root.render(<SavesGrid saves={saves} onRoll={onRoll} />));
+
+    const plaque = container.querySelector<HTMLDivElement>('[data-testid="save-death"]')!;
+    act(() => {
+      plaque.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true, ctrlKey: true }),
+      );
+    });
+
+    expect(onRoll).toHaveBeenCalledTimes(1);
+    const [key, event] = onRoll.mock.calls[0];
+    expect(key).toBe("death");
+    expect(event.ctrlKey).toBe(true);
+  });
+});

--- a/src/OscSheet/features/actions/SavesExploration.tsx
+++ b/src/OscSheet/features/actions/SavesExploration.tsx
@@ -4,14 +4,14 @@ import type { OSESave } from "@domain/types";
 import { SectionTitle } from "@ui/SectionTitle";
 import { StatPlaque } from "@ui/StatPlaque";
 import { cx } from "@ui/cx";
-import { rollable } from "@ui/rollable";
+import { rollable, type ActivateEvent } from "@ui/rollable";
 
 type Props = {
   saves: SaveVM[];
   exploration: ExplorationVM[];
   tabbed?: boolean;
-  onRollSave?: (key: OSESave) => void;
-  onRollExploration?: (key: string) => void;
+  onRollSave?: (key: OSESave, event: ActivateEvent) => void;
+  onRollExploration?: (key: string, event: ActivateEvent) => void;
 };
 
 /** 1–2 char ink-stamp from the save label (Death → D, Paralysis → P). */
@@ -19,7 +19,13 @@ function saveStamp(label: string): string {
   return label.charAt(0).toUpperCase();
 }
 
-export function SavesGrid({ saves, onRoll }: { saves: SaveVM[]; onRoll?: (key: OSESave) => void }) {
+export function SavesGrid({
+  saves,
+  onRoll,
+}: {
+  saves: SaveVM[];
+  onRoll?: (key: OSESave, event: ActivateEvent) => void;
+}) {
   return (
     <div className="fvtt-saves">
       {saves.map((s) => (
@@ -29,7 +35,7 @@ export function SavesGrid({ saves, onRoll }: { saves: SaveVM[]; onRoll?: (key: O
           stampKey={saveStamp(s.label)}
           value={s.target}
           caption={s.label}
-          onActivate={onRoll && (() => onRoll(s.key))}
+          onActivate={onRoll && ((e) => onRoll(s.key, e))}
           title={onRoll ? `Roll ${s.label} save (≥ ${s.target})` : undefined}
           data-testid={`save-${s.key}`}
         />
@@ -38,7 +44,13 @@ export function SavesGrid({ saves, onRoll }: { saves: SaveVM[]; onRoll?: (key: O
   );
 }
 
-export function ExplorationGrid({ exploration, onRoll }: { exploration: ExplorationVM[]; onRoll?: (key: string) => void }) {
+export function ExplorationGrid({
+  exploration,
+  onRoll,
+}: {
+  exploration: ExplorationVM[];
+  onRoll?: (key: string, event: ActivateEvent) => void;
+}) {
   return (
     <div className="fvtt-explore">
       {exploration.map((e) => (
@@ -46,7 +58,7 @@ export function ExplorationGrid({ exploration, onRoll }: { exploration: Explorat
           key={e.key}
           className={cx("fvtt-skill", onRoll && "rollable")}
           title={onRoll ? `Roll ${e.label} (${e.inSix}-in-6)` : undefined}
-          {...rollable(onRoll && (() => onRoll(e.key)))}
+          {...rollable(onRoll && ((ev) => onRoll(e.key, ev)))}
         >
           <i className={cx("skic", e.icon)} aria-hidden="true" />
           <span className="skn">{e.label}</span>

--- a/src/OscSheet/features/actions/exploration.ts
+++ b/src/OscSheet/features/actions/exploration.ts
@@ -1,4 +1,4 @@
-import type { OSEActor } from "@domain/types";
+import type { OSEActor, RollEvent } from "@domain/types";
 import type { ExplorationVM } from "@domain/vm-types";
 
 // `simple` skills (Forage/Hunt) aren't in OSE's exploration schema — they fire a
@@ -26,7 +26,7 @@ export function selectExploration(actor: OSEActor): ExplorationVM[] {
 
 /** Roll an exploration skill — data-backed via OSE, or a plain 1d6 for the
  *  not-yet-modelled Forage/Hunt. Shared by the Actions body + the lg rail. */
-export function rollExploration(actor: OSEActor, key: string): void {
+export function rollExploration(actor: OSEActor, key: string, event?: RollEvent): void {
   const meta = EXPL_META.find((m) => m.key === key);
   if (meta?.simple) {
     const speaker = ChatMessage.getSpeaker({ actor });
@@ -35,5 +35,5 @@ export function rollExploration(actor: OSEActor, key: string): void {
     void new Roll("1d6").toMessage({ speaker, flavor: `${meta.label} (1d6)` } as any);
     return;
   }
-  actor.rollExploration(key, {});
+  actor.rollExploration(key, { event });
 }


### PR DESCRIPTION
Fixes #79.

The Attack button called `rollWeapon({ skipDialog: false })`, so ctrl/meta-click never bypassed the popup. New `domain/rolls/skipRollDialog.ts` mirrors OSE's `skipRollDialogCheck` (ctrl/meta, negated by the `invertedCtrlBehavior` system setting); `AttacksTable`'s `onAttack` now forwards the click event.

Scoped to the Attack button. Follow-up: saves / ability checks / exploration still pass `{}`, which with `invertedCtrlBehavior` on makes OSE skip their dialogs unconditionally — same helper fixes it.