### PR TITLE
fix(edit): match the sheet's ability score order

### DIFF
--- a/src/OscSheet/features/edit/EditModal.tsx
+++ b/src/OscSheet/features/edit/EditModal.tsx
@@ -57,7 +57,9 @@ function HitDiceField({
 const fmtMod = (n: number) => (n >= 0 ? "+" : "") + n;
 const clamp = (n: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, n));
 
-const ABIL_ORDER = ["str", "dex", "con", "int", "wis", "cha"] as const;
+// Mirrors the sheet's plaque order (features/actions/abilities.ts) — editing scores in a
+// different order than they're displayed invites typing a value into the wrong field.
+const ABIL_ORDER = ["str", "int", "wis", "dex", "con", "cha"] as const;
 const ALIGNMENTS = ["Lawful", "Neutral", "Chaotic"];
 const SAVE_DEFS: { k: OSESave; n: string }[] = [
   { k: "death", n: "Death / Poison" },


### PR DESCRIPTION
The edit modal lists ability scores in a different order than the sheet displays them:

- **Sheet** (`features/actions/abilities.ts`) — B/X order: STR · INT · WIS · DEX · CON · CHA
- **Edit modal** (`features/edit/EditModal.tsx`) — classic order: STR · DEX · CON · INT · WIS · CHA

Reading scores in one order and editing them in another is a straightforward way to type a value into the wrong field — and creation / level-up is exactly when six numbers get typed in a row. One line.

**Gate:** lint pass · 155 tests pass · build pass.