### PR TITLE
fix(inventory): report the real coin weight, not an assumed 1 cn

### DIFF
--- a/src/OscSheet/domain/vm-types.ts
+++ b/src/OscSheet/domain/vm-types.ts
@@ -172,6 +172,8 @@ export interface CoinVM {
   value: number;
   /** gp value of one coin of this denom (system.cost, std fallback) — for the wealth total. */
   gpEach: number;
+  /** cn weight of one coin (system.weight, 0 when unset) — what OSE actually encumbers by. */
+  cnEach: number;
 }
 
 /** 0 unencumbered · 1/2/3 OSE movement breakpoints · 4 overloaded (over max). */

--- a/src/OscSheet/features/inventory/InventoryView.stories.tsx
+++ b/src/OscSheet/features/inventory/InventoryView.stories.tsx
@@ -46,9 +46,9 @@ const inventory: InventoryVM = {
 
 const encumbrance: EncumbranceVM = { enabled: true, value: 380, max: 1600, pct: 0.2375, tier: 0, status: "Unencumbered", label: "380 / 1600 cn", move: 120 };
 const coins = [
-  { denom: "PP", id: "pp", name: "Platinum Pieces", img: "", value: 0, gpEach: 5 },
-  { denom: "GP", id: "gp", name: "Gold Pieces", img: "", value: 152, gpEach: 1 },
-  { denom: "SP", id: "sp", name: "Silver Pieces", img: "", value: 8, gpEach: 0.1 },
+  { denom: "PP", id: "pp", name: "Platinum Pieces", img: "", value: 0, gpEach: 5, cnEach: 1 },
+  { denom: "GP", id: "gp", name: "Gold Pieces", img: "", value: 152, gpEach: 1, cnEach: 1 },
+  { denom: "SP", id: "sp", name: "Silver Pieces", img: "", value: 8, gpEach: 0.1, cnEach: 1 },
 ];
 
 const log = (label: string) => (...args: unknown[]) => console.log(label, ...args);

--- a/src/OscSheet/features/inventory/WealthSection.tsx
+++ b/src/OscSheet/features/inventory/WealthSection.tsx
@@ -22,8 +22,8 @@ function fmtCoin(n: number): string {
 /** Wealth section: a header bar (overlapping coin dots · total gp · carried weight)
  *  that toggles a coin table — per-denomination qty (editable), weight, and gp
  *  value, with a totals row. Columns are sortable and rows are drag-reorderable
- *  (a drag bakes the current order as the manual baseline). Coins are 1 cn each,
- *  so qty edits feed the encumbrance figure too. */
+ *  (a drag bakes the current order as the manual baseline). Weight is qty × the
+ *  item's own cn, matching what OSE encumbers by (0-weight coin items weigh 0). */
 export function WealthSection({
   coins,
   onSetCoin,
@@ -62,6 +62,8 @@ export function WealthSection({
     return Number.isNaN(n) ? 0 : Math.max(0, n);
   };
 
+  const cnOf = (c: CoinVM) => qtyOf(c) * c.cnEach;
+
   // Sorted view: manual = the drag order; a column sort orders a copy by that key.
   const rows = sort.key === "manual"
     ? manual
@@ -70,7 +72,9 @@ export function WealthSection({
           ? a.name.localeCompare(b.name)
           : sort.key === "value"
             ? qtyOf(a) * a.gpEach - qtyOf(b) * b.gpEach
-            : qtyOf(a) - qtyOf(b); // qty or weight (1 cn each)
+            : sort.key === "weight"
+              ? cnOf(a) - cnOf(b)
+              : qtyOf(a) - qtyOf(b);
         return sort.dir === "asc" ? cmp : -cmp;
       });
 
@@ -109,7 +113,7 @@ export function WealthSection({
     setSort((s) => (s.key === key ? { key, dir: s.dir === "asc" ? "desc" : "asc" } : { key, dir: "asc" }));
 
   const totalGp = rows.reduce((s, c) => s + qtyOf(c) * c.gpEach, 0);
-  const weight = rows.reduce((s, c) => s + qtyOf(c), 0);
+  const weight = rows.reduce((s, c) => s + cnOf(c), 0);
   const dots = rows.filter((c) => qtyOf(c) > 0).map((c) => c.denom);
   const hasCoins = rows.length > 0;
 
@@ -219,7 +223,7 @@ export function WealthSection({
                   onKeyDown={(e) => { if (e.key === "Enter") { commit(c); setOpen(false); } }}
                   onBlur={() => commit(c)}
                 />
-                <span className="osc-coin-wt">{fmtCoin(qtyOf(c))} cn</span>
+                <span className="osc-coin-wt">{fmtCoin(cnOf(c))} cn</span>
                 <span className="osc-coin-val">{fmtCoin(qtyOf(c) * c.gpEach)} gp</span>
               </div>
             );

--- a/src/OscSheet/features/inventory/inventory.test.ts
+++ b/src/OscSheet/features/inventory/inventory.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { selectInventory, selectEncumbrance, selectCoins, sortInventory, sortEquipped, coinDenom } from "@features/inventory/inventory";
 import type { OseItem, OSEActor } from "@domain/types";
+import type { CoinVM } from "@domain/vm-types";
 import { MODULE_ID, FLAGS } from "@domain/flags";
 
 const mk = (
@@ -304,6 +305,38 @@ describe("selectCoins", () => {
     expect(by).toEqual({ GP: 1, EP: 0.5, CP: 0.01 });
     // total = 1·1 + 300·0.5 + 50·0.01 = 151.5 gp
     expect(coins.reduce((s, c) => s + c.value * c.gpEach, 0)).toBeCloseTo(151.5);
+  });
+
+  it("reads cnEach from system.weight — never an assumed 1 cn per coin", () => {
+    const coins = selectCoins([
+      mk("item", "GP", { treasure: true, weight: 1, quantity: { value: 20 } }),
+      mk("item", "SP", { treasure: true, weight: 0, quantity: { value: 500 } }),
+      mk("item", "CP", { treasure: true, quantity: { value: 90 } }), // weight unset → 0
+    ]);
+    expect(Object.fromEntries(coins.map((c) => [c.denom, c.cnEach]))).toEqual({ GP: 1, SP: 0, CP: 0 });
+
+    // Wealth weight = qty × cnEach: weighted coins count, 0-weight coins count 0.
+    const wt = (cs: CoinVM[]) => cs.reduce((s, c) => s + c.value * c.cnEach, 0);
+    expect(wt(coins.filter((c) => c.denom === "GP"))).toBe(20);
+    expect(wt(coins.filter((c) => c.denom !== "GP"))).toBe(0);
+    expect(wt(coins)).toBe(20);
+  });
+
+  it("wealth weight equals the coins' encumbrance contribution (qty × weight)", () => {
+    const coinItems = [
+      mk("item", "GP", { treasure: true, weight: 1, quantity: { value: 250 } }),
+      mk("item", "SP", { treasure: true, weight: 0, quantity: { value: 400 } }),
+    ];
+    // OSE encumbers by qty × system.weight; the Wealth figure must never disagree with it.
+    const oseLoad = coinItems.reduce(
+      (s, it) =>
+        s +
+        (it.system.quantity?.value ?? 0) * ((it.system as { weight?: number }).weight ?? 0),
+      0,
+    );
+    const wealthWeight = selectCoins(coinItems).reduce((s, c) => s + c.value * c.cnEach, 0);
+    expect(wealthWeight).toBe(oseLoad);
+    expect(wealthWeight).toBe(250);
   });
 });
 

--- a/src/OscSheet/features/inventory/inventory.ts
+++ b/src/OscSheet/features/inventory/inventory.ts
@@ -79,6 +79,9 @@ export function selectCoins(items: OseItem[]): CoinVM[] {
         img: (it.img as string) ?? "",
         value: it.system.quantity?.value ?? 0,
         gpEach: cost > 0 ? cost : (GP_PER_COIN[d] ?? 0),
+        // No 1 cn fallback: OSE encumbers by qty × system.weight, so an unweighted coin
+        // item really does weigh nothing — assuming otherwise contradicts the total.
+        cnEach: (it.system as { weight?: number }).weight ?? 0,
       },
     ];
   });


### PR DESCRIPTION
The Wealth section's weight figure and OSE's encumbrance total disagreed.

OSE computes encumbrance as `quantity × system.weight`. Item weight defaults to `0`, and OSE ships no coin items — so coin items come from third-party compendiums/modules where weight is commonly left at 0. The sheet, meanwhile, hardcoded 1 cn per coin and summed quantity, so it claimed coins weighed N cn while they contributed exactly 0 to encumbrance.

Now `CoinVM` carries `cnEach` (the backing item's real `system.weight`, 0 when unset) and the Wealth weight — header figure, per-row weight column, totals row, and weight sort — is `qty × cnEach`. Properly-weighted coin items show up in both figures; 0-weight coin items show 0 in both. The two can no longer contradict each other.

No user data is migrated or mutated: a 0-weight coin item is the user's setup to fix, not ours to rewrite.

Addresses feedback in #82.

Gates: `pnpm lint` · `pnpm test` (157 passing) · `pnpm build` all green.