### PR TITLE
fix(layout): cap the sticky character rail so it can't scroll off

### DIFF
--- a/src/OscSheet/styles/shell.scss
+++ b/src/OscSheet/styles/shell.scss
@@ -23,10 +23,7 @@
   min-width: 0;
   overflow-y: auto;
   overflow-x: hidden;
-  // `size` (not `inline-size`) so descendants can read the scrollport's block size
-  // via `cqb` — the sticky rail caps its height to it (see .osc-left below). Height is
-  // set by the flex chain, so block-size containment adds no layout risk.
-  container-type: size;
+  container-type: inline-size;
   container-name: sheet;
   scrollbar-width: thin;
   scrollbar-color: var(--surface-3, #3a3429) transparent;
@@ -180,26 +177,39 @@
 @container sheet (min-width: 600px) { .osc-pad { padding: 18px var(--spacer-5); } }
 
 @container sheet (min-width: 700px) {
-  .osc-pad { padding: var(--spacer-6) var(--spacer-6); }
+  // Large view = locked app shell: only the active tab's content (#osc-tabpanel)
+  // scrolls; the body has nothing to overflow, so it doesn't scroll, the rail (a
+  // fixed grid cell) stays put, and the tab bar stays pinned above the content.
+  // NOTE: .osc-sheet-body can't be styled here — it DEFINES the `sheet` container and
+  // a container query can't target its own container. Size its descendants instead:
+  // .osc-pad fills the (definite, flex-derived) body height so the grid below can too.
+  .osc-pad {
+    padding: var(--spacer-6) var(--spacer-6);
+    height: 100%;
+  }
   .osc-twopane {
     display: grid;
     // Dynamic rail: shrinks/grows with the window between bounds; the portrait
     // (capped at 150px) stays put. Narrower than the old fixed 264px.
     grid-template-columns: clamp(190px, 24%, 224px) 1fr;
+    grid-template-rows: 1fr; // definite row = pane height, so the right pane can scroll
     gap: var(--spacer-6);
     align-items: start;
+    height: 100%;
+    min-height: 0;
   }
+  // rail: a fixed, locked cell — natural height, never its own scrollbar.
   .osc-twopane > .osc-left {
-    position: sticky;
-    top: 0;
-    // Cap to the scrollport so a rail taller than the pane can't un-pin and slide
-    // off the top at the scroll extremes (a sticky box taller than its scrollport
-    // travels in the last railH−paneH px). Overflow scrolls the rail's own content.
-    max-height: calc(100cqb - 2 * var(--spacer-6));
-    overflow-y: auto;
     border-bottom: none;
     padding-bottom: 0;
     margin-bottom: 0;
+  }
+  // the whole right panel (tabs + content) is the ONLY scroller; the rail stays put.
+  .osc-twopane > .osc-right {
+    align-self: stretch;
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden; // never a horizontal scrollbar — over-wide content clips, not scrolls
   }
   .osc-rail-extra { display: block; margin-top: var(--spacer-3); }
   .actions-only { display: none; }

--- a/src/OscSheet/styles/shell.scss
+++ b/src/OscSheet/styles/shell.scss
@@ -23,7 +23,10 @@
   min-width: 0;
   overflow-y: auto;
   overflow-x: hidden;
-  container-type: inline-size;
+  // `size` (not `inline-size`) so descendants can read the scrollport's block size
+  // via `cqb` — the sticky rail caps its height to it (see .osc-left below). Height is
+  // set by the flex chain, so block-size containment adds no layout risk.
+  container-type: size;
   container-name: sheet;
   scrollbar-width: thin;
   scrollbar-color: var(--surface-3, #3a3429) transparent;
@@ -189,6 +192,11 @@
   .osc-twopane > .osc-left {
     position: sticky;
     top: 0;
+    // Cap to the scrollport so a rail taller than the pane can't un-pin and slide
+    // off the top at the scroll extremes (a sticky box taller than its scrollport
+    // travels in the last railH−paneH px). Overflow scrolls the rail's own content.
+    max-height: calc(100cqb - 2 * var(--spacer-6));
+    overflow-y: auto;
     border-bottom: none;
     padding-bottom: 0;
     margin-bottom: 0;


### PR DESCRIPTION
## Problem

In the wide (two-pane) layout the left character rail is `position: sticky; top: 0` so it stays pinned while the right pane scrolls. But when the rail is **taller than the scroll pane** — a short window plus a long tab such as Inventory — it fails to stay pinned: a sticky box taller than its scrollport un-pins in the final `railH − paneH` px of scroll and slides up with the content. The result is the portrait and name scrolling off the top of the sheet at the scroll extremes (and back on when you scroll up) — the reported "wiggle."

Measured on the wide sheet with a long inventory (rail 566px, pane 391px): the rail top travelled ~220px (pinned at 108, sliding to −90 at the bottom). Height-dependent, which is why it's intermittent — at tall windows the rail fits the pane and stays pinned.

## Fix

Cap the rail to the scrollport height and let it scroll its own overflow, so it never exceeds the pane and can't un-pin:

- `.osc-twopane > .osc-left`: add `max-height: calc(100cqb - 2 * var(--spacer-6))` and `overflow-y: auto` (keeps `position: sticky; top: 0`).
- `.osc-sheet-body`: `container-type: inline-size` → `size`, so `cqb` (the scrollport's block size) resolves. Its height is set by the flex chain, so block-size containment adds no layout risk.

## Verification

- **`container-type: size` regression check — pass.** With the change live, the two-pane grid still engages (`display: grid`, columns unchanged) and `.osc-rail-extra` (Saves/Exploration) still shows, so the existing `@container sheet (min-width: …)` inline-size queries keep firing. The body still scrolls (scrollHeight 1072 > clientHeight 391) — containment did not collapse it.
- **Travel gone.** Rail `getBoundingClientRect().top` now stays pinned across the full scroll range (constant at the pinned position from scroll offset ~24px onward) instead of sliding to −90. Portrait/name no longer scroll off the top at the bottom extreme.
- **Rail self-scrolls.** When the rail content exceeds the cap it becomes independently scrollable (scrollHeight 565 > clientHeight 332), so nothing is unreachable.
- **Gate:** `pnpm lint` clean · `pnpm test` 155/155 · `pnpm build` OK.

### Note for reviewers

`overflow-y: auto` makes the rail a scroll container, so its computed `overflow-x` becomes non-visible too — any hover popover that escapes the rail's box horizontally will be clipped. Worth confirming against rail-tile tooltips / the MOVE-tile popover.
