### PR TITLE
chore(manifest): rename module title to "Enhanced Character Sheet for Old-School Essentials" (OSC-73)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Old-School Chronicle: Character Sheet
+# Enhanced Character Sheet for Old-School Essentials
 
-A fresh, responsive character sheet for **[Old School Essentials](https://necroticgnome.com/)** in Foundry VTT — rebuilt in React for a faster, cleaner play experience.
+A fresh, responsive character sheet for **[Old-School Essentials](https://necroticgnome.com/)** in Foundry VTT — rebuilt in React for a faster, cleaner play experience.
 
-> **Requires the [Old School Essentials](https://foundryvtt.com/packages/ose) game system.** The OSC Character Sheet replaces the default sheet; your actors, items, and data are untouched.
+> **Requires the [Old-School Essentials](https://foundryvtt.com/packages/ose) game system.** The OSC Character Sheet replaces the default sheet; your actors, items, and data are untouched.
 
 ![Foundry v13](https://img.shields.io/badge/Foundry-v13%E2%80%93v14-informational) ![System: OSE](https://img.shields.io/badge/system-OSE-orange)
 
@@ -12,7 +12,7 @@ Part of the **Old-School Chronicle** toolset, more to come on that soon!
 
 ## Install
 
-In Foundry, open **Add-on Modules → Install Module**, search **Old-School Chronicle: Character Sheet**, and click **Install**. Then launch your OSE world and enable it under **Game Settings → Manage Modules**.
+In Foundry, open **Add-on Modules → Install Module**, search **Enhanced Character Sheet for Old-School Essentials**, and click **Install**. Then launch your OSE world and enable it under **Game Settings → Manage Modules**.
 
 Character and NPC actors use the OSC Character Sheet by default.
 
@@ -54,7 +54,7 @@ Coins, encumbrance, weapon tags, attacks, and inventory are modeled on the OSE d
 | | |
 |---|---|
 | **Foundry VTT** | v13 minimum · v14 verified |
-| **Game system** | Old School Essentials (`ose`) |
+| **Game system** | Old-School Essentials (`ose`) |
 
 ## Feedback & issues
 

--- a/module.json
+++ b/module.json
@@ -1,7 +1,7 @@
 {
   "id": "osc-character-sheet",
-  "title": "Enhanced OSE Character Sheet",
-  "description": "An alternative character sheet for the Old School Essentials system in Foundry VTT. Part of the Old-School Chronicle tool set.",
+  "title": "Enhanced Character Sheet for Old-School Essentials",
+  "description": "An alternative character sheet for the Old-School Essentials system in Foundry VTT. Part of the Old-School Chronicle tool set.",
   "version": "0.4.1",
   "authors": [
     {


### PR DESCRIPTION
Renames the module's display title. `id` (`osc-character-sheet`) is untouched, so existing installs, settings namespaces, and manifest/download URLs keep working — Foundry keys everything off `id`, not `title`.

Strings brought in sync:
- `module.json` — `title`, and `description` (hyphenation)
- `README.md` — H1, install-search string, system-name mentions

Normalized "Old School Essentials" → "Old-School Essentials" (Necrotic Gnome's official spelling) so prose matches the new title.

**Follow-up, not in this PR:** #78 kept the manifest title matched to the Foundry package listing. The listing title updates from the manifest on the next release — worth confirming it lands as expected. Also worth a check against Necrotic Gnome's third-party license re: using the OSE name in a product title.
