### PR TITLE
fix(inventory): allow dropping items into an expanded container

### DIFF
--- a/src/OscSheet/features/inventory/dragNest.test.tsx
+++ b/src/OscSheet/features/inventory/dragNest.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+// Drag-to-nest wiring: an item dropped anywhere on a container — header row, a
+// child row, or the empty body — must nest into it, open or shut.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { OscSheetContext } from "@app/context";
+import { useDragReorder, type NestArgs } from "@features/inventory/useDragReorder";
+import { SortableRow } from "@features/inventory/rows/SortableRow";
+import { ContainerRow } from "@features/inventory/rows/ContainerRow";
+import { indexById, ROOT, EQUIPPED } from "@features/inventory/groups";
+import type { InventoryItemVM } from "@domain/vm-types";
+import type { OscSheetContextValue } from "@domain/types";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const item = (id: string, over: Partial<InventoryItemVM> = {}): InventoryItemVM => ({
+  id,
+  name: id,
+  img: "",
+  category: "Gear",
+  categoryRank: 2,
+  damage: "",
+  tags: [],
+  monogram: id[0]!,
+  weight: 1,
+  cost: 0,
+  armorClass: null,
+  sort: 100,
+  equippedSort: 100,
+  equipped: false,
+  quantity: null,
+  isContainer: false,
+  children: [],
+  ...over,
+});
+
+const rope = item("rope");
+const arrows = item("arrows");
+const sack = item("sack", { isContainer: true, category: "Container", children: [arrows] });
+const items = [rope, sack];
+
+let container: HTMLDivElement;
+let root: Root;
+const onNest = vi.fn<(a: NestArgs) => void>();
+const onReorder = vi.fn();
+
+function Harness({ collapsed }: { collapsed: boolean }) {
+  const dnd = useDragReorder({ onNest, onReorder });
+  const byId = indexById(items);
+  const noop = () => {};
+  const drag = () => undefined;
+  return (
+    <div>
+      {/* stand-in for an equipped-tray tile: its drags must never nest */}
+      <div data-testid="tray" {...dnd.rowProps(EQUIPPED, 0, { axis: "x" })} />
+      <SortableRow
+        item={rope}
+        index={0}
+        group={ROOT}
+        depth={0}
+        dnd={dnd}
+        itemDragData={drag}
+        onEquip={noop}
+        onOpen={noop}
+        onContext={noop}
+      />
+      <ContainerRow
+        item={sack}
+        index={1}
+        childIds={collapsed ? [] : ["arrows"]}
+        byId={byId}
+        collapsed={collapsed}
+        dnd={dnd}
+        itemDragData={drag}
+        onToggle={noop}
+        onEquip={noop}
+        onOpen={noop}
+        onContext={noop}
+      />
+    </div>
+  );
+}
+
+const ctx = { canEdit: true } as OscSheetContextValue;
+
+function render(collapsed = false) {
+  act(() => {
+    root.render(
+      <OscSheetContext.Provider value={ctx}>
+        <Harness collapsed={collapsed} />
+      </OscSheetContext.Provider>,
+    );
+  });
+}
+
+// jsdom has no DragEvent; a bubbling Event with a dataTransfer stub is enough for
+// React's synthetic drag handlers.
+function fire(el: Element, type: string) {
+  const e = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(e, "dataTransfer", {
+    value: { setData: () => {}, effectAllowed: "", dropEffect: "" },
+  });
+  act(() => {
+    el.dispatchEvent(e);
+  });
+}
+
+function dragOnto(source: Element, target: Element) {
+  fire(source, "dragstart");
+  fire(target, "dragover");
+  fire(target, "drop");
+}
+
+const rows = () => [...container.querySelectorAll(".osc-inv-row")];
+const rowFor = (name: string) =>
+  rows().find((r) => r.querySelector(".nm")?.textContent === name)!;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  onNest.mockClear();
+  onReorder.mockClear();
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("drag to nest", () => {
+  it("nests an item dropped on an expanded container's child row", () => {
+    render(false);
+    dragOnto(rowFor("rope"), rowFor("arrows"));
+    expect(onNest).toHaveBeenCalledWith({
+      fromGroup: ROOT,
+      from: 0,
+      targetIdx: 0,
+      zone: "sack",
+    });
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  it("nests an item dropped on an expanded container's header row", () => {
+    render(false);
+    dragOnto(rowFor("rope"), rowFor("sack"));
+    expect(onNest).toHaveBeenCalledWith({
+      fromGroup: ROOT,
+      from: 0,
+      targetIdx: 1,
+      zone: "sack",
+    });
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  it("nests an item dropped on a collapsed container", () => {
+    render(true);
+    dragOnto(rowFor("rope"), rowFor("sack"));
+    expect(onNest).toHaveBeenCalledWith({
+      fromGroup: ROOT,
+      from: 0,
+      targetIdx: 1,
+      zone: "sack",
+    });
+  });
+
+  it("un-nests a child dropped on a root row", () => {
+    render(false);
+    dragOnto(rowFor("arrows"), rowFor("rope"));
+    expect(onNest).toHaveBeenCalledWith(
+      expect.objectContaining({ fromGroup: "c:sack", from: 0, zone: null }),
+    );
+  });
+
+  it("ignores an equipped-tray drag onto a container child (unequip handles it)", () => {
+    render(false);
+    dragOnto(container.querySelector('[data-testid="tray"]')!, rowFor("arrows"));
+    expect(onNest).not.toHaveBeenCalled();
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+});

--- a/src/OscSheet/features/inventory/rows/ContainerRow.tsx
+++ b/src/OscSheet/features/inventory/rows/ContainerRow.tsx
@@ -35,9 +35,11 @@ export function ContainerRow({
 }) {
   const group = gkey(item.id);
   const count = item.children.length;
-  // Only collapsed containers accept drop-into; an expanded one drags/drops as a
-  // normal root row (fill it by dropping among its visible children instead).
-  const isDropTarget = collapsed && dnd.isInto(ROOT, index);
+  // Open or shut, the whole container is one nest target: its header row, its child
+  // rows, and (when empty) its body all resolve to a drop-into on this container.
+  const isDropTarget =
+    dnd.isInto(ROOT, index) ||
+    (dnd.over?.group === group && dnd.over.where === "into");
   const caret = (
     <button
       type="button"
@@ -61,7 +63,7 @@ export function ContainerRow({
         )}
         onContextMenu={(e) => onContext(e, item)}
         {...dnd.rowProps(ROOT, index, {
-          container: collapsed,
+          container: true,
           containerZone: item.id,
           ownZone: ROOT,
           acceptCrossGroup: (from) => from !== EQUIPPED,
@@ -100,6 +102,7 @@ export function ContainerRow({
                 index={i}
                 group={group}
                 depth={1}
+                nestZone={item.id}
                 dnd={dnd}
                 itemDragData={itemDragData}
                 onEquip={onEquip}

--- a/src/OscSheet/features/inventory/rows/SortableRow.tsx
+++ b/src/OscSheet/features/inventory/rows/SortableRow.tsx
@@ -2,7 +2,7 @@
 import type { InventoryItemVM } from "@domain/vm-types";
 import { ItemImage } from "@features/inventory/ItemImage";
 import { RowEquip } from "@features/inventory/EquippedTray";
-import { weightLabel, ROOT, EQUIPPED } from "@features/inventory/groups";
+import { weightLabel, EQUIPPED } from "@features/inventory/groups";
 import type { Dnd, ItemDragData, OnContext } from "@features/inventory/types";
 import { cx } from "@ui/cx";
 
@@ -65,6 +65,7 @@ export function SortableRow({
   index,
   group,
   depth,
+  nestZone,
   dnd,
   itemDragData,
   onEquip,
@@ -75,6 +76,8 @@ export function SortableRow({
   index: number;
   group: string;
   depth: number;
+  /** Set on a container's child rows: a foreign item dropped here nests into that container. */
+  nestZone?: string;
   dnd: Dnd;
   itemDragData: ItemDragData;
   onEquip: (id: string) => void;
@@ -92,11 +95,13 @@ export function SortableRow({
           : undefined
       }
       onContextMenu={(e) => onContext(e, item)}
-      // Root rows accept a container child dropped among them (un-nest), but NOT a
+      // Root rows accept a container child dropped among them (un-nest); a container's
+      // child rows accept a foreign item (nest into that container). Neither accepts a
       // tray tile — equipped-tray drags onto the list are routed to unequip instead.
       {...dnd.rowProps(group, index, {
         ownZone: group,
-        acceptCrossGroup: group === ROOT ? (from) => from !== EQUIPPED : false,
+        nestZone,
+        acceptCrossGroup: (from) => from !== EQUIPPED,
         dragPayload: () => itemDragData(item.id),
       })}
     >

--- a/src/OscSheet/features/inventory/useDragReorder.ts
+++ b/src/OscSheet/features/inventory/useDragReorder.ts
@@ -23,6 +23,9 @@ type RowOpts = {
   container?: boolean;
   /** Container id reported back as the nest target's `zone`. */
   containerZone?: string;
+  /** This row sits INSIDE container `nestZone`: an accepted cross-group drop here
+   *  nests into that container rather than reordering/un-nesting. */
+  nestZone?: string;
   /** Group/zone label echoed back on reorder. */
   ownZone?: string;
   /** Accept a row dragged in from another group as a before/after drop here
@@ -93,11 +96,12 @@ export function useDragReorder(opts: {
         const into = !!o.container && !isSelf; // a container accepts any item except itself
         const crossGroup = !into && drag.group !== group;
         // Reorder only within the same group, unless this row accepts a cross-group
-        // drop (un-nest): then show a before/after line and route through onNest.
+        // drop (un-nest / nest-into): then route through onNest.
         if (crossGroup && !accepts(o, drag.group)) return;
+        const nestHere = crossGroup && !!o.nestZone; // a row inside a container: drop = nest into it
         e.preventDefault();
         e.dataTransfer.dropEffect = "move";
-        const where: DropWhere = into ? "into" : edgeWhere(e, o.axis ?? "y");
+        const where: DropWhere = into || nestHere ? "into" : edgeWhere(e, o.axis ?? "y");
         if (!over || over.group !== group || over.idx !== idx || over.where !== where)
           setOver({ group, idx, where });
       },
@@ -110,6 +114,8 @@ export function useDragReorder(opts: {
         e.preventDefault();
         if (into) {
           onNest?.({ fromGroup: drag.group, from: drag.idx, targetIdx: idx, zone: o.containerZone ?? null });
+        } else if (crossGroup && o.nestZone) {
+          onNest?.({ fromGroup: drag.group, from: drag.idx, targetIdx: idx, zone: o.nestZone });
         } else if (crossGroup) {
           // Un-nest: drop the foreign row among this group's rows at the drop edge.
           // No self-shift — the item leaves a different group, so `to` isn't perturbed.


### PR DESCRIPTION
## Root cause

An **expanded** container had no drop target at all:

- `rows/ContainerRow.tsx:64` — the header row passed `container: collapsed`, so drop-into was only registered while collapsed. Expanded, it behaved as a plain root row (reorder).
- `rows/SortableRow.tsx:99` — child rows passed `acceptCrossGroup: false` for any group other than ROOT, so a root item dragged onto a child row was rejected in `onDragOver` (no `preventDefault` → not a drop target).
- `rows/ContainerRow.tsx:89` — the children body was a nest target only when `childIds.length === 0`.

So an open container with children was inert on all three surfaces. (An open *empty* one worked, via the body.)

## Fix

- `useDragReorder`: new `RowOpts.nestZone` — a row that lives inside a container. An accepted cross-group drop there routes through `onNest` with `zone = nestZone` (re-parent into the container) instead of the un-nest path. Same-group drops still reorder within the container; equipped-tray drags are still rejected (the list wrapper handles unequip).
- `ContainerRow`: header takes `container: true` (open or shut — matching how a collapsed container already swallows drops), child rows get `nestZone`, and the container highlight now also lights up for a child-row/body "into".

Drop position semantics are unchanged: a nest always appends to the end of the destination group, as before.

## Tests

New `features/inventory/dragNest.test.tsx` (5 cases) drives the real rows + hook through jsdom drag events. The two expanded-container cases fail on `main` and pass here; collapsed-nest, un-nest, and the tray-drag rejection cover the regressions.

`pnpm lint` clean · `pnpm test` 155 passed (was 150) · `pnpm build` OK.
