### PR TITLE
Movement rates: encumbrance readout + header MOVE tile

### DIFF
--- a/.claude/skills/vellum-styling/SKILL.md
+++ b/.claude/skills/vellum-styling/SKILL.md
@@ -39,11 +39,16 @@ Prefix `u-`. Values are always tokens — never invent a value.
 - **Spacing:** `u-p*`/`u-m*` on the spacer scale — `u-p-N`, `u-px-N`, `u-py-N`,
   `u-pt/pr/pb/pl-N`, `u-m-N`, `u-mx/my/mt/mr/mb/ml-N`, plus keyword
   `u-m-auto`/`u-mx-auto`/`u-mt-auto`/`u-mr-auto`/`u-ml-auto`
-- **Font size:** `u-fs-{3xs…8xs}` (see scale below)
+- **Font size:** `u-fs-{3xs…8xl}` (see scale below)
 - **Radius:** `u-r-{sm|md|lg|xl}`
 - **Color:** text `u-text`, `u-text-{dim|muted|faint|accent|brass|danger|warn|success|on-accent}`;
   bg `u-bg`, `u-bg-{2|surface|surface-2|surface-3|ink|accent|brass|danger}`;
   border `u-border`, `u-border-{soft|accent|brass|danger|none}`
+- **Foundry responsive display:** `u-foundry-{tier}-display-{value}` (`value` =
+  `none|flex|block|grid|inline-flex`). Tiers `xs`=0 (base) / `md`=480 / `lg`=740
+  (`sm` reserved, unused) are min-width "and up" on the `app` container. Mobile-
+  first hide/show — e.g. `u-foundry-xs-display-none u-foundry-md-display-flex`
+  (hidden on narrow, shown ≥480).
 
 Note: there is **no** "flex column without gap" utility (`u-stack` forces gap-3).
 A tight/no-gap column stays bespoke SCSS.

--- a/src/OscSheet/app/SheetShell.tsx
+++ b/src/OscSheet/app/SheetShell.tsx
@@ -75,6 +75,9 @@ export default function SheetShell() {
       travel: movement.overland,
     },
   };
+  // One encumbrance VM for both consumers — the header MOVE hover and the inventory
+  // rates line must never disagree about the tier.
+  const encumbrance = selectEncumbrance(actor, invItems as OseItem[]);
   // Read-only sheets get no HP stepper/input (undefined onSetHp → static value).
   const onSetHp = !canEdit ? undefined : (value: number) => {
     const next = Math.max(0, Math.min(vitals.hp.max, value));
@@ -316,6 +319,7 @@ export default function SheetShell() {
           <HeaderBand
             identity={identity}
             vitals={vitals}
+            encumbrance={encumbrance}
             onSetHp={onSetHp}
             // Intentionally gated on canEdit (= Foundry `sheet.isEditable`), not
             // raw actor.isOwner: a locked/compendium sheet legitimately shouldn't
@@ -347,7 +351,7 @@ export default function SheetShell() {
         ) : activeTab.id === TabIds.INVENTORY ? (
           <InventoryView
             inventory={selectInventory(invItems as OseItem[])}
-            encumbrance={selectEncumbrance(actor, invItems as OseItem[])}
+            encumbrance={encumbrance}
             coins={selectCoins(invItems as OseItem[])}
             onSetCoin={onSetCoin}
             onEquip={onEquipItem}

--- a/src/OscSheet/components/ui/MovePop.tsx
+++ b/src/OscSheet/components/ui/MovePop.tsx
@@ -2,19 +2,15 @@
 // encumbrance line. `MoveTooltip` is the single source for the popover BODY — both
 // call sites render it, neither re-composes the rows, so the two hovers can never
 // drift apart again. The tier→colour helper lives in @domain/format (encTierClass).
-import type { ReactNode } from "react";
+//
+// The popover is `position: fixed`, positioned in JS off its trigger's rect. Fixed
+// (with no transformed ancestor — verified for the sheet shell) is NOT clipped by an
+// ancestor's `overflow: auto/hidden`, so the popover renders in full even when it
+// lives inside a self-scrolling container like the capped character rail.
+import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import type { EncumbranceTier, MoveBands } from "@domain/vm-types";
 import { encTierClass } from "@domain/format";
 import { cx } from "@ui/cx";
-
-/** Hover popover shell (`.osc-move-pop` — the styles both hovers share). */
-function StatPop({ children }: { children: ReactNode }) {
-  return (
-    <span className="osc-move-pop" role="tooltip">
-      {children}
-    </span>
-  );
-}
 
 /** One key/value line inside the popover; `vClass` tints the value (tier colour). */
 function PopRow({ k, v, vClass }: { k: ReactNode; v: ReactNode; vClass?: string }) {
@@ -26,10 +22,59 @@ function PopRow({ k, v, vClass }: { k: ReactNode; v: ReactNode; vClass?: string 
   );
 }
 
+// Hidden until the trigger (this element's parent) is hovered/focused; then pinned
+// with `position: fixed` just under the trigger. Repositions on scroll/resize so it
+// stays glued while open. Returns the ref for the popover element + its inline style.
+function useTriggerAnchoredFixed(): {
+  ref: React.RefObject<HTMLSpanElement | null>;
+  style: CSSProperties;
+} {
+  const ref = useRef<HTMLSpanElement>(null);
+  const [style, setStyle] = useState<CSSProperties>({ display: "none" });
+
+  useEffect(() => {
+    const trigger = ref.current?.parentElement;
+    if (!trigger) return;
+    let open = false;
+    const place = () => {
+      const r = trigger.getBoundingClientRect();
+      setStyle({ position: "fixed", top: r.bottom + 6, left: r.left });
+    };
+    const show = () => {
+      open = true;
+      place();
+    };
+    const hide = () => {
+      open = false;
+      setStyle({ display: "none" });
+    };
+    const reposition = () => {
+      if (open) place();
+    };
+    trigger.addEventListener("pointerenter", show);
+    trigger.addEventListener("pointerleave", hide);
+    trigger.addEventListener("focusin", show);
+    trigger.addEventListener("focusout", hide);
+    window.addEventListener("scroll", reposition, true);
+    window.addEventListener("resize", reposition);
+    return () => {
+      trigger.removeEventListener("pointerenter", show);
+      trigger.removeEventListener("pointerleave", hide);
+      trigger.removeEventListener("focusin", show);
+      trigger.removeEventListener("focusout", hide);
+      window.removeEventListener("scroll", reposition, true);
+      window.removeEventListener("resize", reposition);
+    };
+  }, []);
+
+  return { ref, style };
+}
+
 /**
- * The one and only movement popover body: the three OSE rates (full labels) plus
- * the encumbrance tier that explains them. Rendered verbatim by BOTH the header MOVE
- * tile and the encumbrance line — change it here, both change.
+ * The one and only movement popover body: the three OSE rates (full labels, each in
+ * its own unit) plus the encumbrance tier that explains them. Rendered verbatim by
+ * BOTH the header MOVE tile and the encumbrance line — change it here, both change.
+ * Must be placed as a direct child of the trigger element (its parent = the anchor).
  */
 export function MoveTooltip({
   bands,
@@ -41,31 +86,58 @@ export function MoveTooltip({
   tier?: EncumbranceTier;
   status?: string;
 }) {
+  const { ref, style } = useTriggerAnchoredFixed();
   return (
-    <StatPop>
-      <PopRow k="Encounter" v={`${bands.encounter}′`} />
-      <PopRow k="Explore" v={`${bands.explore}′`} />
-      <PopRow k="Travel" v={`${bands.travel} mi`} />
+    <span className="osc-move-pop" role="tooltip" ref={ref} style={style}>
+      {/* per-unit suffixes match the OSE rate the value is quoted in — don't cross
+          them: explore is per turn, encounter per round, travel miles per day. */}
+      <PopRow k="Encounter" v={`${bands.encounter}′/round`} />
+      <PopRow k="Explore" v={`${bands.explore}′/turn`} />
+      <PopRow k="Travel" v={`${bands.travel} mi/day`} />
       {tier !== undefined && status && (
         <PopRow k="Encumbrance" v={status} vClass={encTierClass(tier)} />
       )}
-    </StatPop>
+    </span>
   );
 }
 
-/** The three rates on one line, terse: `120′ · 40′ · 24mi` (explore · encounter · travel). */
+/** The three rates on one line, terse: `120′ / 40′ / 24mi` (explore / encounter / travel). */
 export function MoveRates({ bands }: { bands: MoveBands }) {
   return (
     <>
       <span className="rate">{bands.explore}′</span>
       <span className="sep" aria-hidden="true">
-        ·
+        /
       </span>
       <span className="rate">{bands.encounter}′</span>
       <span className="sep" aria-hidden="true">
-        ·
+        /
       </span>
       <span className="rate">{bands.travel}mi</span>
+    </>
+  );
+}
+
+/** The full-unit form: `90′/turn · 30′/round · 18 mi/day` — for the reference rail. */
+export function MoveRatesFull({ bands }: { bands: MoveBands }) {
+  return (
+    <>
+      <span className="rate">
+        {bands.explore}′<span className="u">/turn</span>
+      </span>
+      <span className="sep" aria-hidden="true">
+        ·
+      </span>
+      <span className="rate">
+        {bands.encounter}′<span className="u">/round</span>
+      </span>
+      <span className="sep" aria-hidden="true">
+        ·
+      </span>
+      <span className="rate">
+        {bands.travel}
+        <span className="u"> mi/day</span>
+      </span>
     </>
   );
 }

--- a/src/OscSheet/components/ui/MovePop.tsx
+++ b/src/OscSheet/components/ui/MovePop.tsx
@@ -1,12 +1,14 @@
-// Shared markup for the two movement hovers — the header MOVE tile and the
-// inventory encumbrance line — so both tell the same story from one source.
-// The tier→colour helper lives in @domain/format (see encTierClass).
+// The movement hover popover, shared by the header MOVE tile and the inventory
+// encumbrance line. `MoveTooltip` is the single source for the popover BODY — both
+// call sites render it, neither re-composes the rows, so the two hovers can never
+// drift apart again. The tier→colour helper lives in @domain/format (encTierClass).
 import type { ReactNode } from "react";
-import type { MoveBands } from "@domain/vm-types";
+import type { EncumbranceTier, MoveBands } from "@domain/vm-types";
+import { encTierClass } from "@domain/format";
 import { cx } from "@ui/cx";
 
 /** Hover popover shell (`.osc-move-pop` — the styles both hovers share). */
-export function StatPop({ children }: { children: ReactNode }) {
+function StatPop({ children }: { children: ReactNode }) {
   return (
     <span className="osc-move-pop" role="tooltip">
       {children}
@@ -14,8 +16,8 @@ export function StatPop({ children }: { children: ReactNode }) {
   );
 }
 
-/** One key/value line inside a `StatPop`; `vClass` tints the value (tier colour). */
-export function PopRow({ k, v, vClass }: { k: ReactNode; v: ReactNode; vClass?: string }) {
+/** One key/value line inside the popover; `vClass` tints the value (tier colour). */
+function PopRow({ k, v, vClass }: { k: ReactNode; v: ReactNode; vClass?: string }) {
   return (
     <span className="r">
       <span className="k">{k}</span>
@@ -24,37 +26,46 @@ export function PopRow({ k, v, vClass }: { k: ReactNode; v: ReactNode; vClass?: 
   );
 }
 
-/** The three OSE rates as popover rows (per-round · per-turn · per-day). */
-export function MoveRateRows({ bands }: { bands: MoveBands }) {
+/**
+ * The one and only movement popover body: the three OSE rates (full labels) plus
+ * the encumbrance tier that explains them. Rendered verbatim by BOTH the header MOVE
+ * tile and the encumbrance line — change it here, both change.
+ */
+export function MoveTooltip({
+  bands,
+  tier,
+  status,
+}: {
+  bands: MoveBands;
+  /** Omit both to show rates only (e.g. encumbrance tracking disabled). */
+  tier?: EncumbranceTier;
+  status?: string;
+}) {
   return (
-    <>
+    <StatPop>
       <PopRow k="Encounter" v={`${bands.encounter}′`} />
       <PopRow k="Explore" v={`${bands.explore}′`} />
       <PopRow k="Travel" v={`${bands.travel} mi`} />
-    </>
+      {tier !== undefined && status && (
+        <PopRow k="Encumbrance" v={status} vClass={encTierClass(tier)} />
+      )}
+    </StatPop>
   );
 }
 
-/** The same three rates on one line, units inline (ft/turn · ft/round · mi/day). */
+/** The three rates on one line, terse: `120′ · 40′ · 24mi` (explore · encounter · travel). */
 export function MoveRates({ bands }: { bands: MoveBands }) {
   return (
     <>
-      <span className="rate">
-        {bands.explore}′<span className="u">/turn</span>
-      </span>
+      <span className="rate">{bands.explore}′</span>
       <span className="sep" aria-hidden="true">
         ·
       </span>
-      <span className="rate">
-        {bands.encounter}′<span className="u">/round</span>
-      </span>
+      <span className="rate">{bands.encounter}′</span>
       <span className="sep" aria-hidden="true">
         ·
       </span>
-      <span className="rate">
-        {bands.travel}
-        <span className="u"> mi/day</span>
-      </span>
+      <span className="rate">{bands.travel}mi</span>
     </>
   );
 }

--- a/src/OscSheet/components/ui/MovePop.tsx
+++ b/src/OscSheet/components/ui/MovePop.tsx
@@ -1,0 +1,60 @@
+// Shared markup for the two movement hovers — the header MOVE tile and the
+// inventory encumbrance line — so both tell the same story from one source.
+// The tier→colour helper lives in @domain/format (see encTierClass).
+import type { ReactNode } from "react";
+import type { MoveBands } from "@domain/vm-types";
+import { cx } from "@ui/cx";
+
+/** Hover popover shell (`.osc-move-pop` — the styles both hovers share). */
+export function StatPop({ children }: { children: ReactNode }) {
+  return (
+    <span className="osc-move-pop" role="tooltip">
+      {children}
+    </span>
+  );
+}
+
+/** One key/value line inside a `StatPop`; `vClass` tints the value (tier colour). */
+export function PopRow({ k, v, vClass }: { k: ReactNode; v: ReactNode; vClass?: string }) {
+  return (
+    <span className="r">
+      <span className="k">{k}</span>
+      <span className={cx("vv", vClass)}>{v}</span>
+    </span>
+  );
+}
+
+/** The three OSE rates as popover rows (per-round · per-turn · per-day). */
+export function MoveRateRows({ bands }: { bands: MoveBands }) {
+  return (
+    <>
+      <PopRow k="Encounter" v={`${bands.encounter}′`} />
+      <PopRow k="Explore" v={`${bands.explore}′`} />
+      <PopRow k="Travel" v={`${bands.travel} mi`} />
+    </>
+  );
+}
+
+/** The same three rates on one line, units inline (ft/turn · ft/round · mi/day). */
+export function MoveRates({ bands }: { bands: MoveBands }) {
+  return (
+    <>
+      <span className="rate">
+        {bands.explore}′<span className="u">/turn</span>
+      </span>
+      <span className="sep" aria-hidden="true">
+        ·
+      </span>
+      <span className="rate">
+        {bands.encounter}′<span className="u">/round</span>
+      </span>
+      <span className="sep" aria-hidden="true">
+        ·
+      </span>
+      <span className="rate">
+        {bands.travel}
+        <span className="u"> mi/day</span>
+      </span>
+    </>
+  );
+}

--- a/src/OscSheet/components/ui/MovePop.tsx
+++ b/src/OscSheet/components/ui/MovePop.tsx
@@ -91,8 +91,8 @@ export function MoveTooltip({
     <span className="osc-move-pop" role="tooltip" ref={ref} style={style}>
       {/* per-unit suffixes match the OSE rate the value is quoted in — don't cross
           them: explore is per turn, encounter per round, travel miles per day. */}
-      <PopRow k="Encounter" v={`${bands.encounter}′/round`} />
-      <PopRow k="Explore" v={`${bands.explore}′/turn`} />
+      <PopRow k="Encounter" v={`${bands.encounter}ft/round`} />
+      <PopRow k="Explore" v={`${bands.explore}ft/turn`} />
       <PopRow k="Travel" v={`${bands.travel} mi/day`} />
       {tier !== undefined && status && (
         <PopRow k="Encumbrance" v={status} vClass={encTierClass(tier)} />
@@ -101,43 +101,19 @@ export function MoveTooltip({
   );
 }
 
-/** The three rates on one line, terse: `120′ / 40′ / 24mi` (explore / encounter / travel). */
+/** The three rates on one line, terse: `40ft / 120ft / 24mi` (encounter / explore / travel). */
 export function MoveRates({ bands }: { bands: MoveBands }) {
   return (
     <>
-      <span className="rate">{bands.explore}′</span>
+      <span className="rate">{bands.encounter}ft</span>
       <span className="sep" aria-hidden="true">
         /
       </span>
-      <span className="rate">{bands.encounter}′</span>
+      <span className="rate">{bands.explore}ft</span>
       <span className="sep" aria-hidden="true">
         /
       </span>
       <span className="rate">{bands.travel}mi</span>
-    </>
-  );
-}
-
-/** The full-unit form: `90′/turn · 30′/round · 18 mi/day` — for the reference rail. */
-export function MoveRatesFull({ bands }: { bands: MoveBands }) {
-  return (
-    <>
-      <span className="rate">
-        {bands.explore}′<span className="u">/turn</span>
-      </span>
-      <span className="sep" aria-hidden="true">
-        ·
-      </span>
-      <span className="rate">
-        {bands.encounter}′<span className="u">/round</span>
-      </span>
-      <span className="sep" aria-hidden="true">
-        ·
-      </span>
-      <span className="rate">
-        {bands.travel}
-        <span className="u"> mi/day</span>
-      </span>
     </>
   );
 }

--- a/src/OscSheet/domain/format.ts
+++ b/src/OscSheet/domain/format.ts
@@ -1,4 +1,16 @@
+import type { EncumbranceTier, MoveBands } from "@domain/vm-types";
+
 /** Format a modifier for display: +0, +2, -3. */
 export function formatMod(n: number): string {
   return n >= 0 ? `+${n}` : `${n}`;
+}
+
+/** Tier → colour class (`--enc-0…4`, defined in styles.scss). One tier, one colour, sheet-wide. */
+export function encTierClass(tier: EncumbranceTier): string {
+  return `enc-t${tier}`;
+}
+
+/** Screen-reader sentence for a rates line — the units the glyphs imply, spelled out. */
+export function moveRatesLabel(b: MoveBands): string {
+  return `${b.explore} feet per turn, ${b.encounter} feet per round, ${b.travel} miles per day`;
 }

--- a/src/OscSheet/domain/format.ts
+++ b/src/OscSheet/domain/format.ts
@@ -12,5 +12,5 @@ export function encTierClass(tier: EncumbranceTier): string {
 
 /** Screen-reader sentence for a rates line — the units the glyphs imply, spelled out. */
 export function moveRatesLabel(b: MoveBands): string {
-  return `${b.explore} feet per turn, ${b.encounter} feet per round, ${b.travel} miles per day`;
+  return `${b.encounter} feet per round, ${b.explore} feet per turn, ${b.travel} miles per day`;
 }

--- a/src/OscSheet/domain/vm-types.ts
+++ b/src/OscSheet/domain/vm-types.ts
@@ -9,6 +9,13 @@ export interface IdentityVM {
   title: string;
 }
 
+/** The three OSE movement rates: ft/round · ft/turn · miles/day. */
+export interface MoveBands {
+  encounter: number;
+  explore: number;
+  travel: number;
+}
+
 export interface VitalsVM {
   hp: { value: number; max: number };
   /** Resolved AC for display: value matching the ascendingAC setting + the mode. */
@@ -17,7 +24,7 @@ export interface VitalsVM {
   hd: string;
   move: number;
   /** Movement bands for the MOVE pill popover (per-round / per-turn / per-day). */
-  moveBands: { encounter: number; explore: number; travel: number };
+  moveBands: MoveBands;
 }
 
 export interface AbilityVM {
@@ -189,6 +196,9 @@ export interface EncumbranceVM {
   status: string;
   /** Variant-aware value/max readout, e.g. "1071 / 1600 cn" or "10 / 16 items". */
   label: string;
-  /** Current movement (ft), e.g. 120. */
-  move: number;
+  /** The three movement rates at the current tier (same source as the header MOVE pop). */
+  moveBands: MoveBands;
+  /** Tier boundaries as % of the bar, from the system's own variant-aware `steps`
+   *  (empty when the bar's axis isn't weight — see selectEncumbrance). */
+  bands: number[];
 }

--- a/src/OscSheet/features/inventory/EncumbranceReadout.stories.tsx
+++ b/src/OscSheet/features/inventory/EncumbranceReadout.stories.tsx
@@ -1,10 +1,9 @@
-// The inventory header's encumbrance line + load bar, plus the reference rail — the
-// InventoryView story can't render (it needs the sheet context), so this is where the
-// tier colours, threshold cuts, cn right-alignment, rail, and popover are checked.
+// The inventory header's encumbrance line + load bar — the InventoryView story can't
+// render (it needs the sheet context), so this is where the tier colours, threshold
+// cuts, cn right-alignment, and popover are checked.
 import type { EncumbranceVM } from "@domain/vm-types";
 import { EncumbranceReadout } from "@features/inventory/EncumbranceReadout";
 import { encBarStops } from "@features/inventory/inventory";
-import { MoveRatesFull } from "@ui/MovePop";
 import { SectionTitle } from "@ui/SectionTitle";
 
 export default { title: "Inventory / EncumbranceReadout" };
@@ -58,19 +57,13 @@ export const Tiers = () => (
   </div>
 );
 
-// Full stack: bar + rates-left/load-right, the rail, then section headers — to check
-// the load's cn lines up with the Equipped / All-Items / Wealth cn totals below.
+// Full stack: bar + rates-left/load-right, then section headers — to check the load's
+// cn lines up with the Equipped / All-Items / Wealth cn totals below.
 export const FullHeader = () => {
   const e = vm(2, 690, "Heavily encumbered");
   return (
     <div className="osc-inv" style={{ padding: 16, width: 480 }}>
       <Head e={e} />
-      <div className="osc-enc-rail">
-        <span className="osc-enc-rail-k">Encumbrance:</span>
-        <span className="osc-enc-rail-rates">
-          <MoveRatesFull bands={e.moveBands} />
-        </span>
-      </div>
       <button type="button" className="osc-whead" style={{ display: "flex", width: "100%" }}>
         <span className="key">Wealth</span>
         <span className="v">152 gp</span>

--- a/src/OscSheet/features/inventory/EncumbranceReadout.stories.tsx
+++ b/src/OscSheet/features/inventory/EncumbranceReadout.stories.tsx
@@ -1,9 +1,10 @@
-// The inventory header's encumbrance line + load bar, one row per tier — the
-// InventoryView story can't render (it needs the sheet context), so this is where
-// the tier colours and the bar's threshold cuts are checked visually.
+// The inventory header's encumbrance line + load bar, plus the reference rail — the
+// InventoryView story can't render (it needs the sheet context), so this is where the
+// tier colours, threshold cuts, cn right-alignment, rail, and popover are checked.
 import type { EncumbranceVM } from "@domain/vm-types";
 import { EncumbranceReadout } from "@features/inventory/EncumbranceReadout";
 import { encBarStops } from "@features/inventory/inventory";
+import { MoveRatesFull } from "@ui/MovePop";
 import { SectionTitle } from "@ui/SectionTitle";
 
 export default { title: "Inventory / EncumbranceReadout" };
@@ -19,13 +20,27 @@ const vm = (tier: EncumbranceVM["tier"], value: number, status: string): Encumbr
   tier,
   status,
   label: `${value} / 1600 cn`,
-  // rates at each tier: base 120 → ×0.75 / ×0.5 / ×0.25 / 0
+  // rates at each tier: base 120 -> x0.75 / x0.5 / x0.25 / 0
   moveBands: (() => {
     const base = [120, 90, 60, 30, 0][tier];
     return { encounter: base / 3, explore: base, travel: base / 5 };
   })(),
   bands: STEPS,
 });
+
+function Head({ e }: { e: EncumbranceVM }) {
+  return (
+    <div
+      className="osc-inv-head enc-rule"
+      style={
+        { "--enc-pct": `${Math.round(e.pct * 100)}%`, "--enc-stops": encBarStops(e) } as React.CSSProperties
+      }
+    >
+      <SectionTitle>Inventory</SectionTitle>
+      <EncumbranceReadout e={e} />
+    </div>
+  );
+}
 
 const ROWS: EncumbranceVM[] = [
   vm(0, 300, "Unencumbered"),
@@ -36,82 +51,65 @@ const ROWS: EncumbranceVM[] = [
 ];
 
 export const Tiers = () => (
-  <div style={{ display: "flex", flexDirection: "column", gap: 24, padding: 16, minWidth: 520 }}>
+  <div className="osc-inv" style={{ display: "flex", flexDirection: "column", gap: 24, padding: 16, width: 520 }}>
     {ROWS.map((e) => (
-      <div
-        key={e.tier}
-        className="osc-inv-head enc-rule"
-        style={
-          {
-            "--enc-pct": `${Math.round(e.pct * 100)}%`,
-            "--enc-stops": encBarStops(e),
-          } as React.CSSProperties
-        }
-      >
-        <SectionTitle>Inventory</SectionTitle>
-        <EncumbranceReadout e={e} />
-      </div>
+      <Head key={e.tier} e={e} />
     ))}
   </div>
 );
 
-/**
- * Regression repro for the caret poke-through: the encumbrance-line tooltip opens
- * DOWN over the Wealth header's rotated `▶` caret (its own stacking context). Hover
- * the rates line — the popover must fully cover the caret, nothing bleeding through.
- */
-export const TooltipOverCaret = () => {
-  const e = vm(1, 500, "Lightly encumbered");
+// Full stack: bar + rates-left/load-right, the rail, then section headers — to check
+// the load's cn lines up with the Equipped / All-Items / Wealth cn totals below.
+export const FullHeader = () => {
+  const e = vm(2, 690, "Heavily encumbered");
   return (
-    <div style={{ padding: 16, minWidth: 520 }}>
-      <div
-        className="osc-inv-head enc-rule"
-        style={
-          {
-            "--enc-pct": `${Math.round(e.pct * 100)}%`,
-            "--enc-stops": encBarStops(e),
-          } as React.CSSProperties
-        }
-      >
-        <SectionTitle>Inventory</SectionTitle>
-        <EncumbranceReadout e={e} />
+    <div className="osc-inv" style={{ padding: 16, width: 480 }}>
+      <Head e={e} />
+      <div className="osc-enc-rail">
+        <span className="osc-enc-rail-k">Encumbrance:</span>
+        <span className="osc-enc-rail-rates">
+          <MoveRatesFull bands={e.moveBands} />
+        </span>
       </div>
-      {/* stand-in for the real Wealth bar: an OPEN caret pushed to the RIGHT so it
-          sits directly under the right-aligned tooltip's drop zone. */}
-      <div className="osc-inv">
-        <button type="button" className="osc-whead open">
-          <span className="key">Wealth</span>
-          <span className="v">152 gp</span>
-          <i
-            className="osc-wcaret fa-solid fa-caret-right"
-            aria-hidden="true"
-            style={{ marginLeft: "auto", marginRight: 40 }}
-          >
-            ▶
-          </i>
-        </button>
+      <button type="button" className="osc-whead" style={{ display: "flex", width: "100%" }}>
+        <span className="key">Wealth</span>
+        <span className="v">152 gp</span>
+        <span className="wt">140 cn</span>
+      </button>
+      <div className="osc-inv-sec-head">
+        <span className="section-title sub">Equipped items</span>
+        <span className="osc-inv-sec-count">4 items · 230 cn</span>
+      </div>
+      <div className="osc-inv-sec-head">
+        <span className="section-title sub">All items</span>
+        <span className="osc-inv-sec-count">9 items · 306 cn</span>
       </div>
     </div>
   );
 };
 
-/** Basic encumbrance: no weight axis, so the bar paints solid in the tier colour. */
+// The MOVE/enc popover is position:fixed, so it must render in full even when an
+// ancestor scrolls/clips (mirrors the capped character rail). Hover the line — the
+// popover should spill OUTSIDE this overflow:hidden box, not be cut off at its edge.
+export const ClippedAncestor = () => {
+  const e = vm(2, 690, "Heavily encumbered");
+  return (
+    <div style={{ padding: 40 }}>
+      <div style={{ width: 260, height: 60, overflow: "hidden", outline: "1px dashed #a55", padding: 8 }}>
+        <div className="osc-inv" style={{ width: "100%" }}>
+          <Head e={e} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// Basic encumbrance: no weight axis, so the bar paints solid in the tier colour.
 export const BasicVariant = () => {
   const e: EncumbranceVM = { ...vm(2, 0, "Heavily encumbered"), pct: 2 / 3, label: "", bands: [] };
   return (
-    <div style={{ padding: 16, minWidth: 520 }}>
-      <div
-        className="osc-inv-head enc-rule"
-        style={
-          {
-            "--enc-pct": `${Math.round(e.pct * 100)}%`,
-            "--enc-stops": encBarStops(e),
-          } as React.CSSProperties
-        }
-      >
-        <SectionTitle>Inventory</SectionTitle>
-        <EncumbranceReadout e={e} />
-      </div>
+    <div className="osc-inv" style={{ padding: 16, width: 520 }}>
+      <Head e={e} />
     </div>
   );
 };

--- a/src/OscSheet/features/inventory/EncumbranceReadout.stories.tsx
+++ b/src/OscSheet/features/inventory/EncumbranceReadout.stories.tsx
@@ -55,6 +55,46 @@ export const Tiers = () => (
   </div>
 );
 
+/**
+ * Regression repro for the caret poke-through: the encumbrance-line tooltip opens
+ * DOWN over the Wealth header's rotated `▶` caret (its own stacking context). Hover
+ * the rates line — the popover must fully cover the caret, nothing bleeding through.
+ */
+export const TooltipOverCaret = () => {
+  const e = vm(1, 500, "Lightly encumbered");
+  return (
+    <div style={{ padding: 16, minWidth: 520 }}>
+      <div
+        className="osc-inv-head enc-rule"
+        style={
+          {
+            "--enc-pct": `${Math.round(e.pct * 100)}%`,
+            "--enc-stops": encBarStops(e),
+          } as React.CSSProperties
+        }
+      >
+        <SectionTitle>Inventory</SectionTitle>
+        <EncumbranceReadout e={e} />
+      </div>
+      {/* stand-in for the real Wealth bar: an OPEN caret pushed to the RIGHT so it
+          sits directly under the right-aligned tooltip's drop zone. */}
+      <div className="osc-inv">
+        <button type="button" className="osc-whead open">
+          <span className="key">Wealth</span>
+          <span className="v">152 gp</span>
+          <i
+            className="osc-wcaret fa-solid fa-caret-right"
+            aria-hidden="true"
+            style={{ marginLeft: "auto", marginRight: 40 }}
+          >
+            ▶
+          </i>
+        </button>
+      </div>
+    </div>
+  );
+};
+
 /** Basic encumbrance: no weight axis, so the bar paints solid in the tier colour. */
 export const BasicVariant = () => {
   const e: EncumbranceVM = { ...vm(2, 0, "Heavily encumbered"), pct: 2 / 3, label: "", bands: [] };

--- a/src/OscSheet/features/inventory/EncumbranceReadout.stories.tsx
+++ b/src/OscSheet/features/inventory/EncumbranceReadout.stories.tsx
@@ -1,0 +1,77 @@
+// The inventory header's encumbrance line + load bar, one row per tier — the
+// InventoryView story can't render (it needs the sheet context), so this is where
+// the tier colours and the bar's threshold cuts are checked visually.
+import type { EncumbranceVM } from "@domain/vm-types";
+import { EncumbranceReadout } from "@features/inventory/EncumbranceReadout";
+import { encBarStops } from "@features/inventory/inventory";
+import { SectionTitle } from "@ui/SectionTitle";
+
+export default { title: "Inventory / EncumbranceReadout" };
+
+// Detailed variant: OSE cuts at 25% / 37.5% / 50% of max.
+const STEPS = [25, 37.5, 50];
+
+const vm = (tier: EncumbranceVM["tier"], value: number, status: string): EncumbranceVM => ({
+  enabled: true,
+  value,
+  max: 1600,
+  pct: Math.min(1, value / 1600),
+  tier,
+  status,
+  label: `${value} / 1600 cn`,
+  // rates at each tier: base 120 → ×0.75 / ×0.5 / ×0.25 / 0
+  moveBands: (() => {
+    const base = [120, 90, 60, 30, 0][tier];
+    return { encounter: base / 3, explore: base, travel: base / 5 };
+  })(),
+  bands: STEPS,
+});
+
+const ROWS: EncumbranceVM[] = [
+  vm(0, 300, "Unencumbered"),
+  vm(1, 500, "Lightly encumbered"),
+  vm(2, 700, "Heavily encumbered"),
+  vm(3, 1200, "Severely encumbered"),
+  vm(4, 1600, "Overloaded"),
+];
+
+export const Tiers = () => (
+  <div style={{ display: "flex", flexDirection: "column", gap: 24, padding: 16, minWidth: 520 }}>
+    {ROWS.map((e) => (
+      <div
+        key={e.tier}
+        className="osc-inv-head enc-rule"
+        style={
+          {
+            "--enc-pct": `${Math.round(e.pct * 100)}%`,
+            "--enc-stops": encBarStops(e),
+          } as React.CSSProperties
+        }
+      >
+        <SectionTitle>Inventory</SectionTitle>
+        <EncumbranceReadout e={e} />
+      </div>
+    ))}
+  </div>
+);
+
+/** Basic encumbrance: no weight axis, so the bar paints solid in the tier colour. */
+export const BasicVariant = () => {
+  const e: EncumbranceVM = { ...vm(2, 0, "Heavily encumbered"), pct: 2 / 3, label: "", bands: [] };
+  return (
+    <div style={{ padding: 16, minWidth: 520 }}>
+      <div
+        className="osc-inv-head enc-rule"
+        style={
+          {
+            "--enc-pct": `${Math.round(e.pct * 100)}%`,
+            "--enc-stops": encBarStops(e),
+          } as React.CSSProperties
+        }
+      >
+        <SectionTitle>Inventory</SectionTitle>
+        <EncumbranceReadout e={e} />
+      </div>
+    </div>
+  );
+};

--- a/src/OscSheet/features/inventory/EncumbranceReadout.test.tsx
+++ b/src/OscSheet/features/inventory/EncumbranceReadout.test.tsx
@@ -63,9 +63,9 @@ describe("EncumbranceReadout", () => {
     const readout = container.querySelector(".osc-enc-readout")!;
     // load number is restored (was removed in the first pass)
     expect(readout.querySelector(".load")?.textContent).toBe("700 / 1600 cn");
-    // rates are terse: 90′ · 30′ · 18mi (explore · encounter · travel), no /turn suffixes
+    // rates are terse: 30ft / 90ft / 18mi (encounter / explore / travel), no /turn suffixes
     const rates = [...readout.querySelectorAll(".rate")].map((r) => r.textContent);
-    expect(rates).toEqual(["90′", "30′", "18mi"]);
+    expect(rates).toEqual(["30ft", "90ft", "18mi"]);
     // the rate line carries the tier tint class; the load does not
     expect(container.querySelector(".osc-enc-readout.enc-t2")).toBeTruthy();
   });
@@ -80,8 +80,8 @@ describe("EncumbranceReadout", () => {
     // one shared component ⇒ byte-identical rows in both places
     expect(encRows).toEqual(moveRows);
     expect(encRows).toEqual([
-      "Encounter|30′/round",
-      "Explore|90′/turn",
+      "Encounter|30ft/round",
+      "Explore|90ft/turn",
       "Travel|18 mi/day",
       "Encumbrance|Heavily encumbered",
     ]);

--- a/src/OscSheet/features/inventory/EncumbranceReadout.test.tsx
+++ b/src/OscSheet/features/inventory/EncumbranceReadout.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { EncumbranceReadout } from "@features/inventory/EncumbranceReadout";
+import { HeaderBand } from "@layout/HeaderBand";
+import type { EncumbranceVM, VitalsVM } from "@domain/vm-types";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// HeaderBand's fit-to-width hook observes resize; jsdom has no ResizeObserver.
+(globalThis as { ResizeObserver?: unknown }).ResizeObserver ??= class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+const enc: EncumbranceVM = {
+  enabled: true,
+  value: 700,
+  max: 1600,
+  pct: 700 / 1600,
+  tier: 2,
+  status: "Heavily encumbered",
+  label: "700 / 1600 cn",
+  moveBands: { encounter: 30, explore: 90, travel: 18 },
+  bands: [25, 37.5, 50],
+};
+
+const vitals: VitalsVM = {
+  hp: { value: 8, max: 9 },
+  ac: { value: 12, ascending: true },
+  initMod: 1,
+  hd: "3d4",
+  move: 90,
+  moveBands: enc.moveBands,
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+/** The popover rows as "label|value" pairs — the tooltip's whole visible content. */
+function tooltipRows(scope: HTMLElement): string[] {
+  return [...scope.querySelectorAll(".osc-move-pop .r")].map(
+    (r) =>
+      `${r.querySelector(".k")?.textContent}|${r.querySelector(".vv")?.textContent}`,
+  );
+}
+
+describe("EncumbranceReadout", () => {
+  it("shows the numeric load AND the terse rates above the bar", () => {
+    act(() => root.render(<EncumbranceReadout e={enc} />));
+    const readout = container.querySelector(".osc-enc-readout")!;
+    // load number is restored (was removed in the first pass)
+    expect(readout.querySelector(".load")?.textContent).toBe("700 / 1600 cn");
+    // rates are terse: 90′ · 30′ · 18mi (explore · encounter · travel), no /turn suffixes
+    const rates = [...readout.querySelectorAll(".rate")].map((r) => r.textContent);
+    expect(rates).toEqual(["90′", "30′", "18mi"]);
+    // the rate line carries the tier tint class; the load does not
+    expect(container.querySelector(".osc-enc-readout.enc-t2")).toBeTruthy();
+  });
+
+  it("renders the SAME tooltip rows as the header MOVE hover", () => {
+    act(() => root.render(<EncumbranceReadout e={enc} />));
+    const encRows = tooltipRows(container);
+
+    act(() => root.render(<HeaderBand identity={IDENTITY} vitals={vitals} encumbrance={enc} />));
+    const moveRows = tooltipRows(container);
+
+    // one shared component ⇒ byte-identical rows in both places
+    expect(encRows).toEqual(moveRows);
+    expect(encRows).toEqual([
+      "Encounter|30′",
+      "Explore|90′",
+      "Travel|18 mi",
+      "Encumbrance|Heavily encumbered",
+    ]);
+  });
+});
+
+const IDENTITY = {
+  name: "Eldra Vey",
+  img: "",
+  classLabel: "Magic-User",
+  level: 3,
+  alignment: "Neutral",
+  title: "Conjurer",
+};

--- a/src/OscSheet/features/inventory/EncumbranceReadout.test.tsx
+++ b/src/OscSheet/features/inventory/EncumbranceReadout.test.tsx
@@ -80,9 +80,9 @@ describe("EncumbranceReadout", () => {
     // one shared component ⇒ byte-identical rows in both places
     expect(encRows).toEqual(moveRows);
     expect(encRows).toEqual([
-      "Encounter|30′",
-      "Explore|90′",
-      "Travel|18 mi",
+      "Encounter|30′/round",
+      "Explore|90′/turn",
+      "Travel|18 mi/day",
       "Encumbrance|Heavily encumbered",
     ]);
   });

--- a/src/OscSheet/features/inventory/EncumbranceReadout.tsx
+++ b/src/OscSheet/features/inventory/EncumbranceReadout.tsx
@@ -1,10 +1,11 @@
-// Encumbrance readout for the Inventory header: the three OSE movement rates,
-// tinted by encumbrance tier. Hover reveals the tier name (same tint) + the load
-// breakdown — the header MOVE tile's hover tells the same story from the other end.
+// Encumbrance readout above the load bar: the numeric load (X / 1600 cn, muted) and
+// the three movement rates (terse, tinted by tier). The rates replace the old tier
+// WORD — the load number stays. Hover shows the shared MoveTooltip: same rows, same
+// component as the header MOVE stat hover.
 import type { EncumbranceVM } from "@domain/vm-types";
 import { encTierClass, moveRatesLabel } from "@domain/format";
 import { cx } from "@ui/cx";
-import { MoveRates, PopRow, StatPop } from "@ui/MovePop";
+import { MoveRates, MoveTooltip } from "@ui/MovePop";
 
 export function EncumbranceReadout({ e }: { e: EncumbranceVM }) {
   const tier = encTierClass(e.tier);
@@ -13,13 +14,18 @@ export function EncumbranceReadout({ e }: { e: EncumbranceVM }) {
       className={cx("osc-enc-readout", tier)}
       // focusable so the hover-only popover is reachable by keyboard (:focus-within)
       tabIndex={0}
-      aria-label={`${e.status}. Movement: ${moveRatesLabel(e.moveBands)}`}
+      aria-label={`${e.status}. ${e.label ? `Load ${e.label}. ` : ""}Movement: ${moveRatesLabel(e.moveBands)}`}
     >
+      {e.label && (
+        <>
+          <span className="load">{e.label}</span>
+          <span className="sep" aria-hidden="true">
+            ·
+          </span>
+        </>
+      )}
       <MoveRates bands={e.moveBands} />
-      <StatPop>
-        <PopRow k="Encumbrance" v={e.status} vClass={tier} />
-        {e.label && <PopRow k="Load" v={e.label} />}
-      </StatPop>
+      <MoveTooltip bands={e.moveBands} tier={e.tier} status={e.status} />
     </span>
   );
 }

--- a/src/OscSheet/features/inventory/EncumbranceReadout.tsx
+++ b/src/OscSheet/features/inventory/EncumbranceReadout.tsx
@@ -1,22 +1,25 @@
-// Encumbrance readout for the Inventory header: load · status · move, with the
-// band colour (green/yellow/red) on status+move carrying the signal — no bar.
+// Encumbrance readout for the Inventory header: the three OSE movement rates,
+// tinted by encumbrance tier. Hover reveals the tier name (same tint) + the load
+// breakdown — the header MOVE tile's hover tells the same story from the other end.
 import type { EncumbranceVM } from "@domain/vm-types";
+import { encTierClass, moveRatesLabel } from "@domain/format";
 import { cx } from "@ui/cx";
-
-const ENC_BAND = ["ok", "warn", "danger", "danger", "danger"] as const;
+import { MoveRates, PopRow, StatPop } from "@ui/MovePop";
 
 export function EncumbranceReadout({ e }: { e: EncumbranceVM }) {
+  const tier = encTierClass(e.tier);
   return (
-    <span className={cx("osc-enc-readout", ENC_BAND[e.tier])}>
-      {e.label && (
-        <>
-          <span className="load">{e.label}</span>
-          <span className="sep" aria-hidden="true">·</span>
-        </>
-      )}
-      <span className="status">{e.status}</span>
-      <span className="sep" aria-hidden="true">·</span>
-      <span className="move">{e.move}′</span>
+    <span
+      className={cx("osc-enc-readout", tier)}
+      // focusable so the hover-only popover is reachable by keyboard (:focus-within)
+      tabIndex={0}
+      aria-label={`${e.status}. Movement: ${moveRatesLabel(e.moveBands)}`}
+    >
+      <MoveRates bands={e.moveBands} />
+      <StatPop>
+        <PopRow k="Encumbrance" v={e.status} vClass={tier} />
+        {e.label && <PopRow k="Load" v={e.label} />}
+      </StatPop>
     </span>
   );
 }

--- a/src/OscSheet/features/inventory/EncumbranceReadout.tsx
+++ b/src/OscSheet/features/inventory/EncumbranceReadout.tsx
@@ -11,17 +11,20 @@ import { MoveRates, MoveTooltip } from "@ui/MovePop";
 export function EncumbranceReadout({ e }: { e: EncumbranceVM }) {
   const tier = encTierClass(e.tier);
   return (
-    <span
-      className={cx("osc-enc-readout", tier)}
-      // focusable so the hover-only popover is reachable by keyboard (:focus-within)
-      tabIndex={0}
-      aria-label={`${e.status}. ${e.label ? `Load ${e.label}. ` : ""}Movement: ${moveRatesLabel(e.moveBands)}`}
-    >
-      <span className="rates">
+    <span className={cx("osc-enc-readout", tier)}>
+      {/* only the rates trigger the popover (not the Load number). tabIndex makes
+          the trigger keyboard-reachable; MoveTooltip anchors to its parent, so it
+          must stay a direct child of this span. */}
+      <span
+        className="rates"
+        tabIndex={0}
+        aria-label={`Movement: ${moveRatesLabel(e.moveBands)}${e.status ? `. ${e.status}` : ""}`}
+      >
         <MoveRates bands={e.moveBands} />
+        <MoveTooltip bands={e.moveBands} tier={e.tier} status={e.status} />
       </span>
-      {e.label && <span className="load">{e.label}</span>}
-      <MoveTooltip bands={e.moveBands} tier={e.tier} status={e.status} />
+      <i className="fa fa-dot u-text-faint" />
+      {e.label && <span className="load u-text-faint">{e.label}</span>}
     </span>
   );
 }

--- a/src/OscSheet/features/inventory/EncumbranceReadout.tsx
+++ b/src/OscSheet/features/inventory/EncumbranceReadout.tsx
@@ -1,7 +1,8 @@
-// Encumbrance readout above the load bar: the numeric load (X / 1600 cn, muted) and
-// the three movement rates (terse, tinted by tier). The rates replace the old tier
-// WORD — the load number stays. Hover shows the shared MoveTooltip: same rows, same
-// component as the header MOVE stat hover.
+// Encumbrance readout above the load bar: the three movement rates on the LEFT
+// (terse, tinted by tier) and the numeric load (X / 1600 cn, muted) pushed to the
+// RIGHT edge so it lines up with the cn totals on the section headers below. The
+// rates replace the old tier WORD — the load number stays. Hover shows the shared
+// MoveTooltip: same rows, same component as the header MOVE stat hover.
 import type { EncumbranceVM } from "@domain/vm-types";
 import { encTierClass, moveRatesLabel } from "@domain/format";
 import { cx } from "@ui/cx";
@@ -16,12 +17,10 @@ export function EncumbranceReadout({ e }: { e: EncumbranceVM }) {
       tabIndex={0}
       aria-label={`${e.status}. ${e.label ? `Load ${e.label}. ` : ""}Movement: ${moveRatesLabel(e.moveBands)}`}
     >
-      {e.label && <span className="load">{e.label}</span>}
-      {/* load and rates are separated by whitespace (a margin on .rates), NOT a middot;
-          the only ·'s on the line are the two inside this cluster, between the rates. */}
       <span className="rates">
         <MoveRates bands={e.moveBands} />
       </span>
+      {e.label && <span className="load">{e.label}</span>}
       <MoveTooltip bands={e.moveBands} tier={e.tier} status={e.status} />
     </span>
   );

--- a/src/OscSheet/features/inventory/EncumbranceReadout.tsx
+++ b/src/OscSheet/features/inventory/EncumbranceReadout.tsx
@@ -16,15 +16,12 @@ export function EncumbranceReadout({ e }: { e: EncumbranceVM }) {
       tabIndex={0}
       aria-label={`${e.status}. ${e.label ? `Load ${e.label}. ` : ""}Movement: ${moveRatesLabel(e.moveBands)}`}
     >
-      {e.label && (
-        <>
-          <span className="load">{e.label}</span>
-          <span className="sep" aria-hidden="true">
-            ·
-          </span>
-        </>
-      )}
-      <MoveRates bands={e.moveBands} />
+      {e.label && <span className="load">{e.label}</span>}
+      {/* load and rates are separated by whitespace (a margin on .rates), NOT a middot;
+          the only ·'s on the line are the two inside this cluster, between the rates. */}
+      <span className="rates">
+        <MoveRates bands={e.moveBands} />
+      </span>
       <MoveTooltip bands={e.moveBands} tier={e.tier} status={e.status} />
     </span>
   );

--- a/src/OscSheet/features/inventory/InventoryView.stories.tsx
+++ b/src/OscSheet/features/inventory/InventoryView.stories.tsx
@@ -44,7 +44,7 @@ const inventory: InventoryVM = {
   groups: [],
 };
 
-const encumbrance: EncumbranceVM = { enabled: true, value: 380, max: 1600, pct: 0.2375, tier: 0, status: "Unencumbered", label: "380 / 1600 cn", move: 120 };
+const encumbrance: EncumbranceVM = { enabled: true, value: 380, max: 1600, pct: 0.2375, tier: 0, status: "Unencumbered", label: "380 / 1600 cn", moveBands: { encounter: 40, explore: 120, travel: 24 }, bands: [25, 37.5, 50] };
 const coins = [
   { denom: "PP", id: "pp", name: "Platinum Pieces", img: "", value: 0, gpEach: 5 },
   { denom: "GP", id: "gp", name: "Gold Pieces", img: "", value: 152, gpEach: 1 },

--- a/src/OscSheet/features/inventory/index.tsx
+++ b/src/OscSheet/features/inventory/index.tsx
@@ -18,7 +18,11 @@ import type {
   InventorySortKey,
   SortDir,
 } from "@domain/vm-types";
-import { encBarStops, sortInventory, SORT_DEFAULT_DIR } from "@features/inventory/inventory";
+import {
+  encBarStops,
+  sortInventory,
+  SORT_DEFAULT_DIR,
+} from "@features/inventory/inventory";
 import { useDragReorder } from "@features/inventory/useDragReorder";
 import { buildItemMacroDragData } from "@features/inventory/dragToMacro";
 import { WealthSection } from "@features/inventory/WealthSection";
@@ -30,7 +34,6 @@ import {
 import { EquippedTray } from "@features/inventory/EquippedTray";
 import { ItemContextMenu } from "@features/inventory/ItemContextMenu";
 import { EncumbranceReadout } from "@features/inventory/EncumbranceReadout";
-import { MoveRatesFull } from "@ui/MovePop";
 import { SectionCount } from "@features/inventory/SectionCount";
 import { SortableRow } from "@features/inventory/rows/SortableRow";
 import { ContainerRow } from "@features/inventory/rows/ContainerRow";
@@ -269,20 +272,15 @@ export function InventoryView({
             : undefined
         }
       >
-        <SectionTitle>Inventory</SectionTitle>
+        <SectionTitle className="u-mb-1">Inventory</SectionTitle>
         {encumbrance.enabled && <EncumbranceReadout e={encumbrance} />}
       </div>
-      {/* thin reference rail: the full-unit movement labels, below the bar / above
-          Wealth — a plain readout for eyeballing the labelled rates while iterating. */}
-      {encumbrance.enabled && (
-        <div className="osc-enc-rail">
-          <span className="osc-enc-rail-k">Encumbrance:</span>
-          <span className="osc-enc-rail-rates">
-            <MoveRatesFull bands={encumbrance.moveBands} />
-          </span>
-        </div>
-      )}
-      <WealthSection coins={coins} onSetCoin={onSetCoin} onOpen={onOpen} onContext={openMenu} />
+      <WealthSection
+        coins={coins}
+        onSetCoin={onSetCoin}
+        onOpen={onOpen}
+        onContext={openMenu}
+      />
 
       {/* Equipped tray + All-Items header pin together as one opaque block so the
           two never separate into a see-through gap (no JS height measuring). */}

--- a/src/OscSheet/features/inventory/index.tsx
+++ b/src/OscSheet/features/inventory/index.tsx
@@ -18,7 +18,7 @@ import type {
   InventorySortKey,
   SortDir,
 } from "@domain/vm-types";
-import { sortInventory, SORT_DEFAULT_DIR } from "@features/inventory/inventory";
+import { encBarStops, sortInventory, SORT_DEFAULT_DIR } from "@features/inventory/inventory";
 import { useDragReorder } from "@features/inventory/useDragReorder";
 import { buildItemMacroDragData } from "@features/inventory/dragToMacro";
 import { WealthSection } from "@features/inventory/WealthSection";
@@ -257,10 +257,14 @@ export function InventoryView({
     <section className="osc-inv">
       <div
         className={cx("osc-inv-head", encumbrance.enabled && "enc-rule")}
-        // the header underline doubles as the encumbrance load bar (see .enc-rule)
+        // the header underline doubles as the encumbrance load bar (see .enc-rule);
+        // --enc-stops cuts the colour at the system's real tier thresholds
         style={
           encumbrance.enabled
-            ? ({ "--enc-pct": `${Math.round(encumbrance.pct * 100)}%` } as React.CSSProperties)
+            ? ({
+                "--enc-pct": `${Math.round(encumbrance.pct * 100)}%`,
+                "--enc-stops": encBarStops(encumbrance),
+              } as React.CSSProperties)
             : undefined
         }
       >

--- a/src/OscSheet/features/inventory/index.tsx
+++ b/src/OscSheet/features/inventory/index.tsx
@@ -30,6 +30,7 @@ import {
 import { EquippedTray } from "@features/inventory/EquippedTray";
 import { ItemContextMenu } from "@features/inventory/ItemContextMenu";
 import { EncumbranceReadout } from "@features/inventory/EncumbranceReadout";
+import { MoveRatesFull } from "@ui/MovePop";
 import { SectionCount } from "@features/inventory/SectionCount";
 import { SortableRow } from "@features/inventory/rows/SortableRow";
 import { ContainerRow } from "@features/inventory/rows/ContainerRow";
@@ -271,6 +272,16 @@ export function InventoryView({
         <SectionTitle>Inventory</SectionTitle>
         {encumbrance.enabled && <EncumbranceReadout e={encumbrance} />}
       </div>
+      {/* thin reference rail: the full-unit movement labels, below the bar / above
+          Wealth — a plain readout for eyeballing the labelled rates while iterating. */}
+      {encumbrance.enabled && (
+        <div className="osc-enc-rail">
+          <span className="osc-enc-rail-k">Encumbrance:</span>
+          <span className="osc-enc-rail-rates">
+            <MoveRatesFull bands={encumbrance.moveBands} />
+          </span>
+        </div>
+      )}
       <WealthSection coins={coins} onSetCoin={onSetCoin} onOpen={onOpen} onContext={openMenu} />
 
       {/* Equipped tray + All-Items header pin together as one opaque block so the

--- a/src/OscSheet/features/inventory/inventory.test.ts
+++ b/src/OscSheet/features/inventory/inventory.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { selectInventory, selectEncumbrance, selectCoins, sortInventory, sortEquipped, coinDenom } from "@features/inventory/inventory";
+import { selectInventory, selectEncumbrance, selectCoins, sortInventory, sortEquipped, coinDenom, encBarStops } from "@features/inventory/inventory";
 import type { OseItem, OSEActor } from "@domain/types";
 import { MODULE_ID, FLAGS } from "@domain/flags";
 
@@ -235,16 +235,19 @@ describe("selectInventory — equipped tray order", () => {
 });
 
 describe("selectEncumbrance", () => {
-  it("computes pct + status + movement", () => {
+  it("computes pct + status + the three movement rates", () => {
     const actor = {
-      system: { encumbrance: { value: 380, max: 1600, enabled: true }, movement: { base: 120 } },
+      system: {
+        encumbrance: { value: 380, max: 1600, enabled: true },
+        movement: { base: 120, encounter: 40, overland: 24 },
+      },
     } as unknown as OSEActor;
     const e = selectEncumbrance(actor);
     expect(e.pct).toBeCloseTo(0.2375);
     expect(e.tier).toBe(0);
     expect(e.status).toBe("Unencumbered");
     expect(e.label).toBe("380 / 1600 cn");
-    expect(e.move).toBe(120);
+    expect(e.moveBands).toEqual({ encounter: 40, explore: 120, travel: 24 });
   });
 
   it("drives tier/status off the system breakpoint flags, not raw %", () => {
@@ -253,16 +256,18 @@ describe("selectEncumbrance", () => {
     const actor = {
       system: {
         encumbrance: {
-          value: 1071, max: 1600, enabled: true, variant: "detailed",
+          value: 1071, max: 1600, enabled: true, variant: "detailed", steps: [25, 37.5, 50],
           encumbered: false, atFirstBreakpoint: true, atSecondBreakpoint: true, atThirdBreakpoint: true,
         },
-        movement: { base: 30 },
+        movement: { base: 30, encounter: 10, overland: 6 },
       },
     } as unknown as OSEActor;
     const e = selectEncumbrance(actor);
     expect(e.tier).toBe(3);
     expect(e.status).toBe("Severely encumbered");
-    expect(e.move).toBe(30);
+    expect(e.moveBands.explore).toBe(30);
+    // the bar's colour cuts land on the system's own thresholds, not even thirds
+    expect(e.bands).toEqual([25, 37.5, 50]);
   });
 
   it("basic variant: bar fills from tier (not weight) and drops the cn load", () => {
@@ -270,26 +275,100 @@ describe("selectEncumbrance", () => {
     const actor = {
       system: {
         encumbrance: {
-          value: 100, max: 1600, enabled: true, variant: "basic",
+          value: 100, max: 1600, enabled: true, variant: "basic", steps: [50],
           encumbered: false, atFirstBreakpoint: true, atSecondBreakpoint: true, atThirdBreakpoint: false,
         },
-        movement: { base: 60 },
+        movement: { base: 60, encounter: 20, overland: 12 },
       },
     } as unknown as OSEActor;
     const e = selectEncumbrance(actor);
     expect(e.tier).toBe(2);
     expect(e.label).toBe(""); // no misleading "100 / 1600 cn"
     expect(e.pct).toBeCloseTo(2 / 3); // bar tracks the tier, not 100/1600
+    // basic's bar has no weight axis, so it plots no thresholds (it paints solid)
+    expect(e.bands).toEqual([]);
   });
 
   it("labels item-based encumbrance in items, not cn", () => {
     const actor = {
       system: {
-        encumbrance: { value: 10, max: 16, enabled: true, variant: "itembased", encumbered: false },
-        movement: { base: 120 },
+        encumbrance: {
+          value: 10, max: 16, enabled: true, variant: "itembased", encumbered: false,
+          steps: [62.5, 75, 87.5],
+        },
+        movement: { base: 120, encounter: 40, overland: 24 },
       },
     } as unknown as OSEActor;
-    expect(selectEncumbrance(actor).label).toBe("10 / 16 items");
+    const e = selectEncumbrance(actor);
+    expect(e.label).toBe("10 / 16 items");
+    // item-based steps differ per mode (packed vs equipped) — take them as given
+    expect(e.bands).toEqual([62.5, 75, 87.5]);
+  });
+});
+
+describe("significant treasure (basic encumbrance)", () => {
+  // Stands in for OSE's basic encumbrance class, incl. the line that made the old
+  // boolean bite: `options.significantTreasure || 800` keeps a `true`, turning every
+  // threshold check into `value >= true` — i.e. 1cn of treasure trips it.
+  class FakeBasic {
+    static lastOptions: { significantTreasure: unknown } | undefined;
+    variant = "basic";
+    enabled = true;
+    max: number;
+    value: number;
+    steps: number[] = [];
+    encumbered = false;
+    atSecondBreakpoint = false;
+    atThirdBreakpoint = false;
+    threshold: number;
+    constructor(max: number, its: OseItem[], options: { significantTreasure: unknown }) {
+      FakeBasic.lastOptions = options;
+      this.max = max;
+      this.threshold = (options?.significantTreasure as number) || 800;
+      this.value = its.reduce(
+        (a, i) =>
+          a + (i.system.treasure ? (i.system.quantity?.value ?? 0) * (i.system.weight ?? 0) : 0),
+        0,
+      );
+    }
+    get atFirstBreakpoint() {
+      return this.value >= this.threshold;
+    }
+  }
+
+  const basicActor = () =>
+    ({
+      system: {
+        encumbrance: new FakeBasic(1600, [], { significantTreasure: 800 }),
+        movement: { base: 120, encounter: 40, overland: 24 },
+        scores: { str: { mod: 0 } },
+      },
+    }) as unknown as OSEActor;
+
+  it("passes the threshold as a number, so a single gem doesn't encumber", () => {
+    const gem = mk("item", "Gem", { treasure: true, weight: 10, quantity: { value: 1 } });
+    const e = selectEncumbrance(basicActor(), [gem]);
+    expect(typeof FakeBasic.lastOptions?.significantTreasure).toBe("number");
+    expect(FakeBasic.lastOptions?.significantTreasure).toBe(800); // OSE default, not `true`
+    expect(e.tier).toBe(0);
+    expect(e.status).toBe("Unencumbered");
+  });
+
+  it("still trips once the treasure actually reaches the threshold", () => {
+    const hoard = mk("item", "Gems", { treasure: true, weight: 10, quantity: { value: 80 } });
+    expect(selectEncumbrance(basicActor(), [hoard]).tier).toBe(1);
+  });
+});
+
+describe("encBarStops", () => {
+  it("cuts one hard-edged segment per tier at the system's thresholds", () => {
+    expect(encBarStops({ bands: [25, 37.5, 50], tier: 1 })).toBe(
+      "var(--enc-0) 0% 25%, var(--enc-1) 25% 37.5%, var(--enc-2) 37.5% 50%, var(--enc-3) 50% 100%",
+    );
+  });
+
+  it("paints solid in the current tier's colour when there are no thresholds (basic)", () => {
+    expect(encBarStops({ bands: [], tier: 2 })).toBe("var(--enc-2) 0 100%");
   });
 });
 

--- a/src/OscSheet/features/inventory/inventory.test.ts
+++ b/src/OscSheet/features/inventory/inventory.test.ts
@@ -361,9 +361,22 @@ describe("significant treasure (basic encumbrance)", () => {
 });
 
 describe("encBarStops", () => {
-  it("cuts one hard-edged segment per tier at the system's thresholds", () => {
+  it("fades between tiers over a window centred on each threshold", () => {
+    // ±4% around each threshold: pure colour held to (t-4), ramped to next by (t+4),
+    // so the boundary % itself is the 50/50 midpoint of the blend.
     expect(encBarStops({ bands: [25, 37.5, 50], tier: 1 })).toBe(
-      "var(--enc-0) 0% 25%, var(--enc-1) 25% 37.5%, var(--enc-2) 37.5% 50%, var(--enc-3) 50% 100%",
+      "var(--enc-0) 0%, " +
+        "var(--enc-0) 21%, var(--enc-1) 29%, " +
+        "var(--enc-1) 33.5%, var(--enc-2) 41.5%, " +
+        "var(--enc-2) 46%, var(--enc-3) 54%, " +
+        "var(--enc-3) 100%",
+    );
+  });
+
+  it("clamps the fade window to the bar edges", () => {
+    // a threshold within 4% of an edge can't overrun 0/100
+    expect(encBarStops({ bands: [2, 98], tier: 1 })).toBe(
+      "var(--enc-0) 0%, var(--enc-0) 0%, var(--enc-1) 6%, var(--enc-1) 94%, var(--enc-2) 100%, var(--enc-2) 100%",
     );
   });
 

--- a/src/OscSheet/features/inventory/inventory.ts
+++ b/src/OscSheet/features/inventory/inventory.ts
@@ -438,17 +438,27 @@ export function selectEncumbrance(
 /** Basic tops out at the 3rd breakpoint — its synthetic bar fills tier/3. */
 const BASIC_TIER_CAP = 3;
 
+/** Half-width (in %) of the colour fade centred on each tier threshold. */
+const ENC_FADE_HALF = 4;
+
 /**
- * CSS colour-stop list for the encumbrance bar: one hard-edged segment per tier,
- * cut at `bands` (the system's thresholds), so the colour flips precisely where the
- * character changes tier. No stops ⇒ a solid bar in the current tier's colour.
- * Colours are the shared `--enc-N` tier tokens — same tier, same colour, sheet-wide.
+ * CSS colour-stop list for the encumbrance bar. Each tier holds its pure `--enc-N`
+ * colour across its band, then fades into the next over a narrow window CENTRED on
+ * the real threshold — so at a boundary % the colour is exactly 50/50 between the two
+ * tiers (the tier change still reads at the right spot), but the segments blend
+ * smoothly instead of butting hard edges. No thresholds ⇒ a solid bar in the current
+ * tier's colour. Colours are the shared `--enc-N` tokens — one tier, one colour.
  */
 export function encBarStops({ bands, tier }: Pick<EncumbranceVM, "bands" | "tier">): string {
   if (bands.length === 0) return `var(--enc-${tier}) 0 100%`;
-  const edges = [0, ...bands, 100];
-  return edges
-    .slice(0, -1)
-    .map((from, i) => `var(--enc-${Math.min(i, 4)}) ${from}% ${edges[i + 1]}%`)
-    .join(", ");
+  const stops = ["var(--enc-0) 0%"];
+  bands.forEach((t, i) => {
+    const from = Math.max(0, t - ENC_FADE_HALF);
+    const to = Math.min(100, t + ENC_FADE_HALF);
+    // hold this tier's colour up to the fade's start, then ramp to the next by its end
+    stops.push(`var(--enc-${Math.min(i, 4)}) ${from}%`);
+    stops.push(`var(--enc-${Math.min(i + 1, 4)}) ${to}%`);
+  });
+  stops.push(`var(--enc-${Math.min(bands.length, 4)}) 100%`);
+  return stops.join(", ");
 }

--- a/src/OscSheet/features/inventory/inventory.ts
+++ b/src/OscSheet/features/inventory/inventory.ts
@@ -340,13 +340,22 @@ const TIER_STATUS = [
   "Overloaded",
 ] as const;
 
-/** World significant-treasure setting (basic encumbrance). Safe in non-Foundry tests. */
-function significantTreasure(): boolean {
+/** OSE's default significant-treasure threshold, in cn (basic encumbrance). */
+export const DEFAULT_SIGNIFICANT_TREASURE = 800;
+
+/**
+ * World significant-treasure setting (basic encumbrance), in cn. OSE registers it as a
+ * NUMBER — coercing it to a boolean fed `true` into the encumbrance ctor, where
+ * `options.significantTreasure || 800` kept the `true` and made every threshold check
+ * `value >= true`, i.e. tripping at 1cn of treasure. Safe in non-Foundry tests.
+ */
+export function significantTreasure(): number {
   try {
     const settings = game.settings as { get(ns: string, key: string): unknown };
-    return !!settings.get(game.system.id, "significantTreasure");
+    const v = Number(settings.get(game.system.id, "significantTreasure"));
+    return Number.isFinite(v) && v > 0 ? v : DEFAULT_SIGNIFICANT_TREASURE;
   } catch {
-    return false;
+    return DEFAULT_SIGNIFICANT_TREASURE;
   }
 }
 
@@ -358,7 +367,7 @@ function significantTreasure(): boolean {
 type EncumbranceCtor = new (
   max: number,
   items: OseItem[],
-  options: { significantTreasure: boolean; scores: unknown },
+  options: { significantTreasure: number; scores: unknown },
   strMod: number,
 ) => CharacterEncumbrance;
 
@@ -383,7 +392,7 @@ export function selectEncumbrance(
           },
           actor.system.scores?.str?.mod ?? 0,
         );
-  const move = actor.system.movement?.base ?? 0;
+  const movement = actor.system.movement;
   // Tier = highest breakpoint reached (over-limit tops out at 4); use the system's
   // variant-aware flags, not our own % buckets.
   const breakpoints = [
@@ -399,7 +408,7 @@ export function selectEncumbrance(
   // misleading cn load. Weight/slot variants keep their real value/max load + fill.
   const isBasic = e.variant === "basic";
   const pct = isBasic
-    ? Math.min(1, tier / 3)
+    ? Math.min(1, tier / BASIC_TIER_CAP)
     : e.max > 0
       ? Math.min(1, e.value / e.max)
       : 0;
@@ -412,6 +421,34 @@ export function selectEncumbrance(
     tier,
     status: TIER_STATUS[tier],
     label: isBasic ? "" : `${e.value} / ${e.max} ${unit}`,
-    move,
+    moveBands: {
+      encounter: movement?.encounter ?? 0,
+      explore: movement?.base ?? 0,
+      travel: movement?.overland ?? 0,
+    },
+    // The bar's colour must change exactly where the tier does. For weight/slot
+    // variants the axis IS weight, so the stops are the system's own breakpoints
+    // (`steps`, already variant- and mode-aware). Basic's bar has no weight axis
+    // (see above) — there are no thresholds to plot, so it gets no stops and paints
+    // solid in the current tier's colour instead of implying fictitious ones.
+    bands: isBasic ? [] : (e.steps ?? []),
   };
+}
+
+/** Basic tops out at the 3rd breakpoint — its synthetic bar fills tier/3. */
+const BASIC_TIER_CAP = 3;
+
+/**
+ * CSS colour-stop list for the encumbrance bar: one hard-edged segment per tier,
+ * cut at `bands` (the system's thresholds), so the colour flips precisely where the
+ * character changes tier. No stops ⇒ a solid bar in the current tier's colour.
+ * Colours are the shared `--enc-N` tier tokens — same tier, same colour, sheet-wide.
+ */
+export function encBarStops({ bands, tier }: Pick<EncumbranceVM, "bands" | "tier">): string {
+  if (bands.length === 0) return `var(--enc-${tier}) 0 100%`;
+  const edges = [0, ...bands, 100];
+  return edges
+    .slice(0, -1)
+    .map((from, i) => `var(--enc-${Math.min(i, 4)}) ${from}% ${edges[i + 1]}%`)
+    .join(", ");
 }

--- a/src/OscSheet/layout/HeaderBand.stories.tsx
+++ b/src/OscSheet/layout/HeaderBand.stories.tsx
@@ -1,10 +1,34 @@
+import type { EncumbranceVM } from "@domain/vm-types";
 import { HeaderBand } from "@layout/HeaderBand";
 
 export default { title: "Shell / HeaderBand" };
 
+const identity = { name: "Eldra Vey", img: "", classLabel: "Magic-User", level: 3, alignment: "Neutral", title: "Conjurer" };
+
+const encumbrance: EncumbranceVM = {
+  enabled: true,
+  value: 700,
+  max: 1600,
+  pct: 700 / 1600,
+  tier: 2,
+  status: "Heavily encumbered",
+  label: "700 / 1600 cn",
+  moveBands: { encounter: 20, explore: 60, travel: 12 },
+  bands: [25, 37.5, 50],
+};
+
 export const Default = () => (
   <HeaderBand
-    identity={{ name: "Eldra Vey", img: "", classLabel: "Magic-User", level: 3, alignment: "Neutral", title: "Conjurer" }}
+    identity={identity}
     vitals={{ hp: { value: 8, max: 9 }, ac: { value: 12, ascending: true }, initMod: 1, hd: "3d4", move: 120, moveBands: { encounter: 40, explore: 120, travel: 24 } }}
+  />
+);
+
+/** Hover MOVE: the rates plus the tier that explains them — same tint as the inventory line. */
+export const Encumbered = () => (
+  <HeaderBand
+    identity={identity}
+    vitals={{ hp: { value: 8, max: 9 }, ac: { value: 12, ascending: true }, initMod: 1, hd: "3d4", move: 60, moveBands: encumbrance.moveBands }}
+    encumbrance={encumbrance}
   />
 );

--- a/src/OscSheet/layout/HeaderBand.tsx
+++ b/src/OscSheet/layout/HeaderBand.tsx
@@ -1,7 +1,8 @@
 import { useLayoutEffect, useRef } from "react";
-import type { IdentityVM, VitalsVM } from "@domain/vm-types";
-import { formatMod } from "@domain/format";
+import type { EncumbranceVM, IdentityVM, VitalsVM } from "@domain/vm-types";
+import { encTierClass, formatMod } from "@domain/format";
 import { Stamp } from "@ui/Stamp";
+import { MoveRateRows, PopRow, StatPop } from "@ui/MovePop";
 import { useHpInput } from "@ui/useHpInput";
 
 /** Shrink a single-line element's font to fit its box (down to `min`x) instead of
@@ -29,6 +30,8 @@ function useFitText(text: string, min = 0.6) {
 type Props = {
   identity: IdentityVM;
   vitals: VitalsVM;
+  /** Drives the encumbrance line in the MOVE hover — why the rates are what they are. */
+  encumbrance?: EncumbranceVM;
   /** Commit a new current-HP value; when provided, HP renders an editable input. */
   onSetHp?: (value: number) => void;
   /** Right-click on the portrait (e.g. Token Variant Art's picker). */
@@ -39,7 +42,7 @@ type Props = {
 
 /** Header band. Grid areas (see actions.scss) place: portrait · name+Init/HD/Move
  *  · HP/AC in medium, and stack them in the rail. */
-export function HeaderBand({ identity, vitals, onSetHp, onPortraitContextMenu, canEditPortrait }: Props) {
+export function HeaderBand({ identity, vitals, encumbrance, onSetHp, onPortraitContextMenu, canEditPortrait }: Props) {
   const m = vitals.moveBands;
   const nameRef = useFitText(identity.name);
   const hp = useHpInput({ value: vitals.hp.value, max: vitals.hp.max, onSet: onSetHp ?? (() => {}) });
@@ -84,11 +87,16 @@ export function HeaderBand({ identity, vitals, onSetHp, onPortraitContextMenu, c
         <div className="osc-tile osc-tile-move">
           <Stamp>MOVE</Stamp>
           <div className="osc-tile-v">{vitals.move}′</div>
-          <span className="osc-move-pop" role="tooltip">
-            <span className="r"><span className="k">Encounter</span><span className="vv">{m.encounter}′</span></span>
-            <span className="r"><span className="k">Explore</span><span className="vv">{m.explore}′</span></span>
-            <span className="r"><span className="k">Travel</span><span className="vv">{m.travel} mi</span></span>
-          </span>
+          <StatPop>
+            <MoveRateRows bands={m} />
+            {encumbrance?.enabled && (
+              <PopRow
+                k="Encumbrance"
+                v={encumbrance.status}
+                vClass={encTierClass(encumbrance.tier)}
+              />
+            )}
+          </StatPop>
         </div>
       </div>
       <div className="osc-vitals">

--- a/src/OscSheet/layout/HeaderBand.tsx
+++ b/src/OscSheet/layout/HeaderBand.tsx
@@ -86,7 +86,7 @@ export function HeaderBand({ identity, vitals, encumbrance, onSetHp, onPortraitC
         </div>
         <div className="osc-tile osc-tile-move">
           <Stamp>MOVE</Stamp>
-          <div className="osc-tile-v">{vitals.move}′</div>
+          <div className="osc-tile-v">{m.encounter}ft</div>
           <MoveTooltip
             bands={m}
             tier={encumbrance?.enabled ? encumbrance.tier : undefined}

--- a/src/OscSheet/layout/HeaderBand.tsx
+++ b/src/OscSheet/layout/HeaderBand.tsx
@@ -86,7 +86,7 @@ export function HeaderBand({ identity, vitals, encumbrance, onSetHp, onPortraitC
         </div>
         <div className="osc-tile osc-tile-move">
           <Stamp>MOVE</Stamp>
-          <div className="osc-tile-v">{m.encounter}ft</div>
+          <div className="osc-tile-v">{vitals.move}ft</div>
           <MoveTooltip
             bands={m}
             tier={encumbrance?.enabled ? encumbrance.tier : undefined}

--- a/src/OscSheet/layout/HeaderBand.tsx
+++ b/src/OscSheet/layout/HeaderBand.tsx
@@ -1,8 +1,8 @@
 import { useLayoutEffect, useRef } from "react";
 import type { EncumbranceVM, IdentityVM, VitalsVM } from "@domain/vm-types";
-import { encTierClass, formatMod } from "@domain/format";
+import { formatMod } from "@domain/format";
 import { Stamp } from "@ui/Stamp";
-import { MoveRateRows, PopRow, StatPop } from "@ui/MovePop";
+import { MoveTooltip } from "@ui/MovePop";
 import { useHpInput } from "@ui/useHpInput";
 
 /** Shrink a single-line element's font to fit its box (down to `min`x) instead of
@@ -87,16 +87,11 @@ export function HeaderBand({ identity, vitals, encumbrance, onSetHp, onPortraitC
         <div className="osc-tile osc-tile-move">
           <Stamp>MOVE</Stamp>
           <div className="osc-tile-v">{vitals.move}′</div>
-          <StatPop>
-            <MoveRateRows bands={m} />
-            {encumbrance?.enabled && (
-              <PopRow
-                k="Encumbrance"
-                v={encumbrance.status}
-                vClass={encTierClass(encumbrance.tier)}
-              />
-            )}
-          </StatPop>
+          <MoveTooltip
+            bands={m}
+            tier={encumbrance?.enabled ? encumbrance.tier : undefined}
+            status={encumbrance?.enabled ? encumbrance.status : undefined}
+          />
         </div>
       </div>
       <div className="osc-vitals">

--- a/src/OscSheet/styles/actions.scss
+++ b/src/OscSheet/styles/actions.scss
@@ -363,22 +363,21 @@
   font-size: var(--fs-2xs, 11px);
   color: var(--text);
 }
-// MOVE tile reveals the movement bands on hover
 .osc-tile-move {
-  position: relative;
   cursor: default;
 }
 // Shared by the header MOVE tile and the inventory encumbrance line (see MovePop.tsx).
+// Positioned in JS as `position: fixed` (inline style) so it escapes any overflow-
+// clipping ancestor — the character rail self-scrolls, and fixed with no transformed
+// ancestor is not clipped by it. `display:none` (inline) when closed. z-index keeps it
+// above sheet content (carets, sticky heads) when the layers happen to overlap.
 .osc-move-pop {
   // don't inherit the anchor's tier tint — only a `.vv.enc-t*` row opts back in
   --enc-c: initial;
 
-  position: absolute;
-  top: calc(100% + 6px);
-  left: 0;
   z-index: var(--z-tooltip);
   min-width: 150px;
-  display: flex;
+  display: flex; // open state; inline `display:none` hides it when closed
   flex-direction: column;
   gap: 3px;
   padding: var(--spacer-2) var(--spacer-2);
@@ -386,24 +385,7 @@
   border: 1px solid var(--gold-soft);
   border-radius: var(--r-lg, 10px);
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
-  opacity: 0;
-  visibility: hidden;
-  transition: opacity 0.12s;
-}
-.osc-tile-move:hover .osc-move-pop,
-.osc-tile-move:focus-within .osc-move-pop {
-  opacity: 1;
-  visibility: visible;
-}
-// Lift the whole trigger (not just the popover) to the tooltip layer while open,
-// so the popover clears sibling stacking contexts — a sticky head or a rotated
-// caret — that would otherwise cap it and poke through. Both movement triggers
-// are position:relative already, so z-index takes effect here.
-.osc-tile-move:hover,
-.osc-tile-move:focus-within,
-.osc-enc-readout:hover,
-.osc-enc-readout:focus-within {
-  z-index: var(--z-tooltip);
+  pointer-events: none; // display-only; never intercept clicks on content below
 }
 .osc-move-pop .r {
   display: flex;

--- a/src/OscSheet/styles/actions.scss
+++ b/src/OscSheet/styles/actions.scss
@@ -368,7 +368,11 @@
   position: relative;
   cursor: default;
 }
+// Shared by the header MOVE tile and the inventory encumbrance line (see MovePop.tsx).
 .osc-move-pop {
+  // don't inherit the anchor's tier tint — only a `.vv.enc-t*` row opts back in
+  --enc-c: initial;
+
   position: absolute;
   top: calc(100% + 6px);
   left: 0;
@@ -404,7 +408,8 @@
 .osc-move-pop .vv {
   font-family: var(--mono);
   font-size: var(--fs-xs, 12px);
-  color: var(--text);
+  color: var(--enc-c, var(--text)); // tinted only on rows carrying a tier class
+  white-space: nowrap; // the pop widens for "Severely encumbered" rather than wrapping it
 }
 
 // --- abilities: 3-up (6-up wide) grid of ability plaques ---

--- a/src/OscSheet/styles/actions.scss
+++ b/src/OscSheet/styles/actions.scss
@@ -366,6 +366,11 @@
 .osc-tile-move {
   cursor: default;
 }
+// dotted underline on the value hints at the hover breakdown (all three rates + enc)
+.osc-tile-move .osc-tile-v {
+  text-decoration: underline dotted var(--text-faint);
+  text-underline-offset: 2px;
+}
 // Shared by the header MOVE tile and the inventory encumbrance line (see MovePop.tsx).
 // Positioned in JS as `position: fixed` (inline style) so it escapes any overflow-
 // clipping ancestor — the character rail self-scrolls, and fixed with no transformed

--- a/src/OscSheet/styles/actions.scss
+++ b/src/OscSheet/styles/actions.scss
@@ -376,7 +376,7 @@
   position: absolute;
   top: calc(100% + 6px);
   left: 0;
-  z-index: 20;
+  z-index: var(--z-tooltip);
   min-width: 150px;
   display: flex;
   flex-direction: column;
@@ -394,6 +394,16 @@
 .osc-tile-move:focus-within .osc-move-pop {
   opacity: 1;
   visibility: visible;
+}
+// Lift the whole trigger (not just the popover) to the tooltip layer while open,
+// so the popover clears sibling stacking contexts — a sticky head or a rotated
+// caret — that would otherwise cap it and poke through. Both movement triggers
+// are position:relative already, so z-index takes effect here.
+.osc-tile-move:hover,
+.osc-tile-move:focus-within,
+.osc-enc-readout:hover,
+.osc-enc-readout:focus-within {
+  z-index: var(--z-tooltip);
 }
 .osc-move-pop .r {
   display: flex;

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -2,20 +2,28 @@
 // Button selectors are qualified with .osc-inv so they beat the
 // `.osc-sheet-app button { all: unset }` reset (0,1,1) in styles.scss.
 
-.osc-inv { display: flex; flex-direction: column; }
+.osc-inv {
+  display: flex;
+  flex-direction: column;
+}
 
 // --- header: title + hint ---
 .osc-inv-head {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  flex-wrap: wrap; // readout drops below the title when the row is too narrow (XS)
+  flex-wrap: nowrap; // title + readout always share one line — never wrap the readout below
   gap: var(--spacer-1) var(--spacer-3);
   padding-bottom: var(--spacer-2);
-  margin: var(--spacer-6) 0 var(--spacer-3);
+  margin: var(--spacer-6) 0 var(--spacer-5);
   border-bottom: 2px solid var(--section-rule);
 }
-.osc-inv-head .section-title { flex: 0 0 auto; margin: 0; padding-bottom: 0; border-bottom: none; }
+.osc-inv-head .section-title {
+  flex: 0 0 auto;
+  margin: 0;
+  padding-bottom: 0;
+  border-bottom: none;
+}
 
 // Encumbrance-as-rule: the 2px header underline becomes the load bar. The tier
 // spectrum spans the whole track, each tier's colour blending into the next over a
@@ -27,7 +35,11 @@
   border-bottom: none;
   background-image:
     // top: transparent up to --enc-pct (reveals the spectrum), dim rule beyond
-    linear-gradient(to right, transparent var(--enc-pct, 0%), var(--section-rule) var(--enc-pct, 0%)),
+    linear-gradient(
+      to right,
+      transparent var(--enc-pct, 0%),
+      var(--section-rule) var(--enc-pct, 0%)
+    ),
     // bottom: the tier spectrum across the entire track
     linear-gradient(to right, var(--enc-stops, var(--enc-0)));
   background-repeat: no-repeat;
@@ -40,38 +52,38 @@
 // load to the right edge — lining its cn up with the section headers' cn totals below.
 // Hover/focus reveals the shared MoveTooltip (positioned in JS; see MovePop.tsx). ---
 .osc-enc-readout {
-  position: relative; // reference for the hover anchor
   flex: 1 1 auto; // take the row width left of nothing/right of the title
-  display: flex; align-items: baseline; justify-content: space-between;
-  gap: var(--spacer-3);
-  font-family: var(--mono); font-size: var(--fs-xs, 12px); letter-spacing: 0;
-  color: var(--text-mute); white-space: nowrap;
+  display: flex;
+  align-items: baseline;
+  justify-content: flex-end;
+  gap: var(--spacer-2);
+  font-family: var(--mono);
+  font-size: var(--fs-2xs, 12px);
+  letter-spacing: 0;
+  color: var(--text-mute);
+  white-space: nowrap;
   cursor: default;
 }
-// the load (value/max) stays muted even though the tier class tints the element.
-.osc-enc-readout .load { color: var(--text-mute); }
+
 // rate cluster: very tight gap (2px) around the tier-tinted slash separators so the
 // three scores read as one compact group.
-.osc-enc-readout .rates { display: inline-flex; align-items: baseline; gap: 2px; }
+.osc-enc-readout .rates {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 2px;
+  // dotted underline hints at the hover breakdown; border (not text-decoration,
+  // which doesn't render through an inline-flex) so it draws under the rate cluster.
+  border-bottom: 1px dotted var(--text-faint);
+}
 // the rates AND their `/` separators carry the tier colour (--enc-c, set by .enc-t*).
 .osc-enc-readout .rate,
-.osc-enc-readout .rates .sep { color: var(--enc-c, var(--text-mute)); }
-
-// --- reference rail (below the bar, above Wealth): the full-unit movement labels,
-// thin and understated — a plain readout for eyeballing the labelled rates. ---
-.osc-enc-rail {
-  display: flex; align-items: baseline; gap: var(--spacer-2);
-  margin: var(--spacer-2) 0 var(--spacer-3);
-  font-family: var(--mono); font-size: var(--fs-2xs, 11px);
-  color: var(--text-faint); white-space: nowrap;
+.osc-enc-readout .rates .sep {
+  color: var(--enc-c, var(--text-mute));
 }
-.osc-enc-rail-k {
-  font-family: var(--sans); text-transform: uppercase; letter-spacing: 0.1em;
-  font-size: var(--fs-3xs, 10px); color: var(--text-mute);
+// pull the middot in — halve the flex gap flanking it (spacer-2 → ~spacer-1 each side).
+.osc-enc-readout .fa-dot {
+  margin-inline: calc(var(--spacer-1) * -1);
 }
-.osc-enc-rail-rates { display: inline-flex; align-items: baseline; gap: var(--spacer-2); }
-.osc-enc-rail .sep { color: var(--text-faint); }
-.osc-enc-rail .u { opacity: 0.75; }
 
 // ---------------------------------------------------------------------------
 // List rows — 8-column grid
@@ -97,15 +109,21 @@
   transition: background 0.1s;
 
   &.is-dragging,
-  &.dragging     { opacity: 0.4; }
+  &.dragging {
+    opacity: 0.4;
+  }
   &.is-drop-target {
     border-bottom-color: var(--teal, #1f7575);
     background: color-mix(in srgb, var(--teal, #1f7575) 8%, transparent);
   }
   // Insertion line — a 2px rule painted on the hovered row's leading/trailing edge.
   // box-shadow (not border) so it overlays without shifting the grid: no reflow.
-  &.drop-before { box-shadow: inset 0 2px 0 0 var(--teal, #1f7575); }
-  &.drop-after  { box-shadow: inset 0 -2px 0 0 var(--teal, #1f7575); }
+  &.drop-before {
+    box-shadow: inset 0 2px 0 0 var(--teal, #1f7575);
+  }
+  &.drop-after {
+    box-shadow: inset 0 -2px 0 0 var(--teal, #1f7575);
+  }
 }
 
 // --- sortable column-header row (table head) ---
@@ -113,123 +131,233 @@
   padding-top: 0;
   padding-bottom: var(--spacer-1);
   border-bottom: 2px solid var(--border, #3a342c);
-  &:hover { background: transparent; }
+  &:hover {
+    background: transparent;
+  }
 }
 .osc-inv .osc-inv-th {
-  display: inline-flex; align-items: center; gap: var(--spacer-1);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacer-1);
   min-width: 0;
-  background: transparent; cursor: pointer;
-  font-family: var(--sans); font-size: var(--fs-3xs, 10px); font-weight: 600;
-  letter-spacing: 0.08em; text-transform: uppercase;
+  background: transparent;
+  cursor: pointer;
+  font-family: var(--sans);
+  font-size: var(--fs-3xs, 10px);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   color: var(--text-faint, #6a6354);
   transition: color 0.12s;
-  &:hover { color: var(--text-dim, #b5ad97); }
-  &.active { color: var(--text, #e5dec8); }
+  &:hover {
+    color: var(--text-dim, #b5ad97);
+  }
+  &.active {
+    color: var(--text, #e5dec8);
+  }
 }
 // header alignment matches the cells below it
-.osc-inv .osc-inv-th-wt { justify-content: flex-end; }
-.osc-inv .osc-inv-th-cat { justify-content: flex-end; }
+.osc-inv .osc-inv-th-wt {
+  justify-content: flex-end;
+}
+.osc-inv .osc-inv-th-cat {
+  justify-content: flex-end;
+}
 // "Item" header spans the image + name columns so it starts at the image edge
-.osc-inv .osc-inv-th-item { grid-column: 2 / 4; justify-content: flex-start; }
-.osc-inv-th-caret { font-size: 8px; width: 6px; } // stylelint-disable-line declaration-property-value-disallowed-list -- 8px sort-caret glyph (reserve space so labels don't shift)
+.osc-inv .osc-inv-th-item {
+  grid-column: 2 / 4;
+  justify-content: flex-start;
+}
+.osc-inv-th-caret {
+  font-size: 8px; // stylelint-disable-line declaration-property-value-disallowed-list -- 8px sort-caret glyph (reserve space so labels don't shift)
+  width: 6px;
+}
 
 // --- item image (col 2) ---
 .osc-inv-img {
-  display: inline-flex; align-items: center; justify-content: center;
-  width: 30px; height: 30px;
-  border-radius: var(--r-sm, 4px); overflow: hidden;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: var(--r-sm, 4px);
+  overflow: hidden;
   background: var(--ink, #070605);
   border: 1px solid var(--border, #3a342c);
-  img { width: 100%; height: 100%; object-fit: cover; }
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
   .mono {
-    font-family: var(--display); font-size: var(--fs-2xs, 11px);
-    letter-spacing: 0.03em; color: var(--text-dim, #b5ad97);
+    font-family: var(--display);
+    font-size: var(--fs-2xs, 11px);
+    letter-spacing: 0.03em;
+    color: var(--text-dim, #b5ad97);
   }
 }
 
 // --- drag handle (col 1) ---
 .osc-inv .osc-inv-drag {
-  display: inline-flex; align-items: center; justify-content: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   color: var(--text-faint, #6a6354);
-  cursor: grab; font-size: var(--fs-xs, 12px); line-height: 1;
-  padding: var(--spacer-1); border-radius: 3px;
+  cursor: grab;
+  font-size: var(--fs-xs, 12px);
+  line-height: 1;
+  padding: var(--spacer-1);
+  border-radius: 3px;
   transition: color 0.12s;
-  &:active { cursor: grabbing; }
-  &:hover  { color: var(--text-mute, #8a8270); }
+  &:active {
+    cursor: grabbing;
+  }
+  &:hover {
+    color: var(--text-mute, #8a8270);
+  }
 }
 
 // --- equip hand toggle (col 4, centred under the "Equip" header) ---
-.osc-inv-equip-spacer { display: block; width: 22px; justify-self: center; }
+.osc-inv-equip-spacer {
+  display: block;
+  width: 22px;
+  justify-self: center;
+}
 .osc-inv .osc-inv-equip {
   justify-self: center;
-  display: inline-flex; align-items: center; justify-content: center;
-  width: 22px; height: 22px; padding: 0; border-radius: var(--r-sm, 4px);
-  background: transparent; border: none; cursor: pointer;
-  color: var(--text-faint, #6a6354); font-size: var(--fs-sm, 13px);
-  transition: color 0.12s, background 0.12s;
-  &:hover { color: var(--text-dim, #b5ad97); background: var(--surface-2, #2c2823); }
-  &.is-on { color: var(--teal); }
-  &.is-on:hover { color: var(--teal-dim); }
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border-radius: var(--r-sm, 4px);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--text-faint, #6a6354);
+  font-size: var(--fs-sm, 13px);
+  transition:
+    color 0.12s,
+    background 0.12s;
+  &:hover {
+    color: var(--text-dim, #b5ad97);
+    background: var(--surface-2, #2c2823);
+  }
+  &.is-on {
+    color: var(--teal);
+  }
+  &.is-on:hover {
+    color: var(--teal-dim);
+  }
 }
 // static "Equip" column header label (not sortable)
 .osc-inv-thlabel {
-  font-family: var(--sans); font-size: var(--fs-3xs, 10px); font-weight: 600;
-  letter-spacing: 0.08em; text-transform: uppercase;
+  font-family: var(--sans);
+  font-size: var(--fs-3xs, 10px);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   color: var(--text-faint, #6a6354);
 }
-.osc-inv-thlabel-eq { text-align: center; }
+.osc-inv-thlabel-eq {
+  text-align: center;
+}
 
 // --- name button (col 3) ---
 .osc-inv .osc-inv-name {
-  display: flex; align-items: baseline; gap: var(--spacer-2); flex-wrap: nowrap;
-  min-width: 0; overflow: hidden;
-  background: transparent; cursor: pointer; text-align: left;
+  display: flex;
+  align-items: baseline;
+  gap: var(--spacer-2);
+  flex-wrap: nowrap;
+  min-width: 0;
+  overflow: hidden;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
 }
 .osc-inv-name .nm {
-  font-family: var(--display); font-size: var(--fs-md, 15px);
-  color: var(--text, #e5dec8); transition: color 0.12s;
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  font-family: var(--display);
+  font-size: var(--fs-md, 15px);
+  color: var(--text, #e5dec8);
+  transition: color 0.12s;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-.osc-inv .osc-inv-name:hover .nm { color: var(--gold); }
+.osc-inv .osc-inv-name:hover .nm {
+  color: var(--gold);
+}
 
 // inline meta suffixes after the item name — weapon damage ("1d6") and stack
 // quantity ("×6") — muted mono.
 .osc-inv-qtytag {
-  font-family: var(--mono); font-size: var(--fs-2xs, 11px);
-  color: var(--text-mute, #8a8270); white-space: nowrap; flex: none;
+  font-family: var(--mono);
+  font-size: var(--fs-2xs, 11px);
+  color: var(--text-mute, #8a8270);
+  white-space: nowrap;
+  flex: none;
 }
 
 // container count pill (brass) — now <Tag intent="count">; see .tag.count
 
 // name column (col 3): name (+count) row on top, tags beneath, all left-justified
 .osc-inv-name-c {
-  display: flex; flex-direction: column; align-items: flex-start; gap: 2px;
-  min-width: 0; overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  min-width: 0;
+  overflow: hidden;
 }
 .osc-inv-name-row {
-  display: flex; align-items: baseline; gap: var(--spacer-1);
-  min-width: 0; max-width: 100%;
-  .osc-inv-name { flex: 0 1 auto; }
+  display: flex;
+  align-items: baseline;
+  gap: var(--spacer-1);
+  min-width: 0;
+  max-width: 100%;
+  .osc-inv-name {
+    flex: 0 1 auto;
+  }
 }
 
 // --- collapse chevron (small, inline with the container name text) ---
 .osc-inv .osc-inv-collapse {
-  display: inline-flex; align-items: center; justify-content: center;
-  background: transparent; border: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
   color: var(--text-mute, #8a8270);
-  cursor: pointer; padding: 0 4px; font-size: var(--fs-sm, 13px); line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+  font-size: var(--fs-sm, 13px);
+  line-height: 1;
   transition: color 0.12s;
   // the chevron rotates (a stacking context); pin it low so tooltips clear it.
-  position: relative; z-index: var(--z-raised);
+  position: relative;
+  z-index: var(--z-raised);
 
-  svg, i { transition: transform 0.18s; display: block; }
-  &.collapsed svg, &.collapsed i { transform: rotate(-90deg); }
-  &:hover { color: var(--text, #e5dec8); }
+  svg,
+  i {
+    transition: transform 0.18s;
+    display: block;
+  }
+  &.collapsed svg,
+  &.collapsed i {
+    transform: rotate(-90deg);
+  }
+  &:hover {
+    color: var(--text, #e5dec8);
+  }
 }
 
 // --- tags (beneath the name, left-justified) ---
 .osc-inv-tags {
-  display: flex; align-items: center; gap: var(--spacer-1); flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  gap: var(--spacer-1);
+  flex-wrap: wrap;
   min-width: 0;
 }
 .osc-inv-tag {
@@ -241,69 +369,107 @@
 
 // --- per-row category badge (col 4: Type) ---
 .osc-inv-rowcat {
-  font-family: var(--sans); font-size: var(--fs-3xs, 10px); font-weight: 600;
-  letter-spacing: 0.08em; text-transform: uppercase;
+  font-family: var(--sans);
+  font-size: var(--fs-3xs, 10px);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   color: var(--text-faint, #6a6354);
-  white-space: nowrap; text-align: right;
+  white-space: nowrap;
+  text-align: right;
 }
 
 // xs / mobile (bottom-tabs layout): drop the Type column to save width.
 @container app (max-width: 479px) {
-  .osc-inv-row { grid-template-columns: 18px 30px 1fr 44px 44px; }
+  .osc-inv-row {
+    grid-template-columns: 18px 30px 1fr 44px 44px;
+  }
   .osc-inv-rowcat,
-  .osc-inv .osc-inv-th-cat { display: none; }
+  .osc-inv .osc-inv-th-cat {
+    display: none;
+  }
 }
 
 // --- damage die (col 6) ---
 .osc-inv-dmg {
-  font-family: var(--mono); font-size: var(--fs-xs, 12px);
+  font-family: var(--mono);
+  font-size: var(--fs-xs, 12px);
   color: var(--text-mute, #8a8270);
-  text-align: right; white-space: nowrap;
+  text-align: right;
+  white-space: nowrap;
 }
 
 // --- quantity (col 7): editable for stacks, empty otherwise ---
 .osc-inv-qty {
-  font-family: var(--mono); font-size: var(--fs-2xs, 11px);
+  font-family: var(--mono);
+  font-size: var(--fs-2xs, 11px);
   color: var(--text-mute, #8a8270);
-  text-align: right; white-space: nowrap;
+  text-align: right;
+  white-space: nowrap;
 }
 .osc-inv .osc-inv-qtyin {
-  width: 100%; text-align: center;
-  padding: 2px 0; border-radius: var(--r-sm, 4px);
+  width: 100%;
+  text-align: center;
+  padding: 2px 0;
+  border-radius: var(--r-sm, 4px);
   background: var(--surface, #23201a);
   border: 1px solid var(--border-soft, #2c2823); // always visible so it reads as a field
   color: var(--text-dim, #b5ad97);
-  font-family: var(--mono); font-size: var(--fs-2xs, 11px);
+  font-family: var(--mono);
+  font-size: var(--fs-2xs, 11px);
   cursor: text;
-  transition: border-color 0.12s, background 0.12s;
-  &:hover { border-color: var(--border, #3a342c); }
-  &:focus { border-color: var(--gold); color: var(--text, #e5dec8); }
-  &::-webkit-inner-spin-button, &::-webkit-outer-spin-button { appearance: none; margin: 0; }
-  -moz-appearance: textfield; appearance: textfield;
+  transition:
+    border-color 0.12s,
+    background 0.12s;
+  &:hover {
+    border-color: var(--border, #3a342c);
+  }
+  &:focus {
+    border-color: var(--gold);
+    color: var(--text, #e5dec8);
+  }
+  &::-webkit-inner-spin-button,
+  &::-webkit-outer-spin-button {
+    appearance: none;
+    margin: 0;
+  }
+  -moz-appearance: textfield;
+  appearance: textfield;
 }
 
 // --- weight (col 8) ---
 .osc-inv-wt {
-  font-family: var(--mono); font-size: var(--fs-xs, 12px);
+  font-family: var(--mono);
+  font-size: var(--fs-xs, 12px);
   color: var(--text-mute, #8a8270);
-  text-align: right; white-space: nowrap;
+  text-align: right;
+  white-space: nowrap;
 }
 
 // --- nested children ---
 .osc-inv-children {
-  padding-left: calc(var(--spacer-4) + var(--osc-inv-depth, 1) * var(--spacer-4));
+  padding-left: calc(
+    var(--spacer-4) + var(--osc-inv-depth, 1) * var(--spacer-4)
+  );
   position: relative;
-  .osc-inv-children { --osc-inv-depth: 2; }
+  .osc-inv-children {
+    --osc-inv-depth: 2;
+  }
 
   // brass left-rail marking container membership (item icons are always ink, so a
   // mid-brass --accent-alt-dim is used to read on dark in both themes)
   &::before {
     content: "";
-    position: absolute; left: var(--spacer-4); top: 0; bottom: 0;
-    border-left: 2px solid color-mix(in oklab, var(--accent-alt-dim) 55%, transparent);
+    position: absolute;
+    left: var(--spacer-4);
+    top: 0;
+    bottom: 0;
+    border-left: 2px solid
+      color-mix(in oklab, var(--accent-alt-dim) 55%, transparent);
   }
   .osc-inv-img {
-    border: 1px solid color-mix(in oklab, var(--accent-alt-dim) 60%, transparent);
+    border: 1px solid
+      color-mix(in oklab, var(--accent-alt-dim) 60%, transparent);
   }
 }
 
@@ -319,7 +485,9 @@
 // the whole row is draggable (buttons inside still take clicks)
 .osc-inv-row.is-sortable {
   cursor: grab;
-  &:active { cursor: grabbing; }
+  &:active {
+    cursor: grabbing;
+  }
 }
 
 // Dragging an equipped tray tile down into the list → unequip drop target.
@@ -336,45 +504,89 @@
 
 // Wealth section (below the Inventory header): a header bar whose caret toggles a
 // drag-reorderable coin table. Sits in the same rhythm as Equipped / All Items.
-.osc-wsec { margin: 0 0 var(--spacer-5); }
+.osc-wsec {
+  margin: 0 0 var(--spacer-5);
+}
 
 // header bar — full-width button: overlapping coin dots · "Wealth" · gp total ·
 // caret · carried weight (far right).
 .osc-inv .osc-whead {
-  display: flex; align-items: center; gap: var(--spacer-3); width: 100%;
-  background: none; border: none; padding: 7px 2px 9px; cursor: pointer; text-align: left;
+  display: flex;
+  align-items: center;
+  gap: var(--spacer-3);
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 7px 2px 9px;
+  cursor: pointer;
+  text-align: left;
 }
-.osc-inv .osc-whead:disabled { cursor: default; }
-.osc-whead .coins { display: inline-flex; }
+.osc-inv .osc-whead:disabled {
+  cursor: default;
+}
+.osc-whead .coins {
+  display: inline-flex;
+}
 .osc-whead .coins .ci {
-  width: 11px; height: 11px; margin-left: -4px;
+  width: 11px;
+  height: 11px;
+  margin-left: -4px;
   box-shadow: 0 0 0 1.5px var(--bg, #181612); // ring in the page bg → reads as stacked coins
 }
-.osc-whead .coins .ci:first-child { margin-left: 0; }
-.osc-whead .key {
-  font-family: var(--sans); font-weight: 600; font-size: var(--fs-xs, 12px);
-  letter-spacing: 0.13em; text-transform: uppercase; color: var(--text-mute, #8a8270);
+.osc-whead .coins .ci:first-child {
+  margin-left: 0;
 }
-.osc-whead .v { font-family: var(--display); font-size: var(--fs-lg, 16px); color: var(--accent-alt); line-height: 1; }
+.osc-whead .key {
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: var(--fs-xs, 12px);
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: var(--text-mute, #8a8270);
+}
+.osc-whead .v {
+  font-family: var(--display);
+  font-size: var(--fs-lg, 16px);
+  color: var(--accent-alt);
+  line-height: 1;
+}
 .osc-whead .v small {
-  font-family: var(--mono); font-size: var(--fs-2xs, 11px);
-  color: var(--accent-alt); opacity: 0.75; margin-left: 2px;
+  font-family: var(--mono);
+  font-size: var(--fs-2xs, 11px);
+  color: var(--accent-alt);
+  opacity: 0.75;
+  margin-left: 2px;
 }
 .osc-whead .osc-wcaret {
-  font-size: var(--fs-md, 15px); color: var(--text-mute, #8a8270);
-  transition: transform 0.18s, color 0.15s;
+  font-size: var(--fs-md, 15px);
+  color: var(--text-mute, #8a8270);
+  transition:
+    transform 0.18s,
+    color 0.15s;
   // the rotate() below makes this a stacking context — pin it to the raised layer
   // so it stays below hover tooltips instead of poking through them.
-  position: relative; z-index: var(--z-raised);
+  position: relative;
+  z-index: var(--z-raised);
 }
-.osc-whead.open .osc-wcaret { transform: rotate(90deg); }
-.osc-inv .osc-whead:hover:not(:disabled) .osc-wcaret { color: var(--text, #e5dec8); }
-.osc-whead .wt { margin-left: auto; font-family: var(--mono); font-size: var(--fs-2xs, 11px); color: var(--text-faint, #6a6354); }
+.osc-whead.open .osc-wcaret {
+  transform: rotate(90deg);
+}
+.osc-inv .osc-whead:hover:not(:disabled) .osc-wcaret {
+  color: var(--text, #e5dec8);
+}
+.osc-whead .wt {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: var(--fs-2xs, 11px);
+  color: var(--text-faint, #6a6354);
+}
 
 .osc-wsec-empty {
   margin: 0 0 var(--spacer-2) 2px;
-  font-family: var(--serif); font-style: italic;
-  font-size: var(--fs-sm, 13px); color: var(--text-faint, #6a6354);
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: var(--fs-sm, 13px);
+  color: var(--text-faint, #6a6354);
 }
 
 // coin table — card; rows mirror the items table (handle · ink-icon · name …)
@@ -382,7 +594,8 @@
   background: var(--bg-2, #1f1c17);
   border: 1px solid var(--border-soft, #2c2823);
   border-radius: var(--r-md, 6px);
-  padding: 3px 12px 9px; margin-top: 2px;
+  padding: 3px 12px 9px;
+  margin-top: 2px;
 }
 // Grid mirrors the items table (handle · 30px image · name · …) so the coin rows
 // read as siblings; the trailing Qty/Weight/Value columns are coin-specific.
@@ -391,182 +604,378 @@
 .osc-coin-total {
   display: grid;
   grid-template-columns: 18px 30px minmax(0, 1fr) 74px 56px 64px;
-  column-gap: var(--spacer-2); align-items: center;
+  column-gap: var(--spacer-2);
+  align-items: center;
 }
 .osc-coin-colhead {
   padding: 0 0 var(--spacer-1);
   border-bottom: 2px solid var(--border, #3a342c);
 }
 // right-align the numeric sort headers (reuses the shared .osc-inv-th button)
-.osc-inv .osc-coin-th-num { justify-content: flex-end; }
-
-.osc-coin-row { padding: var(--spacer-2) 0; border-bottom: 1px solid var(--border-soft, #2c2823); }
-// drop-line affordance (matches the items rows)
-.osc-coin-row.drop-before { box-shadow: inset 0 2px 0 0 var(--teal, #1f7575); }
-.osc-coin-row.drop-after  { box-shadow: inset 0 -2px 0 0 var(--teal, #1f7575); }
-.osc-coin-row.dragging { opacity: 0.4; }
-.osc-inv .osc-coin-qty {
-  width: 100%; min-width: 0; text-align: right;
-  font-family: var(--mono); font-size: var(--fs-sm, 13px); color: var(--text, #e5dec8);
-  background: var(--surface, #23201a); border: 1px solid var(--border-soft, #2c2823);
-  border-radius: var(--r-sm, 4px); padding: 5px 8px;
-  transition: border-color 0.12s;
-  -moz-appearance: textfield; appearance: textfield;
+.osc-inv .osc-coin-th-num {
+  justify-content: flex-end;
 }
-.osc-inv .osc-coin-qty:hover { border-color: var(--border, #3a342c); }
-.osc-inv .osc-coin-qty:focus { border-color: var(--accent-alt); outline: none; }
+
+.osc-coin-row {
+  padding: var(--spacer-2) 0;
+  border-bottom: 1px solid var(--border-soft, #2c2823);
+}
+// drop-line affordance (matches the items rows)
+.osc-coin-row.drop-before {
+  box-shadow: inset 0 2px 0 0 var(--teal, #1f7575);
+}
+.osc-coin-row.drop-after {
+  box-shadow: inset 0 -2px 0 0 var(--teal, #1f7575);
+}
+.osc-coin-row.dragging {
+  opacity: 0.4;
+}
+.osc-inv .osc-coin-qty {
+  width: 100%;
+  min-width: 0;
+  text-align: right;
+  font-family: var(--mono);
+  font-size: var(--fs-sm, 13px);
+  color: var(--text, #e5dec8);
+  background: var(--surface, #23201a);
+  border: 1px solid var(--border-soft, #2c2823);
+  border-radius: var(--r-sm, 4px);
+  padding: 5px 8px;
+  transition: border-color 0.12s;
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+.osc-inv .osc-coin-qty:hover {
+  border-color: var(--border, #3a342c);
+}
+.osc-inv .osc-coin-qty:focus {
+  border-color: var(--accent-alt);
+  outline: none;
+}
 .osc-inv .osc-coin-qty::-webkit-inner-spin-button,
-.osc-inv .osc-coin-qty::-webkit-outer-spin-button { appearance: none; margin: 0; }
-.osc-coin-wt { text-align: right; font-family: var(--mono); font-size: var(--fs-xs, 12px); color: var(--text-dim, #b5ad97); }
-.osc-coin-val { text-align: right; font-family: var(--mono); font-size: var(--fs-xs, 12px); color: var(--text, #e5dec8); }
+.osc-inv .osc-coin-qty::-webkit-outer-spin-button {
+  appearance: none;
+  margin: 0;
+}
+.osc-coin-wt {
+  text-align: right;
+  font-family: var(--mono);
+  font-size: var(--fs-xs, 12px);
+  color: var(--text-dim, #b5ad97);
+}
+.osc-coin-val {
+  text-align: right;
+  font-family: var(--mono);
+  font-size: var(--fs-xs, 12px);
+  color: var(--text, #e5dec8);
+}
 
 .osc-coin-total {
   align-items: baseline;
   // no top border — the last coin row's bottom rule is the divider (avoids a double line)
-  padding: 8px 0 1px; margin-top: 2px;
+  padding: 8px 0 1px;
+  margin-top: 2px;
 }
 // explicit close affordance under the table
-.osc-coin-done { display: flex; justify-content: flex-end; margin-top: var(--spacer-3); }
-.osc-coin-total .lab {
-  grid-column: 3; font-family: var(--sans); font-weight: 600; font-size: var(--fs-3xs, 10px);
-  letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-mute, #8a8270);
+.osc-coin-done {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: var(--spacer-3);
 }
-.osc-coin-total .tw { grid-column: 5; text-align: right; font-family: var(--mono); font-size: var(--fs-xs, 12px); color: var(--text-dim, #b5ad97); }
-.osc-coin-total .tv { grid-column: 6; text-align: right; font-family: var(--mono); font-weight: 700; font-size: var(--fs-xs, 12px); color: var(--accent-alt); }
+.osc-coin-total .lab {
+  grid-column: 3;
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: var(--fs-3xs, 10px);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-mute, #8a8270);
+}
+.osc-coin-total .tw {
+  grid-column: 5;
+  text-align: right;
+  font-family: var(--mono);
+  font-size: var(--fs-xs, 12px);
+  color: var(--text-dim, #b5ad97);
+}
+.osc-coin-total .tv {
+  grid-column: 6;
+  text-align: right;
+  font-family: var(--mono);
+  font-weight: 700;
+  font-size: var(--fs-xs, 12px);
+  color: var(--accent-alt);
+}
 
 // Per-denomination dot colours (handoff palette; hex fallbacks are stylelint-allowed).
-.osc-inv .ci { display: inline-block; width: 8px; height: 8px; border-radius: 50%; flex: none; }
-.osc-inv .ci.pp { background: var(--coin-pp, #cfd2da); }
-.osc-inv .ci.gp { background: var(--accent-alt); }
-.osc-inv .ci.ep { background: var(--coin-ep, #cdbb78); }
-.osc-inv .ci.sp { background: var(--coin-sp, #b9bcc4); }
-.osc-inv .ci.cp { background: var(--coin-cp, #b1734a); }
+.osc-inv .ci {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: none;
+}
+.osc-inv .ci.pp {
+  background: var(--coin-pp, #cfd2da);
+}
+.osc-inv .ci.gp {
+  background: var(--accent-alt);
+}
+.osc-inv .ci.ep {
+  background: var(--coin-ep, #cdbb78);
+}
+.osc-inv .ci.sp {
+  background: var(--coin-sp, #b9bcc4);
+}
+.osc-inv .ci.cp {
+  background: var(--coin-cp, #b1734a);
+}
 
 // xs / narrow inventory column: drop Weight + Value columns and the total row.
 // Header children: 1 drag · 2 Coin · 3 Qty · 4 Weight · 5 Value.
 @container app (max-width: 479px) {
   .osc-coin-colhead,
-  .osc-coin-row { grid-template-columns: 18px 30px minmax(0, 1fr) 92px; }
+  .osc-coin-row {
+    grid-template-columns: 18px 30px minmax(0, 1fr) 92px;
+  }
   .osc-coin-colhead > :nth-child(4),
-  .osc-coin-colhead > :nth-child(5) { display: none; }
-  .osc-coin-wt, .osc-coin-val, .osc-coin-total { display: none; }
+  .osc-coin-colhead > :nth-child(5) {
+    display: none;
+  }
+  .osc-coin-wt,
+  .osc-coin-val,
+  .osc-coin-total {
+    display: none;
+  }
 }
 
 // ---------------------------------------------------------------------------
 // Sections (Equipped tray + All Items) + sticky pinning
 // ---------------------------------------------------------------------------
 
-.osc-inv-sec { margin: var(--spacer-3) 0; }
+.osc-inv-sec {
+  margin: var(--spacer-3) 0;
+}
 
 // The equipped tray + the All-Items header live together in one sticky block
 // (.osc-inv-stickyhead) so they pin to the scroll top as a single opaque unit —
 // no JS height measuring, no see-through gap between two separately-sticky bands.
 // Scroll container is .osc-sheet-body.
 .osc-inv-stickyhead {
-  position: sticky; top: 0; z-index: var(--z-sticky);
+  position: sticky;
+  top: 0;
+  z-index: var(--z-sticky);
   background: var(--bg);
 }
-.osc-inv-stickyhead .osc-inv-sec--equipped { margin: 0 0 var(--spacer-3); }
+.osc-inv-stickyhead .osc-inv-sec--equipped {
+  margin: 0 0 var(--spacer-3);
+}
 // breathing room below the sticky "All Items" header so the table (and its
 // outline-offset drop outline) clears the sticky band instead of being clipped.
-.osc-inv-sec--carried { margin-top: var(--spacer-3); }
+.osc-inv-sec--carried {
+  margin-top: var(--spacer-3);
+}
 // static (non-collapsible) header: title on the left, "N items · X cn" on the right
 .osc-inv-sec-head {
-  display: flex; align-items: baseline; gap: var(--spacer-2); width: 100%;
+  display: flex;
+  align-items: baseline;
+  gap: var(--spacer-2);
+  width: 100%;
   padding: var(--spacer-1) 0 var(--spacer-2);
   background: var(--bg);
   color: var(--text-mute, #8a8270);
 }
 // section title is now <SectionTitle variant="sub">; see .section-title.sub
 .osc-inv-sec-count {
-  font-family: var(--mono); font-size: var(--fs-2xs, 11px);
-  color: var(--text-faint, #6a6354); margin-left: auto; white-space: nowrap;
+  font-family: var(--mono);
+  font-size: var(--fs-2xs, 11px);
+  color: var(--text-faint, #6a6354);
+  margin-left: auto;
+  white-space: nowrap;
 }
 
 // --- Equipped tray: dashed-bordered row of large ink-stamp tiles ---
 .osc-equip-tray {
-  display: flex; flex-wrap: wrap; gap: var(--spacer-2); align-items: flex-start;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacer-2);
+  align-items: flex-start;
   padding: var(--spacer-3);
-  border: 1.5px dashed var(--border-soft, #2c2823); border-radius: var(--r-md, 6px);
-  transition: border-color 0.12s, background 0.12s;
+  border: 1.5px dashed var(--border-soft, #2c2823);
+  border-radius: var(--r-md, 6px);
+  transition:
+    border-color 0.12s,
+    background 0.12s;
 }
 // Dragging an item over the tray to equip it — dotted teal accent (equip = teal).
 .osc-equip-tray.is-drop-target {
-  border-style: dotted; border-color: var(--teal);
+  border-style: dotted;
+  border-color: var(--teal);
   background: color-mix(in oklab, var(--teal) 8%, transparent);
 }
-.osc-equip-tcard { position: relative; }
+.osc-equip-tcard {
+  position: relative;
+}
 // tiles drag to reorder within the tray (own order)
-.osc-equip-tcard.is-sortable { cursor: grab; &:active { cursor: grabbing; } }
-.osc-equip-tcard.dragging { opacity: 0.4; }
+.osc-equip-tcard.is-sortable {
+  cursor: grab;
+  &:active {
+    cursor: grabbing;
+  }
+}
+.osc-equip-tcard.dragging {
+  opacity: 0.4;
+}
 // horizontal insertion line on the leading/trailing edge of the hovered tile (teal)
 .osc-equip-tcard.drop-before::before,
 .osc-equip-tcard.drop-after::after {
-  content: ""; position: absolute; top: 2px; bottom: 2px; width: 2px;
-  background: var(--teal, #1f7575); border-radius: 2px; pointer-events: none;
+  content: "";
+  position: absolute;
+  top: 2px;
+  bottom: 2px;
+  width: 2px;
+  background: var(--teal, #1f7575);
+  border-radius: 2px;
+  pointer-events: none;
 }
-.osc-equip-tcard.drop-before::before { left: -5px; }
-.osc-equip-tcard.drop-after::after  { right: -5px; }
+.osc-equip-tcard.drop-before::before {
+  left: -5px;
+}
+.osc-equip-tcard.drop-after::after {
+  right: -5px;
+}
 .osc-inv .osc-equip-tt {
-  position: relative; width: 50px; height: 50px; padding: 0;
-  display: grid; place-items: center; cursor: pointer;
-  background: var(--ink, #070605); color: var(--stamp-text, #e5dec8);
-  border: 1.5px solid var(--teal); border-radius: var(--r-sm, 4px);
+  position: relative;
+  width: 50px;
+  height: 50px;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  background: var(--ink, #070605);
+  color: var(--stamp-text, #e5dec8);
+  border: 1.5px solid var(--teal);
+  border-radius: var(--r-sm, 4px);
   overflow: hidden;
   transition: transform 0.12s;
-  &:hover { transform: translateY(-1px); }
-  img { width: 100%; height: 100%; object-fit: cover; }
+  &:hover {
+    transform: translateY(-1px);
+  }
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
 }
-.osc-equip-tt-ic { font-family: var(--display); font-size: var(--fs-xl, 18px); line-height: 1; }
+.osc-equip-tt-ic {
+  font-family: var(--display);
+  font-size: var(--fs-xl, 18px);
+  line-height: 1;
+}
 
 // hover popover with item detail
 .osc-equip-tt-pop {
-  position: absolute; left: 50%; top: calc(100% + 8px); transform: translate(-50%, 4px);
-  z-index: 12; min-width: 132px; max-width: 200px;
-  display: flex; flex-direction: column; gap: 3px;
-  padding: var(--spacer-2) var(--spacer-3); border-radius: var(--r-md, 6px);
-  background: var(--surface-2, #2c2823); border: 1px solid var(--border, #3a342c);
+  position: absolute;
+  left: 50%;
+  top: calc(100% + 8px);
+  transform: translate(-50%, 4px);
+  z-index: 12;
+  min-width: 132px;
+  max-width: 200px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: var(--spacer-2) var(--spacer-3);
+  border-radius: var(--r-md, 6px);
+  background: var(--surface-2, #2c2823);
+  border: 1px solid var(--border, #3a342c);
   box-shadow: 0 8px 22px rgba(0, 0, 0, 0.32);
-  opacity: 0; pointer-events: none; transition: opacity 0.12s, transform 0.12s;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 0.12s,
+    transform 0.12s;
   &::before {
-    content: ""; position: absolute; left: 50%; top: -5px; transform: translateX(-50%) rotate(45deg);
-    width: 9px; height: 9px; background: var(--surface-2, #2c2823);
-    border-left: 1px solid var(--border, #3a342c); border-top: 1px solid var(--border, #3a342c);
+    content: "";
+    position: absolute;
+    left: 50%;
+    top: -5px;
+    transform: translateX(-50%) rotate(45deg);
+    width: 9px;
+    height: 9px;
+    background: var(--surface-2, #2c2823);
+    border-left: 1px solid var(--border, #3a342c);
+    border-top: 1px solid var(--border, #3a342c);
   }
 }
-.osc-equip-tcard:hover .osc-equip-tt-pop { opacity: 1; transform: translate(-50%, 0); }
-.osc-equip-tt-pop-nm { font-family: var(--display); font-size: var(--fs-base, 15px); color: var(--text, #e5dec8); line-height: 1.1; }
+.osc-equip-tcard:hover .osc-equip-tt-pop {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+.osc-equip-tt-pop-nm {
+  font-family: var(--display);
+  font-size: var(--fs-base, 15px);
+  color: var(--text, #e5dec8);
+  line-height: 1.1;
+}
 .osc-equip-tt-pop-type {
-  font-family: var(--sans); font-size: var(--fs-3xs, 10px);
-  letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-mute, #8a8270);
+  font-family: var(--sans);
+  font-size: var(--fs-3xs, 10px);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-mute, #8a8270);
 }
 // stat rows — label on the left, mono value on the right
 .osc-equip-tt-pop-stats {
-  display: flex; flex-direction: column; gap: 2px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
   margin-top: var(--spacer-1);
-  padding-top: var(--spacer-1); border-top: 1px solid var(--border-soft, #2c2823);
+  padding-top: var(--spacer-1);
+  border-top: 1px solid var(--border-soft, #2c2823);
 }
 .osc-equip-tt-pop-stat {
-  display: flex; align-items: baseline; justify-content: space-between; gap: var(--spacer-3);
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--spacer-3);
   .k {
-    font-family: var(--sans); font-size: var(--fs-3xs, 10px);
-    letter-spacing: 0.04em; text-transform: uppercase; color: var(--text-faint, #6a6354);
+    font-family: var(--sans);
+    font-size: var(--fs-3xs, 10px);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--text-faint, #6a6354);
   }
-  .v { font-family: var(--mono); font-size: var(--fs-xs, 12px); color: var(--text-dim, #b5ad97); }
+  .v {
+    font-family: var(--mono);
+    font-size: var(--fs-xs, 12px);
+    color: var(--text-dim, #b5ad97);
+  }
 }
 // quality tags
 .osc-equip-tt-pop-tags {
-  display: flex; flex-wrap: wrap; gap: var(--spacer-1);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacer-1);
   margin-top: var(--spacer-1);
-  padding-top: var(--spacer-1); border-top: 1px solid var(--border-soft, #2c2823);
+  padding-top: var(--spacer-1);
+  border-top: 1px solid var(--border-soft, #2c2823);
 }
 .osc-equip-tt-pop-tag {
-  display: inline-flex; align-items: center; gap: 3px;
-  font-family: var(--sans); font-size: var(--fs-3xs, 10px);
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-family: var(--sans);
+  font-size: var(--fs-3xs, 10px);
   color: var(--text-dim, #b5ad97);
-  background: var(--bg-2, #1f1c17); border: 1px solid var(--border-soft, #2c2823);
-  border-radius: var(--r-sm, 4px); padding: 1px 6px;
-  i { font-size: 9px; color: var(--gold-dim); } // stylelint-disable-line declaration-property-value-disallowed-list -- 9px tag-icon glyph
+  background: var(--bg-2, #1f1c17);
+  border: 1px solid var(--border-soft, #2c2823);
+  border-radius: var(--r-sm, 4px);
+  padding: 1px 6px;
+  i {
+    font-size: 9px; // stylelint-disable-line declaration-property-value-disallowed-list -- 9px tag-icon glyph
+    color: var(--gold-dim);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -574,30 +983,55 @@
 // ---------------------------------------------------------------------------
 
 .osc-ctx {
-  position: fixed; z-index: 1000; min-width: 168px;
+  position: fixed;
+  z-index: 1000;
+  min-width: 168px;
   padding: var(--spacer-1);
   background: var(--surface, #23201a);
-  border: 1px solid var(--border, #3a342c); border-radius: var(--r-md, 6px);
+  border: 1px solid var(--border, #3a342c);
+  border-radius: var(--r-md, 6px);
   box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45);
 }
 .osc-ctx-title {
-  font-family: var(--display); font-size: var(--fs-sm, 13px);
+  font-family: var(--display);
+  font-size: var(--fs-sm, 13px);
   color: var(--text-dim, #b5ad97);
   padding: var(--spacer-1) var(--spacer-2) var(--spacer-2);
   border-bottom: 1px solid var(--border-soft, #2c2823);
   margin-bottom: var(--spacer-1);
 }
 .osc-inv .osc-ctx-item {
-  display: flex; align-items: center; gap: var(--spacer-2); width: 100%;
-  padding: var(--spacer-2); border-radius: var(--r-sm, 4px);
-  background: transparent; border: none; cursor: pointer; text-align: left;
-  font-family: var(--sans); font-size: var(--fs-sm, 13px);
+  display: flex;
+  align-items: center;
+  gap: var(--spacer-2);
+  width: 100%;
+  padding: var(--spacer-2);
+  border-radius: var(--r-sm, 4px);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--sans);
+  font-size: var(--fs-sm, 13px);
   color: var(--text, #e5dec8);
-  i { width: 16px; text-align: center; color: var(--text-mute, #8a8270); }
-  &:hover { background: var(--surface-2, #2c2823); }
-  &:disabled { opacity: 0.4; cursor: default; }
-  &.is-danger:hover { background: color-mix(in srgb, var(--crimson, #c75044) 18%, transparent); }
-  &.is-danger i { color: var(--crimson, #c75044); }
+  i {
+    width: 16px;
+    text-align: center;
+    color: var(--text-mute, #8a8270);
+  }
+  &:hover {
+    background: var(--surface-2, #2c2823);
+  }
+  &:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+  &.is-danger:hover {
+    background: color-mix(in srgb, var(--crimson, #c75044) 18%, transparent);
+  }
+  &.is-danger i {
+    color: var(--crimson, #c75044);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -606,28 +1040,49 @@
 
 // Layout/size/color come from u-* utilities in the JSX; only the bespoke target
 // button (hover / selected color-mix / disabled) and its icon tile live here.
-.osc-send-targets { list-style: none; margin: 0; padding: 0; }
+.osc-send-targets {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
 // Button selectors qualified with .osc-inv (the dialog is a DOM descendant) so
 // they beat the `.osc-sheet-app button { all: unset }` reset.
 .osc-inv .osc-send-target {
-  display: flex; align-items: center; gap: var(--spacer-3); width: 100%;
+  display: flex;
+  align-items: center;
+  gap: var(--spacer-3);
+  width: 100%;
   padding: var(--spacer-2) var(--spacer-3);
-  background: transparent; cursor: pointer; text-align: left;
-  border: 1px solid var(--border-soft, #2c2823); border-radius: var(--r-md, 6px);
-  font-family: var(--sans); font-size: var(--fs-md, 14px);
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  border: 1px solid var(--border-soft, #2c2823);
+  border-radius: var(--r-md, 6px);
+  font-family: var(--sans);
+  font-size: var(--fs-md, 14px);
   color: var(--text, #e5dec8);
-  &:hover { background: var(--bg-2, #1f1c17); }
+  &:hover {
+    background: var(--bg-2, #1f1c17);
+  }
   &.is-selected {
     border-color: var(--accent-alt, #c89e54);
     background: color-mix(in srgb, var(--accent-alt, #c89e54) 12%, transparent);
   }
-  &:disabled { opacity: 0.4; cursor: not-allowed; }
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
 }
 .osc-send-target-ic {
-  width: var(--spacer-8); height: var(--spacer-8); flex: 0 0 auto;
-  display: grid; place-items: center; overflow: hidden;
+  width: var(--spacer-8);
+  height: var(--spacer-8);
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
   border-radius: var(--r-sm, 4px);
   background: var(--bg-2, #1f1c17);
-  font-family: var(--display); color: var(--text-dim, #b5ad97);
+  font-family: var(--display);
+  color: var(--text-dim, #b5ad97);
   object-fit: cover;
 }

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -35,30 +35,43 @@
   background-size: 100% 2px;
 }
 
-// --- encumbrance readout (inline above the load bar): the numeric load (muted) ·
-// the three movement rates (tinted by tier). Hover/focus reveals the shared
-// MoveTooltip (same rows as the header MOVE hover) ---
+// --- encumbrance readout (above the load bar): rates on the LEFT (tinted by tier),
+// the cn load on the RIGHT. Fills the header row (flex: 1) so space-between pushes the
+// load to the right edge — lining its cn up with the section headers' cn totals below.
+// Hover/focus reveals the shared MoveTooltip (positioned in JS; see MovePop.tsx). ---
 .osc-enc-readout {
-  position: relative; // popover anchor
-  display: inline-flex; align-items: baseline;
+  position: relative; // reference for the hover anchor
+  flex: 1 1 auto; // take the row width left of nothing/right of the title
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: var(--spacer-3);
   font-family: var(--mono); font-size: var(--fs-xs, 12px); letter-spacing: 0;
   color: var(--text-mute); white-space: nowrap;
   cursor: default;
 }
-// the load (value/max) stays muted even though the tier class tints the element;
-// only the rates carry the tier colour (--enc-c, set by .enc-t*).
+// the load (value/max) stays muted even though the tier class tints the element.
 .osc-enc-readout .load { color: var(--text-mute); }
-// rate cluster: tight gap around the two internal middots so the three scores read
-// as one group. Separated from the load by whitespace (margin), not a middot —
-// suppressed when there's no load so the rates don't get a leading indent.
-.osc-enc-readout .rates { display: inline-flex; align-items: baseline; gap: var(--spacer-1); }
-.osc-enc-readout .rates:not(:first-child) { margin-left: var(--spacer-4); }
-.osc-enc-readout .sep { color: var(--text-faint); }
-.osc-enc-readout .rate { color: var(--enc-c, var(--text-mute)); }
-.osc-enc-readout:hover .osc-move-pop,
-.osc-enc-readout:focus-within .osc-move-pop { opacity: 1; visibility: visible; }
-// pop hangs off the right edge here — the readout sits at the header's right
-.osc-enc-readout .osc-move-pop { right: 0; left: auto; }
+// rate cluster: very tight gap (2px) around the tier-tinted slash separators so the
+// three scores read as one compact group.
+.osc-enc-readout .rates { display: inline-flex; align-items: baseline; gap: 2px; }
+// the rates AND their `/` separators carry the tier colour (--enc-c, set by .enc-t*).
+.osc-enc-readout .rate,
+.osc-enc-readout .rates .sep { color: var(--enc-c, var(--text-mute)); }
+
+// --- reference rail (below the bar, above Wealth): the full-unit movement labels,
+// thin and understated — a plain readout for eyeballing the labelled rates. ---
+.osc-enc-rail {
+  display: flex; align-items: baseline; gap: var(--spacer-2);
+  margin: var(--spacer-2) 0 var(--spacer-3);
+  font-family: var(--mono); font-size: var(--fs-2xs, 11px);
+  color: var(--text-faint); white-space: nowrap;
+}
+.osc-enc-rail-k {
+  font-family: var(--sans); text-transform: uppercase; letter-spacing: 0.1em;
+  font-size: var(--fs-3xs, 10px); color: var(--text-mute);
+}
+.osc-enc-rail-rates { display: inline-flex; align-items: baseline; gap: var(--spacer-2); }
+.osc-enc-rail .sep { color: var(--text-faint); }
+.osc-enc-rail .u { opacity: 0.75; }
 
 // ---------------------------------------------------------------------------
 // List rows — 8-column grid

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -18,10 +18,11 @@
 .osc-inv-head .section-title { flex: 0 0 auto; margin: 0; padding-bottom: 0; border-bottom: none; }
 
 // Encumbrance-as-rule: the 2px header underline becomes the load bar. The tier
-// spectrum spans the whole track, cut into hard-edged segments at the system's OWN
-// thresholds (--enc-stops, built from `encumbrance.steps` — see encBarStops), so the
-// colour flips exactly where the character changes tier. We reveal it left→right up
-// to --enc-pct and cover the remainder with the dim section-rule. Still 2px.
+// spectrum spans the whole track, each tier's colour blending into the next over a
+// narrow fade centred on the system's OWN thresholds (--enc-stops, built from
+// `encumbrance.steps` — see encBarStops), so the colour changes right where the
+// character changes tier while still reading as a smooth gradient. We reveal it
+// left→right up to --enc-pct and cover the remainder with the dim section-rule. 2px.
 .osc-inv-head.enc-rule {
   border-bottom: none;
   background-image:
@@ -39,15 +40,20 @@
 // MoveTooltip (same rows as the header MOVE hover) ---
 .osc-enc-readout {
   position: relative; // popover anchor
-  display: inline-flex; align-items: baseline; gap: var(--spacer-2);
+  display: inline-flex; align-items: baseline;
   font-family: var(--mono); font-size: var(--fs-xs, 12px); letter-spacing: 0;
   color: var(--text-mute); white-space: nowrap;
   cursor: default;
 }
-.osc-enc-readout .sep { color: var(--text-faint); }
 // the load (value/max) stays muted even though the tier class tints the element;
 // only the rates carry the tier colour (--enc-c, set by .enc-t*).
 .osc-enc-readout .load { color: var(--text-mute); }
+// rate cluster: tight gap around the two internal middots so the three scores read
+// as one group. Separated from the load by whitespace (margin), not a middot —
+// suppressed when there's no load so the rates don't get a leading indent.
+.osc-enc-readout .rates { display: inline-flex; align-items: baseline; gap: var(--spacer-1); }
+.osc-enc-readout .rates:not(:first-child) { margin-left: var(--spacer-4); }
+.osc-enc-readout .sep { color: var(--text-faint); }
 .osc-enc-readout .rate { color: var(--enc-c, var(--text-mute)); }
 .osc-enc-readout:hover .osc-move-pop,
 .osc-enc-readout:focus-within .osc-move-pop { opacity: 1; visibility: visible; }

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -17,33 +17,40 @@
 }
 .osc-inv-head .section-title { flex: 0 0 auto; margin: 0; padding-bottom: 0; border-bottom: none; }
 
-// Encumbrance-as-rule: the 2px header underline becomes the load bar. A fixed
-// green→yellow→red spectrum spans the whole track; we reveal it left→right up to
-// --enc-pct (so the fill's leading edge colour reads the load) and cover the
-// remainder with the dim section-rule. Same 2px thickness as the plain rule.
+// Encumbrance-as-rule: the 2px header underline becomes the load bar. The tier
+// spectrum spans the whole track, cut into hard-edged segments at the system's OWN
+// thresholds (--enc-stops, built from `encumbrance.steps` — see encBarStops), so the
+// colour flips exactly where the character changes tier. We reveal it left→right up
+// to --enc-pct and cover the remainder with the dim section-rule. Still 2px.
 .osc-inv-head.enc-rule {
   border-bottom: none;
   background-image:
     // top: transparent up to --enc-pct (reveals the spectrum), dim rule beyond
     linear-gradient(to right, transparent var(--enc-pct, 0%), var(--section-rule) var(--enc-pct, 0%)),
-    // bottom: the full load spectrum across the entire track
-    linear-gradient(to right, var(--forest), var(--mustard), var(--crimson));
+    // bottom: the tier spectrum across the entire track
+    linear-gradient(to right, var(--enc-stops, var(--enc-0)));
   background-repeat: no-repeat;
   background-position: left bottom;
   background-size: 100% 2px;
 }
 
-// --- encumbrance readout (inline in the header; band colour carries the signal, no bar) ---
+// --- encumbrance readout (inline in the header): the three movement rates, tinted
+// by tier; hover/focus reveals the tier name + load in the shared popover ---
 .osc-enc-readout {
+  position: relative; // popover anchor
   display: inline-flex; align-items: baseline; gap: var(--spacer-2);
   font-family: var(--mono); font-size: var(--fs-xs, 12px); letter-spacing: 0;
   color: var(--text-mute); white-space: nowrap;
+  cursor: default;
 }
 .osc-enc-readout .sep { color: var(--text-faint); }
-// load (value/max) stays muted; status + move carry the band colour
-.osc-enc-readout.ok     .status, .osc-enc-readout.ok     .move { color: var(--forest); }
-.osc-enc-readout.warn   .status, .osc-enc-readout.warn   .move { color: var(--mustard); }
-.osc-enc-readout.danger .status, .osc-enc-readout.danger .move { color: var(--crimson); }
+// the rates carry the tier colour (--enc-c, set by .enc-t*); the units stay muted
+.osc-enc-readout .rate { color: var(--enc-c, var(--text-mute)); }
+.osc-enc-readout .u { color: var(--text-mute); }
+.osc-enc-readout:hover .osc-move-pop,
+.osc-enc-readout:focus-within .osc-move-pop { opacity: 1; visibility: visible; }
+// pop hangs off the right edge here — the readout sits at the header's right
+.osc-enc-readout .osc-move-pop { right: 0; left: auto; }
 
 // ---------------------------------------------------------------------------
 // List rows — 8-column grid

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -34,8 +34,9 @@
   background-size: 100% 2px;
 }
 
-// --- encumbrance readout (inline in the header): the three movement rates, tinted
-// by tier; hover/focus reveals the tier name + load in the shared popover ---
+// --- encumbrance readout (inline above the load bar): the numeric load (muted) ·
+// the three movement rates (tinted by tier). Hover/focus reveals the shared
+// MoveTooltip (same rows as the header MOVE hover) ---
 .osc-enc-readout {
   position: relative; // popover anchor
   display: inline-flex; align-items: baseline; gap: var(--spacer-2);
@@ -44,9 +45,10 @@
   cursor: default;
 }
 .osc-enc-readout .sep { color: var(--text-faint); }
-// the rates carry the tier colour (--enc-c, set by .enc-t*); the units stay muted
+// the load (value/max) stays muted even though the tier class tints the element;
+// only the rates carry the tier colour (--enc-c, set by .enc-t*).
+.osc-enc-readout .load { color: var(--text-mute); }
 .osc-enc-readout .rate { color: var(--enc-c, var(--text-mute)); }
-.osc-enc-readout .u { color: var(--text-mute); }
 .osc-enc-readout:hover .osc-move-pop,
 .osc-enc-readout:focus-within .osc-move-pop { opacity: 1; visibility: visible; }
 // pop hangs off the right edge here — the readout sits at the header's right
@@ -198,6 +200,8 @@
   color: var(--text-mute, #8a8270);
   cursor: pointer; padding: 0 4px; font-size: var(--fs-sm, 13px); line-height: 1;
   transition: color 0.12s;
+  // the chevron rotates (a stacking context); pin it low so tooltips clear it.
+  position: relative; z-index: var(--z-raised);
 
   svg, i { transition: transform 0.18s; display: block; }
   &.collapsed svg, &.collapsed i { transform: rotate(-90deg); }
@@ -340,6 +344,9 @@
 .osc-whead .osc-wcaret {
   font-size: var(--fs-md, 15px); color: var(--text-mute, #8a8270);
   transition: transform 0.18s, color 0.15s;
+  // the rotate() below makes this a stacking context — pin it to the raised layer
+  // so it stays below hover tooltips instead of poking through them.
+  position: relative; z-index: var(--z-raised);
 }
 .osc-whead.open .osc-wcaret { transform: rotate(90deg); }
 .osc-inv .osc-whead:hover:not(:disabled) .osc-wcaret { color: var(--text, #e5dec8); }
@@ -437,7 +444,7 @@
 // no JS height measuring, no see-through gap between two separately-sticky bands.
 // Scroll container is .osc-sheet-body.
 .osc-inv-stickyhead {
-  position: sticky; top: 0; z-index: 7;
+  position: sticky; top: 0; z-index: var(--z-sticky);
   background: var(--bg);
 }
 .osc-inv-stickyhead .osc-inv-sec--equipped { margin: 0 0 var(--spacer-3); }

--- a/src/OscSheet/styles/styles.scss
+++ b/src/OscSheet/styles/styles.scss
@@ -195,6 +195,21 @@
   }
 }
 
+// --- z-index scale --------------------------------------------------------
+// A small, ordered set of stacking layers so components reference an intent
+// (`--z-tooltip`) instead of a magic integer, and so a hover popover can never
+// again be pierced by a caret sitting in a taller sibling stacking context.
+// Repo-local (this sheet only) — the shared @osc/vellum package stays untouched.
+// Values preserve the existing sticky-head number (7); everything popover-and-up
+// is new headroom above it.
+.osc-sheet {
+  --z-base: 0; // normal flow
+  --z-raised: 1; // small inline lifts (carets, chevrons)
+  --z-sticky: 7; // sticky section heads inside the scroll body
+  --z-popover: 12; // menus / dropdowns anchored to a control
+  --z-tooltip: 30; // hover popovers — above sticky heads and carets
+}
+
 // --- encumbrance tier colours ---------------------------------------------
 // One tier → one colour, everywhere: the inventory rates line, the tier string in
 // both hover popovers, and the load bar's gradient stops. Vellum tokens only —

--- a/src/OscSheet/styles/styles.scss
+++ b/src/OscSheet/styles/styles.scss
@@ -194,3 +194,26 @@
     pointer-events: none;
   }
 }
+
+// --- encumbrance tier colours ---------------------------------------------
+// One tier → one colour, everywhere: the inventory rates line, the tier string in
+// both hover popovers, and the load bar's gradient stops. Vellum tokens only —
+// tier 2 is the missing rung between mustard and crimson, so it's mixed from the
+// two rather than inventing a new brand colour.
+// On .osc-sheet, not :root — that's where the vellum palette actually lands once
+// scope-vellum.mjs has rewritten it, so var(--forest) resolves here (not at :root).
+.osc-sheet {
+  --enc-0: var(--forest);
+  --enc-1: var(--mustard);
+  --enc-2: color-mix(in oklab, var(--mustard) 45%, var(--crimson));
+  --enc-3: var(--crimson);
+  --enc-4: var(--crimson-dim);
+}
+
+@for $i from 0 through 4 {
+  .enc-t#{$i} {
+    --enc-c: var(--enc-#{$i});
+
+    color: var(--enc-c);
+  }
+}

--- a/src/OscSheet/styles/vellum/_scales.scss
+++ b/src/OscSheet/styles/vellum/_scales.scss
@@ -49,3 +49,15 @@ $spacers: (
   10: 40px,
   12: 48px,
 );
+
+// Foundry sheet responsive tiers — min-width edges on the `app` container
+// (container-name: app on .osc-sheet-app). Mobile-first: each tier applies at
+// its width AND UP. Container queries can't read var(), so this Sass map is the
+// source of truth — no --bp-* custom properties are emitted. Named foundry-* to
+// leave room for a $web-breakpoints (viewport @media) scale later.
+$foundry-breakpoints: (
+  "xs": 0,       // base
+  // "sm" reserved — deliberate gap, unused for now
+  "md": 480px,   // default sheet width (rail ⇄ tab-bar edge)
+  "lg": 740px,   // wide
+);

--- a/src/OscSheet/styles/vellum/utilities.scss
+++ b/src/OscSheet/styles/vellum/utilities.scss
@@ -155,3 +155,15 @@ $space-family:
   .u-border#{sfx($k)} { border: 1px solid var(--#{$tok}); }
 }
 .u-border-none { border: none; }
+
+/* ─── Foundry responsive display (min-width on the `app` container) ──────── */
+/* u-foundry-{xs|md|lg}-display-{none|flex|block|grid|inline-flex}: applies at
+   the tier width AND UP. Tiers from scales.$foundry-breakpoints (source of truth). */
+$foundry-display-values: none flex block grid inline-flex;
+@each $tier, $bp in scales.$foundry-breakpoints {
+  @container app (min-width: #{$bp}) {
+    @each $val in $foundry-display-values {
+      .u-foundry-#{$tier}-display-#{$val} { display: #{$val}; }
+    }
+  }
+}


### PR DESCRIPTION
- Encumbrance readout shows all three OSE movement rates, tinted by encumbrance tier
- Movement hover popover scoped to the rates only, not the load number
- Dotted-underline affordance on the movement hover triggers (readout + header MOVE tile)
- Rate order: encounter / explore / travel
- `ft` units everywhere (dropped the `′` tick)
- Header MOVE tile shows base movement speed
- Readout: tighter middot spacing, single line (no wrap), more margin under the bar
- Removed dead `MoveRatesFull` component + reference rail
- Restored two `stylelint-disable` exemptions displaced by a reflow
- Added foundry-only responsive display utilities: `u-foundry-{xs|md|lg}-display-*` (min-width `@container` queries) + `$foundry-breakpoints` map + vellum-styling skill doc
- Follow-ups filed: OSC-114 (mode-aware section totals), OSC-115 (tooltip consolidation)
