### PR TITLE
fix(theme): restore normal font smoothing in the cream theme

### DIFF
--- a/src/OscSheet/styles/vellum/tokens.scss
+++ b/src/OscSheet/styles/vellum/tokens.scss
@@ -105,6 +105,11 @@
 /* ─── Cream theme ──────────────────────────────────────────────────── */
 
 [data-theme="cream"] {
+  /* Dark-on-light needs the OS's subpixel smoothing; the body's grayscale
+     antialiasing (tuned for the dark theme) renders it thin and washed out. */
+  -webkit-font-smoothing: auto;
+  -moz-osx-font-smoothing: auto;
+
   --bg:            #efe9d8;
   --bg-2:          #e8e1ca;
   --surface:       #f5efde;


### PR DESCRIPTION
The cream (light) theme renders text thin and hard to read.

`body { -webkit-font-smoothing: antialiased }` (`tokens.scss`) is rewritten to `.osc-sheet` by the vellum scoping pass, so it applies to **both** themes. Grayscale antialiasing is tuned for the dark theme’s light-on-dark text; it thins dark-on-light. The cream block now sets smoothing back to `auto` (higher specificity, so no `!important` needed). Dark theme unchanged.

Reported in #82.

**Gate:** lint pass · 155 tests pass · build pass.