### PR TITLE
fix(sheet): re-derive canEdit from every published context

### DIFF
--- a/src/OscSheet/app/OscSheetProvider.tsx
+++ b/src/OscSheet/app/OscSheetProvider.tsx
@@ -9,7 +9,7 @@ function OscSheetProvider({
   children,
   source,
   contextConnector,
-  canEdit,
+  canEdit: initialCanEdit,
 }: {
   initialActor: OSEActor;
   source: OSEActor;
@@ -18,6 +18,9 @@ function OscSheetProvider({
   canEdit: boolean;
 }) {
   const [actor, setActor] = useState<OSEActor>(initialActor);
+  // Props reach React only at mount, so the edit gate lives in state and re-derives
+  // from every published context — a GM granting ownership mid-session unlocks the sheet.
+  const [canEdit, setCanEdit] = useState(initialCanEdit);
   const [actorData, setActorData] = useState(initialActor.system);
   const [items, setItems] = useState<OseItem[]>(
     initialActor.items.contents as OseItem[]
@@ -51,9 +54,10 @@ function OscSheetProvider({
 
   useEffect(() => {
     const handleUpdate = foundry.utils.debounce(
-      ({ document }: { document: OSEActor }) => {
+      ({ document, isEditable }: OscContext) => {
         _setTimestampedActor(document);
         setItems([...(document.items.contents as OseItem[])]);
+        setCanEdit(isEditable ?? document.isOwner ?? false);
       },
       200
     );

--- a/src/OscSheet/app/readOnlyClass.test.tsx
+++ b/src/OscSheet/app/readOnlyClass.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+// Read-only presentation must track ownership changes, not freeze at mount.
+// `initialProps` reach React only on the first render (foundry-vtt-react mounts
+// once and republishes context thereafter), so a GM granting ownership mid-session
+// must reach the app root through the context connector — including the
+// `.is-readonly` class, which lives ABOVE the provider in ThemedRoot.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import OscSheetApp from "@src/OscSheet";
+import { raistlin } from "@src/OscSheet/__fixtures__/raistlin";
+import type { OSEActor, OscContext } from "@domain/types";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Minimal Foundry globals the shell touches (debounce is passed through so
+// republished context lands synchronously inside act()).
+(globalThis as { foundry?: unknown }).foundry = {
+  utils: { debounce: (fn: unknown) => fn },
+};
+(globalThis as { game?: unknown }).game = {
+  i18n: { localize: (k: string) => k },
+};
+(globalThis as { CONFIG?: unknown }).CONFIG = { OSE: { classes: {} } };
+// jsdom has no ResizeObserver; the layout components observe their containers.
+(globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+let container: HTMLDivElement;
+let root: Root;
+let publish: (ctx: OscContext) => void;
+
+const connector = {
+  onUpdate: (cb: (ctx: OscContext) => void) => (publish = cb),
+  tearDown: vi.fn(),
+} as never;
+
+function makeActor() {
+  const { system, ...rest } = raistlin;
+  return {
+    ...rest,
+    // The view-model fixture omits the bits only the full shell reads: an embedded
+    // item collection (provider) and the spellcasting flag (tab list).
+    system: { ...system, spells: { enabled: false } },
+    items: { contents: [] },
+    update: vi.fn().mockResolvedValue(undefined),
+  } as unknown as OSEActor;
+}
+
+/** Mount the real app root the way osc-sheet.js does: props once, then context. */
+function mount(actor: OSEActor, isEditable: boolean) {
+  act(() =>
+    root.render(
+      <OscSheetApp
+        actor={actor}
+        source={actor}
+        contextConnector={connector}
+        isEditable={isEditable}
+      />,
+    ),
+  );
+}
+
+const appRoot = () => container.querySelector(".osc-sheet-app")!;
+const editButton = () =>
+  [...container.querySelectorAll("button")].find(
+    (b) => b.textContent?.trim() === "✎Edit",
+  );
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("read-only presentation — ownership granted while the sheet is open", () => {
+  it("drops .is-readonly from the app root when the sheet republishes isEditable=true", () => {
+    mount(makeActor(), false);
+    expect(appRoot().classList.contains("is-readonly")).toBe(true);
+
+    act(() => publish({ document: makeActor(), isEditable: true }));
+
+    expect(appRoot().classList.contains("is-readonly")).toBe(false);
+  });
+
+  it("shows the Edit button when the sheet republishes isEditable=true", () => {
+    mount(makeActor(), false);
+    expect(editButton()).toBeUndefined();
+
+    act(() => publish({ document: makeActor(), isEditable: true }));
+
+    expect(editButton()).toBeDefined();
+  });
+
+  it("restores .is-readonly when ownership is revoked", () => {
+    mount(makeActor(), true);
+    expect(appRoot().classList.contains("is-readonly")).toBe(false);
+
+    act(() => publish({ document: makeActor(), isEditable: false }));
+
+    expect(appRoot().classList.contains("is-readonly")).toBe(true);
+  });
+});

--- a/src/OscSheet/app/writeGate.test.tsx
+++ b/src/OscSheet/app/writeGate.test.tsx
@@ -8,7 +8,7 @@ import { createRoot, type Root } from "react-dom/client";
 import OscSheetProvider from "./OscSheetProvider";
 import { OptimisticProvider } from "./OptimisticProvider";
 import { useOscSheetContext } from "./context";
-import type { OSEActor, OscSheetContextValue } from "@domain/types";
+import type { OSEActor, OscContext, OscSheetContextValue } from "@domain/types";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -104,5 +104,59 @@ describe("write layer — read-only gate", () => {
       await new Promise((r) => setTimeout(r, 5));
     });
     expect(commit).toHaveBeenCalledOnce();
+  });
+});
+
+// canEdit is published on every context update, not frozen at mount: a GM granting
+// ownership while the sheet is open must unlock it without a close/reopen.
+describe("write layer — canEdit re-derives from the published context", () => {
+  let publish: (ctx: OscContext) => void;
+  const liveConnector = {
+    onUpdate: (cb: (ctx: OscContext) => void) => (publish = cb),
+    tearDown: vi.fn(),
+  } as never;
+
+  function renderLive(actor: OSEActor, canEdit: boolean) {
+    act(() =>
+      root.render(
+        <OscSheetProvider
+          initialActor={actor}
+          source={actor}
+          contextConnector={liveConnector}
+          canEdit={canEdit}
+        >
+          <Capture />
+        </OscSheetProvider>,
+      ),
+    );
+  }
+
+  it("flips read-only → editable when the sheet republishes isEditable=true", async () => {
+    const actor = makeActor();
+    renderLive(actor, false);
+    expect(ctx.canEdit).toBe(false);
+
+    act(() => publish({ document: actor, isEditable: true }));
+    expect(ctx.canEdit).toBe(true);
+
+    await act(async () => {
+      await ctx.updateActor({ "system.hp.value": 7 });
+    });
+    expect((actor as unknown as { update: ReturnType<typeof vi.fn> }).update).toHaveBeenCalled();
+  });
+
+  it("flips editable → read-only when ownership is revoked", () => {
+    const actor = makeActor();
+    renderLive(actor, true);
+    act(() => publish({ document: actor, isEditable: false }));
+    expect(ctx.canEdit).toBe(false);
+  });
+
+  it("falls back to actor.isOwner when the context omits isEditable", () => {
+    const actor = makeActor();
+    (actor as unknown as { isOwner: boolean }).isOwner = true;
+    renderLive(actor, false);
+    act(() => publish({ document: actor }));
+    expect(ctx.canEdit).toBe(true);
   });
 });

--- a/src/OscSheet/domain/types.ts
+++ b/src/OscSheet/domain/types.ts
@@ -17,6 +17,9 @@ export type AttackType = AttackKind | "attack";
 // Add props as needed
 export type OscContext = {
   document: OSEActor;
+  /** Foundry's `sheet.isEditable`, republished on every render (ownership can change
+   *  while the sheet is open). Absent outside a Foundry sheet (Storybook / tests). */
+  isEditable?: boolean;
 };
 
 export type OscSheetAppProps = {

--- a/src/OscSheet/index.tsx
+++ b/src/OscSheet/index.tsx
@@ -6,6 +6,7 @@ import "./styles/vellum/components.css";
 import "./styles/styles.scss";
 import "./styles/edit-modal.scss";
 import OscSheetProvider from "@app/OscSheetProvider";
+import { useOscSheetContext } from "@app/context";
 import { OptimisticProvider } from "@app/OptimisticProvider";
 import { SheetErrorBoundary, CrashTestProbe } from "@app/ErrorBoundary";
 import SheetShell from "@app/SheetShell";
@@ -14,14 +15,14 @@ import { useEffect, useRef, type ReactNode } from "react";
 
 /** App root element. Theme is owned by the window (osc-sheet.js `_onRender`
  *  sets data-theme on this.element from the client setting), so this only stops
- *  mousedown bubbling into Foundry. */
-function ThemedRoot({
-  children,
-  canEdit,
-}: {
-  children: ReactNode;
-  canEdit: boolean;
-}) {
+ *  mousedown bubbling into Foundry.
+ *
+ *  Sits INSIDE OscSheetProvider and reads `canEdit` from context, not from a
+ *  prop: props reach React only at mount, so a mount-time prop would freeze
+ *  `.is-readonly` while the provider's gate re-derived — leaving the sheet
+ *  functionally editable but still styled read-only after a mid-session grant. */
+function ThemedRoot({ children }: { children: ReactNode }) {
+  const { canEdit } = useOscSheetContext();
   const appRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -52,27 +53,27 @@ function OscSheetApp({
   contextConnector,
   isEditable,
 }: OscSheetAppProps) {
-  // Prefer Foundry's authoritative `sheet.isEditable`; fall back to ownership
-  // when mounted outside a Foundry sheet (Storybook / tests).
+  // Seeds the provider's gate; it re-derives from every published context after.
+  // Falls back to ownership when mounted outside a Foundry sheet (Storybook/tests).
   const canEdit = isEditable ?? actor?.isOwner ?? false;
   return (
-    <ThemedRoot canEdit={canEdit}>
-      <SheetErrorBoundary actor={actor}>
-        <ToastProvider>
-          <OscSheetProvider
-            initialActor={actor!}
-            source={source!}
-            contextConnector={contextConnector}
-            canEdit={canEdit}
-          >
+    <SheetErrorBoundary actor={actor}>
+      <OscSheetProvider
+        initialActor={actor!}
+        source={source!}
+        contextConnector={contextConnector}
+        canEdit={canEdit}
+      >
+        <ThemedRoot>
+          <ToastProvider>
             <OptimisticProvider>
               <SheetShell />
               <CrashTestProbe />
             </OptimisticProvider>
-          </OscSheetProvider>
-        </ToastProvider>
-      </SheetErrorBoundary>
-    </ThemedRoot>
+          </ToastProvider>
+        </ThemedRoot>
+      </OscSheetProvider>
+    </SheetErrorBoundary>
   );
 }
 

--- a/src/applications/osc-sheet.js
+++ b/src/applications/osc-sheet.js
@@ -158,6 +158,9 @@ class OscSheet extends ReactActorSheetV2 {
     const context = await super._prepareContext(options);
     // You can add additional context data here if needed
     context.rootId = this.rootId;
+    // Published on every render (initialProps only reach React at mount), so the
+    // sheet re-derives its edit gate when ownership changes while it's open.
+    context.isEditable = this.isEditable;
     context.initialProps = {
       actor: context.document,
       source: context.source,


### PR DESCRIPTION
`canEdit` was captured once at mount and never re-derived: `mountApp` only runs on the first render, and every later render just calls `publishContext`. So a GM granting a player ownership **while their sheet is open** left it read-only until the sheet was closed and reopened, with nothing explaining why.

`isEditable` is now published on the context and `canEdit` lives in provider state, so it re-derives on every update. Write-gate semantics are unchanged.

Adds regression tests for flip-on, flip-off and the `isOwner` fallback — this was never covered.

Found while investigating the "players cannot edit their own stats" report in #82; the permission gate itself turned out to be correct, but this is a real bug in its own right.

fixes osc-100

**Gate:** lint pass · 158 tests pass · build pass.