### PR TITLE
feat(inventory): let owners create items and containers

### DIFF
--- a/src/OscSheet/app/SheetShell.tsx
+++ b/src/OscSheet/app/SheetShell.tsx
@@ -17,6 +17,10 @@ import {
   selectEncumbrance,
   selectCoins,
 } from "@features/inventory/inventory";
+import {
+  createItem,
+  type InventoryItemType,
+} from "@features/inventory/createItem";
 import { flagPath, FLAGS, readFlag } from "@domain/flags";
 import { collectTree, classifyRoute } from "@features/inventory/sendItem";
 import {
@@ -112,6 +116,10 @@ export default function SheetShell() {
     if (!canEdit) return;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     void (actor as any).updateEmbeddedDocuments("Item", updates);
+  };
+  const onCreateItem = (type: InventoryItemType) => {
+    if (!canEdit) return;
+    void createItem(actor, type);
   };
 
   const onEquipItem = (id: string) => {
@@ -350,6 +358,7 @@ export default function SheetShell() {
             encumbrance={selectEncumbrance(actor, invItems as OseItem[])}
             coins={selectCoins(invItems as OseItem[])}
             onSetCoin={onSetCoin}
+            onCreate={onCreateItem}
             onEquip={onEquipItem}
             onOpen={onOpenItem}
             onDelete={onDeleteItem}

--- a/src/OscSheet/features/inventory/AddItemMenu.tsx
+++ b/src/OscSheet/features/inventory/AddItemMenu.tsx
@@ -36,7 +36,7 @@ export function AddItemMenu({
   return (
     <span className="menu-host" ref={host}>
       <IconButton
-        variant="round"
+        variant="accent"
         size="sm"
         title="Add item"
         aria-label="Add item"

--- a/src/OscSheet/features/inventory/AddItemMenu.tsx
+++ b/src/OscSheet/features/inventory/AddItemMenu.tsx
@@ -1,0 +1,67 @@
+// "+" control in the All-Items header: pick an OSE type, create it, land in its sheet.
+import { useEffect, useRef, useState } from "react";
+import { IconButton } from "@ui/IconButton";
+import { Menu, MenuItem, MenuLabel } from "@ui/Menu";
+import type { InventoryItemType } from "@features/inventory/createItem";
+
+const TYPES: { type: InventoryItemType; label: string; icon: string }[] = [
+  { type: "weapon", label: "Weapon", icon: "fa-solid fa-khanda" },
+  { type: "armor", label: "Armor", icon: "fa-solid fa-shield-halved" },
+  { type: "item", label: "Item", icon: "fa-solid fa-box" },
+  { type: "container", label: "Container", icon: "fa-solid fa-bag-shopping" },
+];
+
+export function AddItemMenu({
+  onCreate,
+}: {
+  onCreate: (type: InventoryItemType) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const host = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const close = (e: Event) => {
+      if (!host.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setOpen(false);
+    window.addEventListener("pointerdown", close);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("pointerdown", close);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <span className="menu-host" ref={host}>
+      <IconButton
+        variant="round"
+        size="sm"
+        title="Add item"
+        aria-label="Add item"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+      >
+        <i className="fas fa-plus" aria-hidden="true" />
+      </IconButton>
+      <Menu popover open={open} role="menu">
+        <MenuLabel>New item</MenuLabel>
+        {TYPES.map((t) => (
+          <MenuItem
+            key={t.type}
+            icon={<i className={t.icon} aria-hidden="true" />}
+            tabIndex={0}
+            onClick={() => {
+              setOpen(false);
+              onCreate(t.type);
+            }}
+          >
+            {t.label}
+          </MenuItem>
+        ))}
+      </Menu>
+    </span>
+  );
+}

--- a/src/OscSheet/features/inventory/AddItemMenu.tsx
+++ b/src/OscSheet/features/inventory/AddItemMenu.tsx
@@ -46,7 +46,9 @@ export function AddItemMenu({
       >
         <i className="fas fa-plus" aria-hidden="true" />
       </IconButton>
-      <Menu popover open={open} role="menu">
+      {/* align-start: the trigger sits at the LEFT of the section head, so the menu
+          must open rightward — the default (right: 0) sends it off the sheet's edge. */}
+      <Menu popover open={open} role="menu" className="align-start">
         <MenuLabel>New item</MenuLabel>
         {TYPES.map((t) => (
           <MenuItem

--- a/src/OscSheet/features/inventory/AddItemMenu.tsx
+++ b/src/OscSheet/features/inventory/AddItemMenu.tsx
@@ -46,8 +46,6 @@ export function AddItemMenu({
       >
         <i className="fas fa-plus" aria-hidden="true" />
       </IconButton>
-      {/* align-start: the trigger sits at the LEFT of the section head, so the menu
-          must open rightward — the default (right: 0) sends it off the sheet's edge. */}
       <Menu popover open={open} role="menu" className="align-start">
         <MenuLabel>New item</MenuLabel>
         {TYPES.map((t) => (

--- a/src/OscSheet/features/inventory/InventoryView.stories.tsx
+++ b/src/OscSheet/features/inventory/InventoryView.stories.tsx
@@ -60,6 +60,7 @@ export const Default = () => (
       encumbrance={encumbrance}
       coins={coins}
       onSetCoin={log("setCoin")}
+      onCreate={log("create")}
       onEquip={log("equip")}
       onOpen={log("open")}
       onDelete={log("delete")}

--- a/src/OscSheet/features/inventory/SectionCount.tsx
+++ b/src/OscSheet/features/inventory/SectionCount.tsx
@@ -1,4 +1,5 @@
-// Section header (static — title + "N items · X cn").
+// Section header (static — title + "N items · X cn", plus an optional control slot).
+import type { ReactNode } from "react";
 import type { InventoryItemVM } from "@domain/vm-types";
 import { sectionCountLabel } from "@features/inventory/groups";
 import { SectionTitle } from "@ui/SectionTitle";
@@ -6,13 +7,17 @@ import { SectionTitle } from "@ui/SectionTitle";
 export function SectionCount({
   title,
   items,
+  controls,
 }: {
   title: string;
   items: InventoryItemVM[];
+  controls?: ReactNode;
 }) {
   return (
     <div className="osc-inv-sec-head">
       <SectionTitle variant="sub">{title}</SectionTitle>
+      {/* controls sit beside the title; the count keeps the right edge (margin-left: auto) */}
+      {controls}
       <span className="osc-inv-sec-count">{sectionCountLabel(items)}</span>
     </div>
   );

--- a/src/OscSheet/features/inventory/SectionCount.tsx
+++ b/src/OscSheet/features/inventory/SectionCount.tsx
@@ -16,7 +16,6 @@ export function SectionCount({
   return (
     <div className="osc-inv-sec-head">
       <SectionTitle variant="sub">{title}</SectionTitle>
-      {/* controls sit beside the title; the count keeps the right edge (margin-left: auto) */}
       {controls}
       <span className="osc-inv-sec-count">{sectionCountLabel(items)}</span>
     </div>

--- a/src/OscSheet/features/inventory/createItem.test.ts
+++ b/src/OscSheet/features/inventory/createItem.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createItem, INVENTORY_ITEM_TYPES } from "@features/inventory/createItem";
+import type { OSEActor } from "@domain/types";
+
+const defaultName = vi.fn(({ type }: { type: string }) => `New ${type}`);
+
+beforeEach(() => {
+  (globalThis as { Item?: unknown }).Item = { implementation: { defaultName } };
+});
+afterEach(() => {
+  delete (globalThis as { Item?: unknown }).Item;
+  vi.restoreAllMocks();
+});
+
+function makeActor(render = vi.fn()) {
+  return {
+    createEmbeddedDocuments: vi
+      .fn()
+      .mockResolvedValue([{ sheet: { render } }]),
+  } as unknown as OSEActor & { createEmbeddedDocuments: ReturnType<typeof vi.fn> };
+}
+
+describe("createItem", () => {
+  it("offers exactly the four inventory types (no spell/ability)", () => {
+    expect(INVENTORY_ITEM_TYPES).toEqual(["weapon", "armor", "item", "container"]);
+  });
+
+  it("creates the embedded item with Foundry's default name", async () => {
+    const actor = makeActor();
+    await createItem(actor, "container");
+    expect(actor.createEmbeddedDocuments).toHaveBeenCalledWith("Item", [
+      { type: "container", name: "New container" },
+    ]);
+  });
+
+  it("opens the new item's sheet so the user can fill it in", async () => {
+    const render = vi.fn();
+    const actor = makeActor(render);
+    await createItem(actor, "weapon");
+    expect(render).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/OscSheet/features/inventory/createItem.ts
+++ b/src/OscSheet/features/inventory/createItem.ts
@@ -1,0 +1,36 @@
+import type { OSEActor } from "@domain/types";
+
+/** OSE item types the inventory can create. `spell`/`ability` live on their own tabs. */
+export const INVENTORY_ITEM_TYPES = [
+  "weapon",
+  "armor",
+  "item",
+  "container",
+] as const;
+export type InventoryItemType = (typeof INVENTORY_ITEM_TYPES)[number];
+
+/** Minimal shape for an inventory-item create — fvtt-types doesn't know OSE subtypes. */
+type ItemCreateData = { type: InventoryItemType; name: string };
+
+/** Create a new inventory Item on the actor and open its sheet for editing. */
+export async function createItem(
+  actor: OSEActor,
+  type: InventoryItemType,
+): Promise<void> {
+  const data: ItemCreateData = {
+    type,
+    // Foundry's standard "New <Type>" naming (localized).
+    name: Item.implementation.defaultName({
+      // OSE subtype not in fvtt-types' union.
+      type: type as Item.SubType,
+      parent: actor,
+    }),
+  };
+  const created = await actor.createEmbeddedDocuments(
+    "Item",
+    // OSE subtypes aren't in fvtt-types' union; cast the create payload.
+    [data] as unknown as Parameters<OSEActor["createEmbeddedDocuments"]>[1],
+  );
+  // Foundry returns the created docs; open the first so the user can fill it in.
+  created?.[0]?.sheet?.render(true);
+}

--- a/src/OscSheet/features/inventory/index.tsx
+++ b/src/OscSheet/features/inventory/index.tsx
@@ -31,6 +31,7 @@ import { EquippedTray } from "@features/inventory/EquippedTray";
 import { ItemContextMenu } from "@features/inventory/ItemContextMenu";
 import { EncumbranceReadout } from "@features/inventory/EncumbranceReadout";
 import { SectionCount } from "@features/inventory/SectionCount";
+import { AddItemMenu } from "@features/inventory/AddItemMenu";
 import { SortableRow } from "@features/inventory/rows/SortableRow";
 import { ContainerRow } from "@features/inventory/rows/ContainerRow";
 import { SortHeaderRow } from "@features/inventory/rows/SortHeaderRow";
@@ -62,6 +63,7 @@ export function InventoryView({
   encumbrance,
   coins,
   onSetCoin,
+  onCreate,
   onEquip,
   onOpen,
   onDelete,
@@ -296,7 +298,11 @@ export function InventoryView({
             />
           </div>
         )}
-        <SectionCount title="All Items" items={sortedTop} />
+        <SectionCount
+          title="All Items"
+          items={sortedTop}
+          controls={canEdit ? <AddItemMenu onCreate={onCreate} /> : undefined}
+        />
       </div>
 
       <section className="osc-inv-sec osc-inv-sec--carried">

--- a/src/OscSheet/features/inventory/types.ts
+++ b/src/OscSheet/features/inventory/types.ts
@@ -9,6 +9,7 @@ import type {
 } from "@domain/vm-types";
 import { useDragReorder } from "@features/inventory/useDragReorder";
 import type { SendTargetVM } from "@features/inventory/sendTargets";
+import type { InventoryItemType } from "@features/inventory/createItem";
 
 export type Dnd = ReturnType<typeof useDragReorder>;
 
@@ -17,6 +18,8 @@ export type Dnd = ReturnType<typeof useDragReorder>;
 export type ItemDragData = (id: string) => string | undefined;
 
 export type Ops = {
+  /** Create a new item of the given OSE type and open its sheet to fill in. */
+  onCreate: (type: InventoryItemType) => void;
   onEquip: (id: string) => void;
   onOpen: (id: string) => void;
   onDelete: (id: string) => void;

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -456,8 +456,8 @@
   transform: translateY(-1px);
 }
 // hang the box left of the trigger so the caret keeps its natural 14px inset and
-// still lands on the 18px button's centre (-11 + 14 + half the 12px caret = 9px).
-.osc-inv-sec-head .menu.is-popover.align-start { left: -11px; }
+// still lands on the 18px button's centre.
+.osc-inv-sec-head .menu.is-popover.align-start { left: -12px; }
 
 // --- Equipped tray: dashed-bordered row of large ink-stamp tiles ---
 .osc-equip-tray {

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -455,8 +455,9 @@
   color: var(--text-mute);
   transform: translateY(-1px);
 }
-// the caret's default 14px assumes a 28px trigger; centre it on this 18px one.
-.osc-inv-sec-head .menu.is-popover.align-start::before { left: 3px; }
+// hang the box left of the trigger so the caret keeps its natural 14px inset and
+// still lands on the 18px button's centre (-11 + 14 + half the 12px caret = 9px).
+.osc-inv-sec-head .menu.is-popover.align-start { left: -11px; }
 
 // --- Equipped tray: dashed-bordered row of large ink-stamp tiles ---
 .osc-equip-tray {

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -453,6 +453,18 @@
 }
 // the "+" sits beside the title; the row gap alone spaces it
 .osc-inv-sec-head > .menu-host { display: inline-flex; }
+// Quiet by default: it reads as part of the section label (.section-title.sub is
+// --text-mute), not as a brass call to action. The round variant's brass fill is
+// kept — but only on hover.
+.osc-inv-sec-head .icon-btn.round {
+  color: var(--text-mute);
+  border-color: currentcolor;
+}
+.osc-inv-sec-head .icon-btn.round:hover:not(:disabled) {
+  background: var(--accent-alt);
+  border-color: var(--accent-alt);
+  color: var(--on-accent);
+}
 
 // --- Equipped tray: dashed-bordered row of large ink-stamp tiles ---
 .osc-equip-tray {

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -438,8 +438,10 @@
 // outline-offset drop outline) clears the sticky band instead of being clipped.
 .osc-inv-sec--carried { margin-top: var(--spacer-3); }
 // static (non-collapsible) header: title on the left, "N items · X cn" on the right
+// centred (not baseline) so the icon-btn in the control slot sits on the row's
+// optical centre — matches .section-header, which is the pattern this mirrors.
 .osc-inv-sec-head {
-  display: flex; align-items: baseline; gap: var(--spacer-2); width: 100%;
+  display: flex; align-items: center; gap: var(--spacer-2); width: 100%;
   padding: var(--spacer-1) 0 var(--spacer-2);
   background: var(--bg);
   color: var(--text-mute, #8a8270);
@@ -449,6 +451,8 @@
   font-family: var(--mono); font-size: var(--fs-2xs, 11px);
   color: var(--text-faint, #6a6354); margin-left: auto; white-space: nowrap;
 }
+// the "+" sits beside the title; the row gap alone spaces it
+.osc-inv-sec-head > .menu-host { display: inline-flex; }
 
 // --- Equipped tray: dashed-bordered row of large ink-stamp tiles ---
 .osc-equip-tray {

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -456,7 +456,13 @@
 // A plain glyph, no chrome: at rest it matches the section label
 // (.section-title.sub is --text-mute) rather than reading as a call to action.
 // The accent variant already carries the brass hover.
-.osc-inv-sec-head .icon-btn { color: var(--text-mute); }
+// The nudge is optical, not layout: the label is all-caps, so its glyphs sit above
+// the baseline with empty descender space below — its optical centre is higher than
+// its box centre, and a box-centred glyph beside it reads low.
+.osc-inv-sec-head .icon-btn {
+  color: var(--text-mute);
+  transform: translateY(-1px);
+}
 
 // --- Equipped tray: dashed-bordered row of large ink-stamp tiles ---
 .osc-equip-tray {

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -438,8 +438,6 @@
 // outline-offset drop outline) clears the sticky band instead of being clipped.
 .osc-inv-sec--carried { margin-top: var(--spacer-3); }
 // static (non-collapsible) header: title on the left, "N items · X cn" on the right
-// centred (not baseline) so the icon-btn in the control slot sits on the row's
-// optical centre — matches .section-header, which is the pattern this mirrors.
 .osc-inv-sec-head {
   display: flex; align-items: center; gap: var(--spacer-2); width: 100%;
   padding: var(--spacer-1) 0 var(--spacer-2);
@@ -451,18 +449,14 @@
   font-family: var(--mono); font-size: var(--fs-2xs, 11px);
   color: var(--text-faint, #6a6354); margin-left: auto; white-space: nowrap;
 }
-// the "+" sits beside the title; the row gap alone spaces it
 .osc-inv-sec-head > .menu-host { display: inline-flex; }
-// A plain glyph, no chrome: at rest it matches the section label
-// (.section-title.sub is --text-mute) rather than reading as a call to action.
-// The accent variant already carries the brass hover.
-// The nudge is optical, not layout: the label is all-caps, so its glyphs sit above
-// the baseline with empty descender space below — its optical centre is higher than
-// its box centre, and a box-centred glyph beside it reads low.
+// translateY is optical: the all-caps label's centre sits above its box centre.
 .osc-inv-sec-head .icon-btn {
   color: var(--text-mute);
   transform: translateY(-1px);
 }
+// the caret's default 14px assumes a 28px trigger; centre it on this 18px one.
+.osc-inv-sec-head .menu.is-popover.align-start::before { left: 3px; }
 
 // --- Equipped tray: dashed-bordered row of large ink-stamp tiles ---
 .osc-equip-tray {

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -453,18 +453,10 @@
 }
 // the "+" sits beside the title; the row gap alone spaces it
 .osc-inv-sec-head > .menu-host { display: inline-flex; }
-// Quiet by default: it reads as part of the section label (.section-title.sub is
-// --text-mute), not as a brass call to action. The round variant's brass fill is
-// kept — but only on hover.
-.osc-inv-sec-head .icon-btn.round {
-  color: var(--text-mute);
-  border-color: currentcolor;
-}
-.osc-inv-sec-head .icon-btn.round:hover:not(:disabled) {
-  background: var(--accent-alt);
-  border-color: var(--accent-alt);
-  color: var(--on-accent);
-}
+// A plain glyph, no chrome: at rest it matches the section label
+// (.section-title.sub is --text-mute) rather than reading as a call to action.
+// The accent variant already carries the brass hover.
+.osc-inv-sec-head .icon-btn { color: var(--text-mute); }
 
 // --- Equipped tray: dashed-bordered row of large ink-stamp tiles ---
 .osc-equip-tray {


### PR DESCRIPTION
Adds a canEdit-gated "+" beside the All Items title to create weapon/armor/item/container. Reported in #82.