### PR TITLE
feat(inventory): tick-off pips for stacked items (OSC-98)

### DIFF
--- a/src/OscSheet/app/SheetShell.tsx
+++ b/src/OscSheet/app/SheetShell.tsx
@@ -173,6 +173,11 @@ export default function SheetShell() {
       (it?.system as { quantity?: { value: number } })?.quantity?.value ?? 0;
     if (it && cur > 0) writeItem(it, { "system.quantity.value": cur - 1 });
   };
+  // Set a stackable's quantity directly (pip tick / Use-1) — optimistic, floored at 0.
+  const onSetQty = (id: string, value: number) => {
+    const it = resolveItem(id);
+    if (it) writeItem(it, { "system.quantity.value": Math.max(0, value) }, id);
+  };
 
   // Manual order is stored in our own flag (not Foundry's `sort`, which the core
   // sheet and other modules also write).
@@ -367,6 +372,7 @@ export default function SheetShell() {
             onOpen={onOpenItem}
             onDelete={onDeleteItem}
             onConsume={onConsume}
+            onSetQty={onSetQty}
             onReorder={onReorder}
             onReorderEquipped={onReorderEquipped}
             onNest={onNest}

--- a/src/OscSheet/app/SheetShell.tsx
+++ b/src/OscSheet/app/SheetShell.tsx
@@ -23,6 +23,7 @@ import {
 } from "@features/inventory/createItem";
 import { flagPath, FLAGS, readFlag } from "@domain/flags";
 import { collectTree, classifyRoute } from "@features/inventory/sendItem";
+import { consumeToast } from "@features/inventory/consumeToast";
 import {
   applySend,
   emitSendItem,
@@ -166,17 +167,29 @@ export default function SheetShell() {
     if (!it) return;
     writeItem(it, { "system.quantity.value": value }, id);
   };
-  // Consume one: decrement the item's quantity (floored at 0).
+  // Set a stackable's quantity directly (pip tick / Use link) — optimistic, floored
+  // at 0. A decrease is a "use one" and fires a confirming toast; a no-op is skipped.
+  const onSetQty = (id: string, value: number) => {
+    const it = resolveItem(id);
+    if (!it) return;
+    const cur =
+      (it.system as { quantity?: { value: number } })?.quantity?.value ?? 0;
+    const next = Math.max(0, value);
+    if (next === cur) return;
+    writeItem(it, { "system.quantity.value": next }, id);
+    const t = consumeToast(it.name ?? "item", cur, next);
+    if (t)
+      toast({
+        ...t,
+        icon: <i className="fa-solid fa-circle-minus" aria-hidden="true" />,
+      });
+  };
+  // Consume one (right-click): same "use one" path as the pips/Use link.
   const onConsume = (id: string) => {
     const it = resolveItem(id);
     const cur =
       (it?.system as { quantity?: { value: number } })?.quantity?.value ?? 0;
-    if (it && cur > 0) writeItem(it, { "system.quantity.value": cur - 1 });
-  };
-  // Set a stackable's quantity directly (pip tick / Use-1) — optimistic, floored at 0.
-  const onSetQty = (id: string, value: number) => {
-    const it = resolveItem(id);
-    if (it) writeItem(it, { "system.quantity.value": Math.max(0, value) }, id);
+    if (it && cur > 0) onSetQty(id, cur - 1);
   };
 
   // Manual order is stored in our own flag (not Foundry's `sort`, which the core

--- a/src/OscSheet/components/ui/Button.tsx
+++ b/src/OscSheet/components/ui/Button.tsx
@@ -6,7 +6,7 @@ type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
   /** Color tone for the outline variant (no effect without variant="outline").
    *  Names match the Vellum color vocabulary. Default is the plain outline accent. */
   tone?: "accent" | "brass" | "danger" | "success" | "warn";
-  size?: "sm";
+  size?: "sm" | "xs";
 };
 
 /** @category Controls */

--- a/src/OscSheet/components/ui/Pips.stories.tsx
+++ b/src/OscSheet/components/ui/Pips.stories.tsx
@@ -11,6 +11,15 @@ export const CastDots = () => (
   </div>
 );
 
+// Square dots (size="sm") — squared instead of the disc (e.g. inventory uses).
+export const SquareDots = () => (
+  <div className="u-stack u-gap-3">
+    <Pips total={5} filled={5} size="sm" square role="img" aria-label="5 of 5" />
+    <Pips total={5} filled={3} size="sm" square role="img" aria-label="3 of 5" />
+    <Pips total={5} filled={0} size="sm" square role="img" aria-label="0 of 5" />
+  </div>
+);
+
 // Slot pips (hollow) — the filled dots carry a diamond glyph.
 export const SlotPips = () => (
   <div className="u-stack u-gap-3">

--- a/src/OscSheet/components/ui/Pips.tsx
+++ b/src/OscSheet/components/ui/Pips.tsx
@@ -1,11 +1,12 @@
-import type { HTMLAttributes, ReactNode } from "react";
+import type { HTMLAttributes, ReactNode, Ref } from "react";
 import { cx } from "./cx";
 
 /** Dot-meter: `total` dots, the first `filled` of them marked `.filled`. Fully
  *  vellum-styled (see `.pips`/`.pip` in components.css) — no per-call-site CSS.
  *  `size="sm"` shrinks the dots (cast rows); `hollow` switches to the bordered
  *  slot-pip ring that can hold a `glyph` inside its filled dots (level heads).
- *  Spread aria/HTML attrs onto the wrapper (role, aria-label, aria-hidden). */
+ *  Spread aria/HTML attrs onto the wrapper (role, aria-label, aria-hidden).
+ *  Pass `onPipClick` to make each dot a button (e.g. inventory tick-off). */
 export function Pips({
   total,
   filled,
@@ -13,6 +14,10 @@ export function Pips({
   hollow,
   className,
   glyph,
+  ref,
+  onPipClick,
+  pipLabel,
+  pipDisabled,
   ...rest
 }: {
   total: number;
@@ -24,14 +29,45 @@ export function Pips({
   className?: string;
   /** rendered inside FILLED dots only (hollow variant) */
   glyph?: ReactNode;
+  /** wrapper ref (e.g. to measure overflow) */
+  ref?: Ref<HTMLSpanElement>;
+  /** when set, each dot renders as a button that calls this with its index */
+  onPipClick?: (index: number) => void;
+  /** per-dot aria-label for the interactive variant */
+  pipLabel?: (index: number) => string;
+  /** disables every interactive dot */
+  pipDisabled?: boolean;
 } & HTMLAttributes<HTMLSpanElement>) {
   return (
-    <span className={cx("pips", size, hollow && "hollow", className)} {...rest}>
-      {Array.from({ length: total }).map((_, i) => (
-        <span key={i} className={cx("pip", i < filled && "filled")} aria-hidden="true">
-          {i < filled ? glyph : null}
-        </span>
-      ))}
+    <span
+      ref={ref}
+      className={cx("pips", size, hollow && "hollow", className)}
+      {...rest}
+    >
+      {Array.from({ length: total }).map((_, i) => {
+        const isFilled = i < filled;
+        const content = isFilled ? glyph : null;
+        return onPipClick ? (
+          <button
+            key={i}
+            type="button"
+            className={cx("pip", isFilled && "filled")}
+            aria-label={pipLabel?.(i)}
+            disabled={pipDisabled}
+            onClick={() => onPipClick(i)}
+          >
+            {content}
+          </button>
+        ) : (
+          <span
+            key={i}
+            className={cx("pip", isFilled && "filled")}
+            aria-hidden="true"
+          >
+            {content}
+          </span>
+        );
+      })}
     </span>
   );
 }

--- a/src/OscSheet/components/ui/Pips.tsx
+++ b/src/OscSheet/components/ui/Pips.tsx
@@ -3,27 +3,27 @@ import { cx } from "./cx";
 
 /** Dot-meter: `total` dots, the first `filled` of them marked `.filled`. Fully
  *  vellum-styled (see `.pips`/`.pip` in components.css) — no per-call-site CSS.
- *  `size="sm"` shrinks the dots (cast rows); `hollow` switches to the bordered
- *  slot-pip ring that can hold a `glyph` inside its filled dots (level heads).
- *  Spread aria/HTML attrs onto the wrapper (role, aria-label, aria-hidden).
- *  Pass `onPipClick` to make each dot a button (e.g. inventory tick-off). */
+ *  `size="sm"` shrinks the dots (cast rows); `square` swaps the disc for a small
+ *  square (inventory uses); `hollow` switches to the bordered slot-pip ring that
+ *  can hold a `glyph` inside its filled dots (level heads). Spread aria/HTML attrs
+ *  onto the wrapper (role, aria-label, aria-hidden). Dots are display-only. */
 export function Pips({
   total,
   filled,
   size,
+  square,
   hollow,
   className,
   glyph,
   ref,
-  onPipClick,
-  pipLabel,
-  pipDisabled,
   ...rest
 }: {
   total: number;
   filled: number;
   /** dot size — default (md, 16px) or "sm" (9px) */
   size?: "sm";
+  /** square dots instead of the default circle */
+  square?: boolean;
   /** bordered ring style (transparent empty) that holds `glyph`; default = solid disc */
   hollow?: boolean;
   className?: string;
@@ -31,43 +31,22 @@ export function Pips({
   glyph?: ReactNode;
   /** wrapper ref (e.g. to measure overflow) */
   ref?: Ref<HTMLSpanElement>;
-  /** when set, each dot renders as a button that calls this with its index */
-  onPipClick?: (index: number) => void;
-  /** per-dot aria-label for the interactive variant */
-  pipLabel?: (index: number) => string;
-  /** disables every interactive dot */
-  pipDisabled?: boolean;
 } & HTMLAttributes<HTMLSpanElement>) {
   return (
     <span
       ref={ref}
-      className={cx("pips", size, hollow && "hollow", className)}
+      className={cx("pips", size, square && "square", hollow && "hollow", className)}
       {...rest}
     >
-      {Array.from({ length: total }).map((_, i) => {
-        const isFilled = i < filled;
-        const content = isFilled ? glyph : null;
-        return onPipClick ? (
-          <button
-            key={i}
-            type="button"
-            className={cx("pip", isFilled && "filled")}
-            aria-label={pipLabel?.(i)}
-            disabled={pipDisabled}
-            onClick={() => onPipClick(i)}
-          >
-            {content}
-          </button>
-        ) : (
-          <span
-            key={i}
-            className={cx("pip", isFilled && "filled")}
-            aria-hidden="true"
-          >
-            {content}
-          </span>
-        );
-      })}
+      {Array.from({ length: total }).map((_, i) => (
+        <span
+          key={i}
+          className={cx("pip", i < filled && "filled")}
+          aria-hidden="true"
+        >
+          {i < filled ? glyph : null}
+        </span>
+      ))}
     </span>
   );
 }

--- a/src/OscSheet/features/inventory/InventoryView.stories.tsx
+++ b/src/OscSheet/features/inventory/InventoryView.stories.tsx
@@ -65,6 +65,7 @@ export const Default = () => (
       onOpen={log("open")}
       onDelete={log("delete")}
       onConsume={log("consume")}
+      onSetQty={log("setQty")}
       onReorder={log("reorder")}
       onReorderEquipped={log("reorderEquipped")}
       onNest={log("nest")}

--- a/src/OscSheet/features/inventory/consumeToast.test.ts
+++ b/src/OscSheet/features/inventory/consumeToast.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { consumeToast } from "@features/inventory/consumeToast";
+
+describe("consumeToast", () => {
+  it("a decrement (use one) yields a success toast naming the item + remaining", () => {
+    expect(consumeToast("Arrows", 18, 17)).toEqual({
+      intent: "success",
+      title: "Used 1 Arrows",
+      message: "17 left",
+    });
+  });
+
+  it("reports the amount used when more than one drops off", () => {
+    expect(consumeToast("Rations", 5, 2)).toEqual({
+      intent: "success",
+      title: "Used 3 Rations",
+      message: "2 left",
+    });
+  });
+
+  it("no toast when the quantity did not drop (no-op at 0)", () => {
+    expect(consumeToast("Arrows", 0, 0)).toBeNull();
+  });
+
+  it("no toast on an increase", () => {
+    expect(consumeToast("Arrows", 3, 5)).toBeNull();
+  });
+});

--- a/src/OscSheet/features/inventory/consumeToast.ts
+++ b/src/OscSheet/features/inventory/consumeToast.ts
@@ -1,0 +1,18 @@
+import type { ToastInput } from "@ui/toastContext";
+
+/** Toast text for a "use one" / consume decrement (pip click, Use link, or the
+ *  right-click Consume). Returns null when the quantity didn't actually drop — a
+ *  no-op at 0 or an increase — so callers can `if (t) toast({ ...t, icon })`. */
+export function consumeToast(
+  name: string,
+  from: number,
+  to: number,
+): Pick<ToastInput, "intent" | "title" | "message"> | null {
+  if (to >= from) return null;
+  const used = from - to;
+  return {
+    intent: "success",
+    title: `Used ${used} ${name}`,
+    message: `${to} left`,
+  };
+}

--- a/src/OscSheet/features/inventory/dragNest.test.tsx
+++ b/src/OscSheet/features/inventory/dragNest.test.tsx
@@ -61,9 +61,11 @@ function Harness({ collapsed }: { collapsed: boolean }) {
         depth={0}
         dnd={dnd}
         itemDragData={drag}
+        canEdit
         onEquip={noop}
         onOpen={noop}
         onContext={noop}
+        onSetQty={noop}
       />
       <ContainerRow
         item={sack}
@@ -73,10 +75,12 @@ function Harness({ collapsed }: { collapsed: boolean }) {
         collapsed={collapsed}
         dnd={dnd}
         itemDragData={drag}
+        canEdit
         onToggle={noop}
         onEquip={noop}
         onOpen={noop}
         onContext={noop}
+        onSetQty={noop}
       />
     </div>
   );

--- a/src/OscSheet/features/inventory/groups.ts
+++ b/src/OscSheet/features/inventory/groups.ts
@@ -10,8 +10,6 @@ export const groupContainerId = (key: string) =>
   key === ROOT ? null : key.slice(2);
 
 export const weightLabel = (w: number) => (w > 0 ? `${w} cn` : "—");
-// Bare weight for the inventory row WT cell — the "cn" unit lives in the column header.
-export const weightValue = (w: number) => (w > 0 ? `${w}` : "—");
 
 // "N items · X cn" — count + total weight, used by both section headers.
 export function flattenItems(list: InventoryItemVM[]): InventoryItemVM[] {

--- a/src/OscSheet/features/inventory/groups.ts
+++ b/src/OscSheet/features/inventory/groups.ts
@@ -10,6 +10,8 @@ export const groupContainerId = (key: string) =>
   key === ROOT ? null : key.slice(2);
 
 export const weightLabel = (w: number) => (w > 0 ? `${w} cn` : "—");
+// Bare weight for the inventory row WT cell — the "cn" unit lives in the column header.
+export const weightValue = (w: number) => (w > 0 ? `${w}` : "—");
 
 // "N items · X cn" — count + total weight, used by both section headers.
 export function flattenItems(list: InventoryItemVM[]): InventoryItemVM[] {

--- a/src/OscSheet/features/inventory/index.tsx
+++ b/src/OscSheet/features/inventory/index.tsx
@@ -72,6 +72,7 @@ export function InventoryView({
   onOpen,
   onDelete,
   onConsume,
+  onSetQty,
   onReorder,
   onReorderEquipped,
   onNest,
@@ -374,10 +375,12 @@ export function InventoryView({
                 collapsed={!expanded.has(id)}
                 dnd={dnd}
                 itemDragData={itemDragData}
+                canEdit={canEdit}
                 onToggle={toggleCollapse}
                 onEquip={onEquip}
                 onOpen={onOpen}
                 onContext={openMenu}
+                onSetQty={onSetQty}
               />
             ) : (
               <SortableRow
@@ -388,9 +391,11 @@ export function InventoryView({
                 depth={0}
                 dnd={dnd}
                 itemDragData={itemDragData}
+                canEdit={canEdit}
                 onEquip={onEquip}
                 onOpen={onOpen}
                 onContext={openMenu}
+                onSetQty={onSetQty}
               />
             );
           })}

--- a/src/OscSheet/features/inventory/inventory.test.ts
+++ b/src/OscSheet/features/inventory/inventory.test.ts
@@ -82,6 +82,24 @@ describe("selectInventory", () => {
     expect(vm2.items[0].tags.map((t) => t.label)).toEqual(["Precious"]);
   });
 
+  it("keeps quantity on a stackable down to its last unit (max-driven)", () => {
+    // 1 of 24 arrows: still stackable (max>1), so the qty control persists to the end.
+    const last = selectInventory([
+      mk("weapon", "Arrows", { quantity: { value: 1, max: 24 }, weight: 5 }),
+    ]).items[0];
+    expect(last.quantity).toEqual({ value: 1, max: 24 });
+    // A true singleton (sword, qty 1 / max 0) still carries no quantity.
+    const sword = selectInventory([
+      mk("weapon", "Sword", { quantity: { value: 1, max: 0 }, weight: 30 }),
+    ]).items[0];
+    expect(sword.quantity).toBeNull();
+    // A plain multi with no max still shows (max falls back to value).
+    const spikes = selectInventory([
+      mk("item", "Iron spikes", { quantity: { value: 12 }, weight: 1 }),
+    ]).items[0];
+    expect(spikes.quantity).toEqual({ value: 12, max: 12 });
+  });
+
   it("legacy groups still present for grid view", () => {
     expect(vm.groups.map((g) => g.key)).toContain("weapons");
   });

--- a/src/OscSheet/features/inventory/inventory.ts
+++ b/src/OscSheet/features/inventory/inventory.ts
@@ -172,7 +172,10 @@ function toVM(
 ): InventoryItemVM {
   const s = item.system;
   const q = s.quantity;
-  const hasQty = !!q && (q.value > 1 || (q.max ?? 0) > 1);
+  // Stackable (ammo/consumables carry a real max) keeps the qty control down to the
+  // last unit; a plain multi still shows. True singletons (max 0/1) stay null.
+  const stackable = !!q && (q.max ?? 0) > 1;
+  const hasQty = !!q && (q.value > 1 || stackable);
   const cat = categoryFor(item.type as string);
   const dmg =
     item.type === "weapon" ? ((s as { damage?: string }).damage ?? "") : "";

--- a/src/OscSheet/features/inventory/rows/ContainerRow.tsx
+++ b/src/OscSheet/features/inventory/rows/ContainerRow.tsx
@@ -3,7 +3,7 @@ import type { InventoryItemVM } from "@domain/vm-types";
 import { ItemImage } from "@features/inventory/ItemImage";
 import { RowEquip } from "@features/inventory/EquippedTray";
 import { NameCell, SortableRow } from "@features/inventory/rows/SortableRow";
-import { weightValue, gkey, ROOT, EQUIPPED } from "@features/inventory/groups";
+import { weightLabel, gkey, ROOT, EQUIPPED } from "@features/inventory/groups";
 import type { Dnd, ItemDragData, OnContext } from "@features/inventory/types";
 import { Tag } from "@ui/Tag";
 import { cx } from "@ui/cx";
@@ -85,7 +85,7 @@ export function ContainerRow({
           trailing={caret}
         />
         <span className="osc-inv-rowcat">{item.category}</span>
-        <span className="osc-inv-wt">{weightValue(item.weight)}</span>
+        <span className="osc-inv-wt">{weightLabel(item.weight)}</span>
         <RowEquip item={item} onEquip={onEquip} />
       </div>
 

--- a/src/OscSheet/features/inventory/rows/ContainerRow.tsx
+++ b/src/OscSheet/features/inventory/rows/ContainerRow.tsx
@@ -16,10 +16,12 @@ export function ContainerRow({
   collapsed,
   dnd,
   itemDragData,
+  canEdit,
   onToggle,
   onEquip,
   onOpen,
   onContext,
+  onSetQty,
 }: {
   item: InventoryItemVM;
   index: number;
@@ -28,10 +30,12 @@ export function ContainerRow({
   collapsed: boolean;
   dnd: Dnd;
   itemDragData: ItemDragData;
+  canEdit: boolean;
   onToggle: (id: string) => void;
   onEquip: (id: string) => void;
   onOpen: (id: string) => void;
   onContext: OnContext;
+  onSetQty: (id: string, value: number) => void;
 }) {
   const group = gkey(item.id);
   const count = item.children.length;
@@ -105,9 +109,11 @@ export function ContainerRow({
                 nestZone={item.id}
                 dnd={dnd}
                 itemDragData={itemDragData}
+                canEdit={canEdit}
                 onEquip={onEquip}
                 onOpen={onOpen}
                 onContext={onContext}
+                onSetQty={onSetQty}
               />
             ) : null;
           })}

--- a/src/OscSheet/features/inventory/rows/ContainerRow.tsx
+++ b/src/OscSheet/features/inventory/rows/ContainerRow.tsx
@@ -3,7 +3,7 @@ import type { InventoryItemVM } from "@domain/vm-types";
 import { ItemImage } from "@features/inventory/ItemImage";
 import { RowEquip } from "@features/inventory/EquippedTray";
 import { NameCell, SortableRow } from "@features/inventory/rows/SortableRow";
-import { weightLabel, gkey, ROOT, EQUIPPED } from "@features/inventory/groups";
+import { weightValue, gkey, ROOT, EQUIPPED } from "@features/inventory/groups";
 import type { Dnd, ItemDragData, OnContext } from "@features/inventory/types";
 import { Tag } from "@ui/Tag";
 import { cx } from "@ui/cx";
@@ -85,7 +85,7 @@ export function ContainerRow({
           trailing={caret}
         />
         <span className="osc-inv-rowcat">{item.category}</span>
-        <span className="osc-inv-wt">{weightLabel(item.weight)}</span>
+        <span className="osc-inv-wt">{weightValue(item.weight)}</span>
         <RowEquip item={item} onEquip={onEquip} />
       </div>
 

--- a/src/OscSheet/features/inventory/rows/SortHeaderRow.tsx
+++ b/src/OscSheet/features/inventory/rows/SortHeaderRow.tsx
@@ -29,7 +29,13 @@ export function SortHeaderRow({
       {/* "Item" spans the image + name columns so it left-aligns to the image */}
       {th("name", "Item", "osc-inv-th-item")}
       {th("category", "Type", "osc-inv-th-cat")}
-      {th("weight", "Wt", "osc-inv-th-wt")}
+      {th(
+        "weight",
+        <>
+          Wt <span className="osc-inv-th-unit">(cn)</span>
+        </>,
+        "osc-inv-th-wt",
+      )}
       <span className="osc-inv-thlabel osc-inv-thlabel-eq">Equip</span>
     </div>
   );

--- a/src/OscSheet/features/inventory/rows/SortHeaderRow.tsx
+++ b/src/OscSheet/features/inventory/rows/SortHeaderRow.tsx
@@ -29,13 +29,7 @@ export function SortHeaderRow({
       {/* "Item" spans the image + name columns so it left-aligns to the image */}
       {th("name", "Item", "osc-inv-th-item")}
       {th("category", "Type", "osc-inv-th-cat")}
-      {th(
-        "weight",
-        <>
-          Wt <span className="osc-inv-th-unit">(cn)</span>
-        </>,
-        "osc-inv-th-wt",
-      )}
+      {th("weight", "Wt", "osc-inv-th-wt")}
       <span className="osc-inv-thlabel osc-inv-thlabel-eq">Equip</span>
     </div>
   );

--- a/src/OscSheet/features/inventory/rows/SortableRow.test.tsx
+++ b/src/OscSheet/features/inventory/rows/SortableRow.test.tsx
@@ -101,9 +101,9 @@ describe("SortableRow inline Use pill", () => {
     expect(inlineUse()).toBeNull();
   });
 
-  it("WT cell shows the bare number (unit lives in the column header)", () => {
+  it("WT cell shows the weight with its cn unit", () => {
     render(mkItem({ weight: 15 }));
-    expect(container.querySelector(".osc-inv-wt")?.textContent).toBe("15");
+    expect(container.querySelector(".osc-inv-wt")?.textContent).toBe("15 cn");
   });
 
   it("WT cell shows an em dash for weightless items", () => {

--- a/src/OscSheet/features/inventory/rows/SortableRow.test.tsx
+++ b/src/OscSheet/features/inventory/rows/SortableRow.test.tsx
@@ -89,9 +89,10 @@ describe("SortableRow inline Use pill", () => {
     expect(inlineUse()!.disabled).toBe(true);
   });
 
-  it("read-only rows get neither the pip buttons nor an inline Use pill", () => {
+  it("read-only rows get no clickable pip strip nor an inline Use pill", () => {
     render(mkItem(), false);
     expect(inlineUse()).toBeNull();
+    expect(container.querySelector(".osc-inv-usebtn")).toBeNull();
     expect(container.querySelectorAll("button.pip")).toHaveLength(0);
   });
 

--- a/src/OscSheet/features/inventory/rows/SortableRow.test.tsx
+++ b/src/OscSheet/features/inventory/rows/SortableRow.test.tsx
@@ -92,7 +92,7 @@ describe("SortableRow inline Use pill", () => {
   it("read-only rows get neither the pip buttons nor an inline Use pill", () => {
     render(mkItem(), false);
     expect(inlineUse()).toBeNull();
-    expect(container.querySelectorAll("button.osc-inv-pip")).toHaveLength(0);
+    expect(container.querySelectorAll("button.pip")).toHaveLength(0);
   });
 
   it("non-stacked rows get no Uses sub-row and no inline Use pill", () => {

--- a/src/OscSheet/features/inventory/rows/SortableRow.test.tsx
+++ b/src/OscSheet/features/inventory/rows/SortableRow.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+// The xs inline "Use" pill: rendered on the item row for stacked, editable items
+// (a CSS container query swaps it for the pip "Uses" sub-row at wider widths).
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { OscSheetContext } from "@app/context";
+import { useDragReorder } from "@features/inventory/useDragReorder";
+import { SortableRow } from "@features/inventory/rows/SortableRow";
+import { ROOT } from "@features/inventory/groups";
+import type { InventoryItemVM } from "@domain/vm-types";
+import type { OscSheetContextValue } from "@domain/types";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mkItem = (o: Partial<InventoryItemVM> = {}): InventoryItemVM => ({
+  id: "arrows", name: "Arrows", img: "", category: "Weapon", categoryRank: 0,
+  damage: "", tags: [], monogram: "AR", weight: 5, cost: 0, armorClass: null,
+  sort: 0, equippedSort: 0, equipped: null, quantity: { value: 3, max: 5 },
+  isContainer: false, children: [], ...o,
+});
+
+let container: HTMLDivElement;
+let root: Root;
+const onSetQty = vi.fn();
+
+function Harness({ item, canEdit }: { item: InventoryItemVM; canEdit: boolean }) {
+  const dnd = useDragReorder({ onNest: () => {}, onReorder: () => {} });
+  const noop = () => {};
+  return (
+    <SortableRow
+      item={item}
+      index={0}
+      group={ROOT}
+      depth={0}
+      dnd={dnd}
+      itemDragData={() => undefined}
+      canEdit={canEdit}
+      onEquip={noop}
+      onOpen={noop}
+      onContext={noop}
+      onSetQty={onSetQty}
+    />
+  );
+}
+
+const ctx = { canEdit: true } as OscSheetContextValue;
+const render = (item: InventoryItemVM, canEdit = true) =>
+  act(() =>
+    root.render(
+      <OscSheetContext.Provider value={ctx}>
+        <Harness item={item} canEdit={canEdit} />
+      </OscSheetContext.Provider>,
+    ),
+  );
+
+const inlineUse = () =>
+  container.querySelector<HTMLButtonElement>(".osc-inv-useinline");
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  onSetQty.mockClear();
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("SortableRow inline Use pill", () => {
+  it("renders both the pip Uses sub-row and the inline Use pill for a stacked, editable row", () => {
+    // The two coexist in the DOM; the xs container query hides one or the other.
+    render(mkItem());
+    expect(container.querySelector(".osc-inv-uses")).toBeTruthy();
+    const pill = inlineUse()!;
+    expect(pill).toBeTruthy();
+    expect(pill.textContent).toBe("Use");
+  });
+
+  it("inline Use decrements by one", () => {
+    render(mkItem({ quantity: { value: 3, max: 5 } }));
+    act(() => inlineUse()!.click());
+    expect(onSetQty).toHaveBeenCalledWith("arrows", 2);
+  });
+
+  it("inline Use is disabled at 0", () => {
+    render(mkItem({ quantity: { value: 0, max: 5 } }));
+    expect(inlineUse()!.disabled).toBe(true);
+  });
+
+  it("read-only rows get neither the pip buttons nor an inline Use pill", () => {
+    render(mkItem(), false);
+    expect(inlineUse()).toBeNull();
+    expect(container.querySelectorAll("button.osc-inv-pip")).toHaveLength(0);
+  });
+
+  it("non-stacked rows get no Uses sub-row and no inline Use pill", () => {
+    render(mkItem({ quantity: null }));
+    expect(container.querySelector(".osc-inv-uses")).toBeNull();
+    expect(inlineUse()).toBeNull();
+  });
+});

--- a/src/OscSheet/features/inventory/rows/SortableRow.test.tsx
+++ b/src/OscSheet/features/inventory/rows/SortableRow.test.tsx
@@ -100,4 +100,14 @@ describe("SortableRow inline Use pill", () => {
     expect(container.querySelector(".osc-inv-uses")).toBeNull();
     expect(inlineUse()).toBeNull();
   });
+
+  it("WT cell shows the bare number (unit lives in the column header)", () => {
+    render(mkItem({ weight: 15 }));
+    expect(container.querySelector(".osc-inv-wt")?.textContent).toBe("15");
+  });
+
+  it("WT cell shows an em dash for weightless items", () => {
+    render(mkItem({ weight: 0 }));
+    expect(container.querySelector(".osc-inv-wt")?.textContent).toBe("—");
+  });
 });

--- a/src/OscSheet/features/inventory/rows/SortableRow.tsx
+++ b/src/OscSheet/features/inventory/rows/SortableRow.tsx
@@ -3,6 +3,7 @@ import type { InventoryItemVM } from "@domain/vm-types";
 import { ItemImage } from "@features/inventory/ItemImage";
 import { RowEquip } from "@features/inventory/EquippedTray";
 import { UsesRow } from "@features/inventory/rows/UsesRow";
+import { InlineButton } from "@ui/InlineButton";
 import { weightLabel, EQUIPPED } from "@features/inventory/groups";
 import type { Dnd, ItemDragData, OnContext } from "@features/inventory/types";
 import { cx } from "@ui/cx";
@@ -60,14 +61,14 @@ function InlineUse({
 }) {
   const value = item.quantity?.value ?? 0;
   return (
-    <button
-      type="button"
-      className="osc-inv-useinline"
+    <InlineButton
+      className="osc-inv-useinline osc-inv-use"
       onClick={() => onSetQty(item.id, Math.max(0, value - 1))}
       disabled={value <= 0}
+      aria-label={`Use one ${item.name}`}
     >
       Use
-    </button>
+    </InlineButton>
   );
 }
 

--- a/src/OscSheet/features/inventory/rows/SortableRow.tsx
+++ b/src/OscSheet/features/inventory/rows/SortableRow.tsx
@@ -8,19 +8,23 @@ import type { Dnd, ItemDragData, OnContext } from "@features/inventory/types";
 import { cx } from "@ui/cx";
 
 /** Name + optional (count/qty) on top, tags beneath. `action` sits right after the
- * name (e.g. the xs inline Use pill); `trailing` sits beside it (e.g. a caret). */
+ * name (e.g. the xs inline Use pill); `trailing` sits beside it (e.g. a caret).
+ * `below` is a second line inside the cell (the Uses pip row) so the grid row grows
+ * to name+uses height and the flanking cells center across the whole block. */
 export function NameCell({
   item,
   onOpen,
   badge,
   action,
   trailing,
+  below,
 }: {
   item: InventoryItemVM;
   onOpen: (id: string) => void;
   badge?: React.ReactNode;
   action?: React.ReactNode;
   trailing?: React.ReactNode;
+  below?: React.ReactNode;
 }) {
   return (
     <div className="osc-inv-name-c">
@@ -40,6 +44,7 @@ export function NameCell({
         {action}
         {trailing}
       </div>
+      {below}
     </div>
   );
 }
@@ -66,8 +71,9 @@ function InlineUse({
   );
 }
 
-// Shared row body (cols 2–8). Stacked + editable rows carry the xs inline Use pill
-// (hidden until the xs container query; the pip sub-row covers wider widths).
+// Shared row body (cols 2–8). Stacked rows nest a "Uses" pip line under the name
+// (so the row centers across name+uses) and, in xs, an inline Use pill on the name
+// row (the pip line is hidden there via the container query).
 function RowInner({
   item,
   canEdit,
@@ -91,6 +97,11 @@ function RowInner({
         action={
           stacked && canEdit ? (
             <InlineUse item={item} onSetQty={onSetQty} />
+          ) : undefined
+        }
+        below={
+          stacked ? (
+            <UsesRow item={item} canEdit={canEdit} onSetQty={onSetQty} />
           ) : undefined
         }
       />
@@ -129,8 +140,6 @@ export function SortableRow({
   onContext: OnContext;
   onSetQty: (id: string, value: number) => void;
 }) {
-  // Stackable items grow a "Uses" sub-row beneath (box pips / Use-1 fallback).
-  const showUses = !item.isContainer && item.quantity != null;
   // No handle: the whole row is draggable. Clicks on the inner buttons/inputs still
   // fire (a click is a press without movement), so name/equip/qty stay interactive.
   return (
@@ -139,7 +148,6 @@ export function SortableRow({
         className={cx(
           "osc-inv-row",
           "is-sortable",
-          showUses && "has-uses",
           dnd.rowClass(group, index),
         )}
         style={
@@ -169,9 +177,6 @@ export function SortableRow({
           onSetQty={onSetQty}
         />
       </div>
-      {showUses && (
-        <UsesRow item={item} canEdit={canEdit} onSetQty={onSetQty} />
-      )}
     </>
   );
 }

--- a/src/OscSheet/features/inventory/rows/SortableRow.tsx
+++ b/src/OscSheet/features/inventory/rows/SortableRow.tsx
@@ -7,16 +7,19 @@ import { weightLabel, EQUIPPED } from "@features/inventory/groups";
 import type { Dnd, ItemDragData, OnContext } from "@features/inventory/types";
 import { cx } from "@ui/cx";
 
-/** Name + optional (count/qty) on top, tags beneath. `trailing` sits beside the name button (e.g. a caret). */
+/** Name + optional (count/qty) on top, tags beneath. `action` sits right after the
+ * name (e.g. the xs inline Use pill); `trailing` sits beside it (e.g. a caret). */
 export function NameCell({
   item,
   onOpen,
   badge,
+  action,
   trailing,
 }: {
   item: InventoryItemVM;
   onOpen: (id: string) => void;
   badge?: React.ReactNode;
+  action?: React.ReactNode;
   trailing?: React.ReactNode;
 }) {
   return (
@@ -34,26 +37,63 @@ export function NameCell({
           )}
           {badge}
         </button>
+        {action}
         {trailing}
       </div>
     </div>
   );
 }
 
-// Shared row body (cols 2–8) — used by the main list AND the equipped table.
-function RowInner({
+// xs-only inline decrement pill (shown in place of the "Uses" pip sub-row at
+// narrow widths — see the @container xs block). Same tick-off-one behaviour.
+function InlineUse({
   item,
-  onEquip,
-  onOpen,
+  onSetQty,
 }: {
   item: InventoryItemVM;
+  onSetQty: (id: string, value: number) => void;
+}) {
+  const value = item.quantity?.value ?? 0;
+  return (
+    <button
+      type="button"
+      className="osc-inv-useinline"
+      onClick={() => onSetQty(item.id, Math.max(0, value - 1))}
+      disabled={value <= 0}
+    >
+      Use
+    </button>
+  );
+}
+
+// Shared row body (cols 2–8). Stacked + editable rows carry the xs inline Use pill
+// (hidden until the xs container query; the pip sub-row covers wider widths).
+function RowInner({
+  item,
+  canEdit,
+  onEquip,
+  onOpen,
+  onSetQty,
+}: {
+  item: InventoryItemVM;
+  canEdit: boolean;
   onEquip: (id: string) => void;
   onOpen: (id: string) => void;
+  onSetQty: (id: string, value: number) => void;
 }) {
+  const stacked = !item.isContainer && item.quantity != null;
   return (
     <>
       <ItemImage img={item.img} monogram={item.monogram} />
-      <NameCell item={item} onOpen={onOpen} />
+      <NameCell
+        item={item}
+        onOpen={onOpen}
+        action={
+          stacked && canEdit ? (
+            <InlineUse item={item} onSetQty={onSetQty} />
+          ) : undefined
+        }
+      />
       <span className="osc-inv-rowcat">{item.category}</span>
       <span className="osc-inv-wt">{weightLabel(item.weight)}</span>
       <RowEquip item={item} onEquip={onEquip} />
@@ -121,7 +161,13 @@ export function SortableRow({
         <span className="osc-inv-drag" aria-hidden="true">
           <i className="fa-solid fa-grip-lines" />
         </span>
-        <RowInner item={item} onEquip={onEquip} onOpen={onOpen} />
+        <RowInner
+          item={item}
+          canEdit={canEdit}
+          onEquip={onEquip}
+          onOpen={onOpen}
+          onSetQty={onSetQty}
+        />
       </div>
       {showUses && (
         <UsesRow item={item} canEdit={canEdit} onSetQty={onSetQty} />

--- a/src/OscSheet/features/inventory/rows/SortableRow.tsx
+++ b/src/OscSheet/features/inventory/rows/SortableRow.tsx
@@ -3,7 +3,7 @@ import type { InventoryItemVM } from "@domain/vm-types";
 import { ItemImage } from "@features/inventory/ItemImage";
 import { RowEquip } from "@features/inventory/EquippedTray";
 import { UsesRow } from "@features/inventory/rows/UsesRow";
-import { weightValue, EQUIPPED } from "@features/inventory/groups";
+import { weightLabel, EQUIPPED } from "@features/inventory/groups";
 import type { Dnd, ItemDragData, OnContext } from "@features/inventory/types";
 import { cx } from "@ui/cx";
 
@@ -106,7 +106,7 @@ function RowInner({
         }
       />
       <span className="osc-inv-rowcat">{item.category}</span>
-      <span className="osc-inv-wt">{weightValue(item.weight)}</span>
+      <span className="osc-inv-wt">{weightLabel(item.weight)}</span>
       <RowEquip item={item} onEquip={onEquip} />
     </>
   );

--- a/src/OscSheet/features/inventory/rows/SortableRow.tsx
+++ b/src/OscSheet/features/inventory/rows/SortableRow.tsx
@@ -2,6 +2,7 @@
 import type { InventoryItemVM } from "@domain/vm-types";
 import { ItemImage } from "@features/inventory/ItemImage";
 import { RowEquip } from "@features/inventory/EquippedTray";
+import { UsesRow } from "@features/inventory/rows/UsesRow";
 import { weightLabel, EQUIPPED } from "@features/inventory/groups";
 import type { Dnd, ItemDragData, OnContext } from "@features/inventory/types";
 import { cx } from "@ui/cx";
@@ -68,9 +69,11 @@ export function SortableRow({
   nestZone,
   dnd,
   itemDragData,
+  canEdit,
   onEquip,
   onOpen,
   onContext,
+  onSetQty,
 }: {
   item: InventoryItemVM;
   index: number;
@@ -80,35 +83,49 @@ export function SortableRow({
   nestZone?: string;
   dnd: Dnd;
   itemDragData: ItemDragData;
+  canEdit: boolean;
   onEquip: (id: string) => void;
   onOpen: (id: string) => void;
   onContext: OnContext;
+  onSetQty: (id: string, value: number) => void;
 }) {
+  // Stackable items grow a "Uses" sub-row beneath (box pips / Use-1 fallback).
+  const showUses = !item.isContainer && item.quantity != null;
   // No handle: the whole row is draggable. Clicks on the inner buttons/inputs still
   // fire (a click is a press without movement), so name/equip/qty stay interactive.
   return (
-    <div
-      className={cx("osc-inv-row", "is-sortable", dnd.rowClass(group, index))}
-      style={
-        depth > 0
-          ? ({ "--osc-inv-depth": depth } as React.CSSProperties)
-          : undefined
-      }
-      onContextMenu={(e) => onContext(e, item)}
-      // Root rows accept a container child dropped among them (un-nest); a container's
-      // child rows accept a foreign item (nest into that container). Neither accepts a
-      // tray tile — equipped-tray drags onto the list are routed to unequip instead.
-      {...dnd.rowProps(group, index, {
-        ownZone: group,
-        nestZone,
-        acceptCrossGroup: (from) => from !== EQUIPPED,
-        dragPayload: () => itemDragData(item.id),
-      })}
-    >
-      <span className="osc-inv-drag" aria-hidden="true">
-        <i className="fa-solid fa-grip-lines" />
-      </span>
-      <RowInner item={item} onEquip={onEquip} onOpen={onOpen} />
-    </div>
+    <>
+      <div
+        className={cx(
+          "osc-inv-row",
+          "is-sortable",
+          showUses && "has-uses",
+          dnd.rowClass(group, index),
+        )}
+        style={
+          depth > 0
+            ? ({ "--osc-inv-depth": depth } as React.CSSProperties)
+            : undefined
+        }
+        onContextMenu={(e) => onContext(e, item)}
+        // Root rows accept a container child dropped among them (un-nest); a container's
+        // child rows accept a foreign item (nest into that container). Neither accepts a
+        // tray tile — equipped-tray drags onto the list are routed to unequip instead.
+        {...dnd.rowProps(group, index, {
+          ownZone: group,
+          nestZone,
+          acceptCrossGroup: (from) => from !== EQUIPPED,
+          dragPayload: () => itemDragData(item.id),
+        })}
+      >
+        <span className="osc-inv-drag" aria-hidden="true">
+          <i className="fa-solid fa-grip-lines" />
+        </span>
+        <RowInner item={item} onEquip={onEquip} onOpen={onOpen} />
+      </div>
+      {showUses && (
+        <UsesRow item={item} canEdit={canEdit} onSetQty={onSetQty} />
+      )}
+    </>
   );
 }

--- a/src/OscSheet/features/inventory/rows/SortableRow.tsx
+++ b/src/OscSheet/features/inventory/rows/SortableRow.tsx
@@ -3,7 +3,7 @@ import type { InventoryItemVM } from "@domain/vm-types";
 import { ItemImage } from "@features/inventory/ItemImage";
 import { RowEquip } from "@features/inventory/EquippedTray";
 import { UsesRow } from "@features/inventory/rows/UsesRow";
-import { InlineButton } from "@ui/InlineButton";
+import { Button } from "@ui/Button";
 import { weightLabel, EQUIPPED } from "@features/inventory/groups";
 import type { Dnd, ItemDragData, OnContext } from "@features/inventory/types";
 import { cx } from "@ui/cx";
@@ -61,14 +61,17 @@ function InlineUse({
 }) {
   const value = item.quantity?.value ?? 0;
   return (
-    <InlineButton
-      className="osc-inv-useinline osc-inv-use"
+    <Button
+      variant="outline"
+      tone="brass"
+      size="xs"
+      className="osc-inv-useinline"
       onClick={() => onSetQty(item.id, Math.max(0, value - 1))}
       disabled={value <= 0}
       aria-label={`Use one ${item.name}`}
     >
       Use
-    </InlineButton>
+    </Button>
   );
 }
 

--- a/src/OscSheet/features/inventory/rows/SortableRow.tsx
+++ b/src/OscSheet/features/inventory/rows/SortableRow.tsx
@@ -3,7 +3,7 @@ import type { InventoryItemVM } from "@domain/vm-types";
 import { ItemImage } from "@features/inventory/ItemImage";
 import { RowEquip } from "@features/inventory/EquippedTray";
 import { UsesRow } from "@features/inventory/rows/UsesRow";
-import { weightLabel, EQUIPPED } from "@features/inventory/groups";
+import { weightValue, EQUIPPED } from "@features/inventory/groups";
 import type { Dnd, ItemDragData, OnContext } from "@features/inventory/types";
 import { cx } from "@ui/cx";
 
@@ -95,7 +95,7 @@ function RowInner({
         }
       />
       <span className="osc-inv-rowcat">{item.category}</span>
-      <span className="osc-inv-wt">{weightLabel(item.weight)}</span>
+      <span className="osc-inv-wt">{weightValue(item.weight)}</span>
       <RowEquip item={item} onEquip={onEquip} />
     </>
   );

--- a/src/OscSheet/features/inventory/rows/UsesRow.test.tsx
+++ b/src/OscSheet/features/inventory/rows/UsesRow.test.tsx
@@ -35,45 +35,44 @@ afterEach(() => {
   container.remove();
 });
 
-const pips = () =>
-  Array.from(container.querySelectorAll<HTMLButtonElement>(".pip"));
+const pips = () => Array.from(container.querySelectorAll<HTMLElement>(".pip"));
+const strip = () =>
+  container.querySelector<HTMLButtonElement>(".osc-inv-usebtn");
 
 describe("UsesRow", () => {
-  it("renders `max` boxes, `value` of them filled", () => {
+  it("renders `max` boxes, `value` of them filled (display-only spans)", () => {
     render(<UsesRow item={mkItem()} canEdit onSetQty={() => {}} />);
     const boxes = pips();
     expect(boxes).toHaveLength(5);
     expect(boxes.filter((b) => b.classList.contains("filled"))).toHaveLength(3);
+    expect(container.querySelectorAll("button.pip")).toHaveLength(0);
   });
 
-  it("clicking any pip consumes one (quantity − 1), whichever pip is clicked", () => {
+  it("clicking anywhere on the pip strip consumes one (quantity − 1)", () => {
     const onSetQty = vi.fn();
     render(<UsesRow item={mkItem({ quantity: { value: 3, max: 5 } })} canEdit onSetQty={onSetQty} />);
-    act(() => pips()[4].click()); // an empty pip → still just -1
-    expect(onSetQty).toHaveBeenCalledWith("arrows", 2);
-    onSetQty.mockClear();
-    act(() => pips()[0].click()); // a filled pip → also -1
+    act(() => strip()!.click());
     expect(onSetQty).toHaveBeenCalledWith("arrows", 2);
   });
 
   it("last remaining unit decrements to 0, not below", () => {
     const onSetQty = vi.fn();
     render(<UsesRow item={mkItem({ quantity: { value: 1, max: 5 } })} canEdit onSetQty={onSetQty} />);
-    act(() => pips()[0].click());
+    act(() => strip()!.click());
     expect(onSetQty).toHaveBeenCalledWith("arrows", 0);
   });
 
-  it("at 0 the pips are disabled — a click is a no-op", () => {
+  it("at 0 the strip button is disabled — a click is a no-op", () => {
     const onSetQty = vi.fn();
     render(<UsesRow item={mkItem({ quantity: { value: 0, max: 5 } })} canEdit onSetQty={onSetQty} />);
-    expect(pips().every((b) => b.disabled)).toBe(true);
-    act(() => pips()[2].click());
+    expect(strip()!.disabled).toBe(true);
+    act(() => strip()!.click());
     expect(onSetQty).not.toHaveBeenCalled();
   });
 
-  it("read-only renders static pips (no buttons) + a count", () => {
+  it("read-only renders static pips (no strip button) + a count", () => {
     render(<UsesRow item={mkItem()} canEdit={false} onSetQty={() => {}} />);
-    expect(container.querySelectorAll("button.pip")).toHaveLength(0);
+    expect(strip()).toBeNull();
     expect(container.querySelectorAll("span.pip")).toHaveLength(5);
     expect(container.querySelector(".osc-inv-uses-count")?.textContent).toBe("3/5");
   });

--- a/src/OscSheet/features/inventory/rows/UsesRow.test.tsx
+++ b/src/OscSheet/features/inventory/rows/UsesRow.test.tsx
@@ -36,7 +36,7 @@ afterEach(() => {
 });
 
 const pips = () =>
-  Array.from(container.querySelectorAll<HTMLButtonElement>(".osc-inv-pip"));
+  Array.from(container.querySelectorAll<HTMLButtonElement>(".pip"));
 
 describe("UsesRow", () => {
   it("renders `max` boxes, `value` of them filled", () => {
@@ -73,8 +73,8 @@ describe("UsesRow", () => {
 
   it("read-only renders static pips (no buttons) + a count", () => {
     render(<UsesRow item={mkItem()} canEdit={false} onSetQty={() => {}} />);
-    expect(container.querySelectorAll("button.osc-inv-pip")).toHaveLength(0);
-    expect(container.querySelectorAll("span.osc-inv-pip")).toHaveLength(5);
+    expect(container.querySelectorAll("button.pip")).toHaveLength(0);
+    expect(container.querySelectorAll("span.pip")).toHaveLength(5);
     expect(container.querySelector(".osc-inv-uses-count")?.textContent).toBe("3/5");
   });
 

--- a/src/OscSheet/features/inventory/rows/UsesRow.test.tsx
+++ b/src/OscSheet/features/inventory/rows/UsesRow.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { UsesRow } from "@features/inventory/rows/UsesRow";
+import type { InventoryItemVM } from "@domain/vm-types";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+// jsdom has no ResizeObserver; the fit-measure hook needs it to exist (no-op is fine —
+// scrollWidth/clientWidth are 0 here, so pips always "fit" and never fall back).
+(globalThis as { ResizeObserver?: unknown }).ResizeObserver ??= class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+const mkItem = (o: Partial<InventoryItemVM> = {}): InventoryItemVM => ({
+  id: "arrows", name: "Arrows", img: "", category: "Weapon", categoryRank: 0,
+  damage: "", tags: [], monogram: "AR", weight: 5, cost: 0, armorClass: null,
+  sort: 0, equippedSort: 0, equipped: null, quantity: { value: 3, max: 5 },
+  isContainer: false, children: [], ...o,
+});
+
+let container: HTMLDivElement;
+let root: Root;
+const render = (ui: React.ReactNode) => act(() => root.render(ui));
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+const pips = () =>
+  Array.from(container.querySelectorAll<HTMLButtonElement>(".osc-inv-pip"));
+
+describe("UsesRow", () => {
+  it("renders `max` boxes, `value` of them filled", () => {
+    render(<UsesRow item={mkItem()} canEdit onSetQty={() => {}} />);
+    const boxes = pips();
+    expect(boxes).toHaveLength(5);
+    expect(boxes.filter((b) => b.classList.contains("filled"))).toHaveLength(3);
+  });
+
+  it("clicking an empty pip sets the count to that pip", () => {
+    const onSetQty = vi.fn();
+    render(<UsesRow item={mkItem()} canEdit onSetQty={onSetQty} />);
+    act(() => pips()[3].click()); // 4th box (n=4), currently empty
+    expect(onSetQty).toHaveBeenCalledWith("arrows", 4);
+  });
+
+  it("clicking the last filled pip ticks one off", () => {
+    const onSetQty = vi.fn();
+    render(<UsesRow item={mkItem({ quantity: { value: 3, max: 5 } })} canEdit onSetQty={onSetQty} />);
+    act(() => pips()[2].click()); // 3rd box = last filled (n===value) → value-1
+    expect(onSetQty).toHaveBeenCalledWith("arrows", 2);
+  });
+
+  it("stops at 0 — the last remaining unit ticks off to 0, not below", () => {
+    const onSetQty = vi.fn();
+    render(<UsesRow item={mkItem({ quantity: { value: 1, max: 5 } })} canEdit onSetQty={onSetQty} />);
+    act(() => pips()[0].click()); // only filled box → 0
+    expect(onSetQty).toHaveBeenCalledWith("arrows", 0);
+  });
+
+  it("read-only renders static pips (no buttons) + a count", () => {
+    render(<UsesRow item={mkItem()} canEdit={false} onSetQty={() => {}} />);
+    expect(container.querySelectorAll("button.osc-inv-pip")).toHaveLength(0);
+    expect(container.querySelectorAll("span.osc-inv-pip")).toHaveLength(5);
+    expect(container.querySelector(".osc-inv-uses-count")?.textContent).toBe("3/5");
+  });
+
+  it("Use-1 fallback decrements and disables at 0", () => {
+    const onSetQty = vi.fn();
+    render(<UsesRow item={mkItem({ quantity: { value: 2, max: 24 } })} canEdit onSetQty={onSetQty} />);
+    const use1 = container.querySelector<HTMLButtonElement>(".osc-inv-use1")!;
+    expect(use1).toBeTruthy();
+    act(() => use1.click());
+    expect(onSetQty).toHaveBeenCalledWith("arrows", 1);
+
+    render(<UsesRow item={mkItem({ quantity: { value: 0, max: 24 } })} canEdit onSetQty={onSetQty} />);
+    expect(container.querySelector<HTMLButtonElement>(".osc-inv-use1")!.disabled).toBe(true);
+  });
+});

--- a/src/OscSheet/features/inventory/rows/UsesRow.test.tsx
+++ b/src/OscSheet/features/inventory/rows/UsesRow.test.tsx
@@ -74,11 +74,12 @@ describe("UsesRow", () => {
     expect(container.querySelector(".osc-inv-uses-count")?.textContent).toBe("3/5");
   });
 
-  it("Use-1 fallback decrements and disables at 0", () => {
+  it("Use fallback is labelled `Use`, decrements and disables at 0", () => {
     const onSetQty = vi.fn();
     render(<UsesRow item={mkItem({ quantity: { value: 2, max: 24 } })} canEdit onSetQty={onSetQty} />);
     const use1 = container.querySelector<HTMLButtonElement>(".osc-inv-use1")!;
     expect(use1).toBeTruthy();
+    expect(use1.textContent).toBe("Use");
     act(() => use1.click());
     expect(onSetQty).toHaveBeenCalledWith("arrows", 1);
 

--- a/src/OscSheet/features/inventory/rows/UsesRow.test.tsx
+++ b/src/OscSheet/features/inventory/rows/UsesRow.test.tsx
@@ -46,25 +46,29 @@ describe("UsesRow", () => {
     expect(boxes.filter((b) => b.classList.contains("filled"))).toHaveLength(3);
   });
 
-  it("clicking an empty pip sets the count to that pip", () => {
-    const onSetQty = vi.fn();
-    render(<UsesRow item={mkItem()} canEdit onSetQty={onSetQty} />);
-    act(() => pips()[3].click()); // 4th box (n=4), currently empty
-    expect(onSetQty).toHaveBeenCalledWith("arrows", 4);
-  });
-
-  it("clicking the last filled pip ticks one off", () => {
+  it("clicking any pip consumes one (quantity − 1), whichever pip is clicked", () => {
     const onSetQty = vi.fn();
     render(<UsesRow item={mkItem({ quantity: { value: 3, max: 5 } })} canEdit onSetQty={onSetQty} />);
-    act(() => pips()[2].click()); // 3rd box = last filled (n===value) → value-1
+    act(() => pips()[4].click()); // an empty pip → still just -1
+    expect(onSetQty).toHaveBeenCalledWith("arrows", 2);
+    onSetQty.mockClear();
+    act(() => pips()[0].click()); // a filled pip → also -1
     expect(onSetQty).toHaveBeenCalledWith("arrows", 2);
   });
 
-  it("stops at 0 — the last remaining unit ticks off to 0, not below", () => {
+  it("last remaining unit decrements to 0, not below", () => {
     const onSetQty = vi.fn();
     render(<UsesRow item={mkItem({ quantity: { value: 1, max: 5 } })} canEdit onSetQty={onSetQty} />);
-    act(() => pips()[0].click()); // only filled box → 0
+    act(() => pips()[0].click());
     expect(onSetQty).toHaveBeenCalledWith("arrows", 0);
+  });
+
+  it("at 0 the pips are disabled — a click is a no-op", () => {
+    const onSetQty = vi.fn();
+    render(<UsesRow item={mkItem({ quantity: { value: 0, max: 5 } })} canEdit onSetQty={onSetQty} />);
+    expect(pips().every((b) => b.disabled)).toBe(true);
+    act(() => pips()[2].click());
+    expect(onSetQty).not.toHaveBeenCalled();
   });
 
   it("read-only renders static pips (no buttons) + a count", () => {

--- a/src/OscSheet/features/inventory/rows/UsesRow.tsx
+++ b/src/OscSheet/features/inventory/rows/UsesRow.tsx
@@ -1,7 +1,7 @@
 // "Uses" sub-row: box pips for a stackable item's quantity (OG-OSE tick-off).
 // Filled = remaining, empty = up to max. Click a pip to set that many; click the
 // last filled to tick one off. When the strip can't fit the row, the pips hide
-// (kept measurable) and a "Use 1" pill takes over.
+// (kept measurable) and a "Use" pill takes over.
 import { useLayoutEffect, useRef, useState } from "react";
 import type { InventoryItemVM } from "@domain/vm-types";
 import { cx } from "@ui/cx";
@@ -78,7 +78,7 @@ export function UsesRow({
               onClick={() => set(value - 1)}
               disabled={value <= 0}
             >
-              Use 1
+              Use
             </button>
           ) : (
             <span className="osc-inv-uses-count">

--- a/src/OscSheet/features/inventory/rows/UsesRow.tsx
+++ b/src/OscSheet/features/inventory/rows/UsesRow.tsx
@@ -1,7 +1,8 @@
-// "Uses" sub-row: box pips for a stackable item's quantity (OG-OSE tick-off).
+// "Uses" line: box pips for a stackable item's quantity (OG-OSE tick-off). Nested
+// under the name (grid col 3) so the flanking cells center across name+uses.
 // Filled = remaining, empty = up to max. Click a pip to set that many; click the
-// last filled to tick one off. When the strip can't fit the row, the pips hide
-// (kept measurable) and a "Use" pill takes over.
+// last filled to tick one off. When the strip can't fit, the pips hide (kept
+// measurable) and a "Use" pill takes over.
 import { useLayoutEffect, useRef, useState } from "react";
 import type { InventoryItemVM } from "@domain/vm-types";
 import { cx } from "@ui/cx";
@@ -38,55 +39,53 @@ export function UsesRow({
 
   return (
     <div className="osc-inv-uses" data-overflow={overflow || undefined}>
-      <div className="osc-inv-uses-c">
-        <span className="osc-inv-uses-label">Uses</span>
-        <span className="osc-inv-uses-strip">
-          <span
-            className="osc-inv-pips"
-            ref={pipsRef}
-            role="group"
-            aria-label={`${item.name} uses: ${value} of ${total}`}
-          >
-            {Array.from({ length: total }).map((_, i) => {
-              const n = i + 1;
-              const filled = i < value;
-              // Clicking the last filled pip ticks it OFF (→ n-1); any other pip sets
-              // the count to that pip. So every value, including 0, is reachable.
-              const to = n === value ? value - 1 : n;
-              return canEdit ? (
-                <button
-                  key={i}
-                  type="button"
-                  className={cx("osc-inv-pip", filled && "filled")}
-                  aria-label={`Set ${item.name} to ${to}`}
-                  aria-pressed={filled}
-                  onClick={() => set(to)}
-                />
-              ) : (
-                <span
-                  key={i}
-                  className={cx("osc-inv-pip", filled && "filled")}
-                  aria-hidden="true"
-                />
-              );
-            })}
-          </span>
-          {canEdit ? (
-            <button
-              type="button"
-              className="osc-inv-use1"
-              onClick={() => set(value - 1)}
-              disabled={value <= 0}
-            >
-              Use
-            </button>
-          ) : (
-            <span className="osc-inv-uses-count">
-              {value}/{total}
-            </span>
-          )}
+      <span className="osc-inv-uses-label">Uses</span>
+      <span className="osc-inv-uses-strip">
+        <span
+          className="osc-inv-pips"
+          ref={pipsRef}
+          role="group"
+          aria-label={`${item.name} uses: ${value} of ${total}`}
+        >
+          {Array.from({ length: total }).map((_, i) => {
+            const n = i + 1;
+            const filled = i < value;
+            // Clicking the last filled pip ticks it OFF (→ n-1); any other pip sets
+            // the count to that pip. So every value, including 0, is reachable.
+            const to = n === value ? value - 1 : n;
+            return canEdit ? (
+              <button
+                key={i}
+                type="button"
+                className={cx("osc-inv-pip", filled && "filled")}
+                aria-label={`Set ${item.name} to ${to}`}
+                aria-pressed={filled}
+                onClick={() => set(to)}
+              />
+            ) : (
+              <span
+                key={i}
+                className={cx("osc-inv-pip", filled && "filled")}
+                aria-hidden="true"
+              />
+            );
+          })}
         </span>
-      </div>
+        {canEdit ? (
+          <button
+            type="button"
+            className="osc-inv-use1"
+            onClick={() => set(value - 1)}
+            disabled={value <= 0}
+          >
+            Use
+          </button>
+        ) : (
+          <span className="osc-inv-uses-count">
+            {value}/{total}
+          </span>
+        )}
+      </span>
     </div>
   );
 }

--- a/src/OscSheet/features/inventory/rows/UsesRow.tsx
+++ b/src/OscSheet/features/inventory/rows/UsesRow.tsx
@@ -1,0 +1,92 @@
+// "Uses" sub-row: box pips for a stackable item's quantity (OG-OSE tick-off).
+// Filled = remaining, empty = up to max. Click a pip to set that many; click the
+// last filled to tick one off. When the strip can't fit the row, the pips hide
+// (kept measurable) and a "Use 1" pill takes over.
+import { useLayoutEffect, useRef, useState } from "react";
+import type { InventoryItemVM } from "@domain/vm-types";
+import { cx } from "@ui/cx";
+
+export function UsesRow({
+  item,
+  canEdit,
+  onSetQty,
+}: {
+  item: InventoryItemVM;
+  canEdit: boolean;
+  onSetQty: (id: string, value: number) => void;
+}) {
+  const q = item.quantity;
+  const pipsRef = useRef<HTMLSpanElement>(null);
+  const [overflow, setOverflow] = useState(false);
+  const total = q ? Math.max(q.max, q.value) : 0;
+
+  useLayoutEffect(() => {
+    const el = pipsRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    // Pips fill the strip (flex:1); they overflow when their content is wider than
+    // the grid gives them → swap to the Use-1 button. Mirrors HeaderBand's useFitText.
+    const measure = () => setOverflow(el.scrollWidth > el.clientWidth + 1);
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [total]);
+
+  if (!q) return null;
+  const value = q.value;
+  const set = (next: number) => canEdit && onSetQty(item.id, Math.max(0, next));
+
+  return (
+    <div className="osc-inv-uses" data-overflow={overflow || undefined}>
+      <div className="osc-inv-uses-c">
+        <span className="osc-inv-uses-label">Uses</span>
+        <span className="osc-inv-uses-strip">
+          <span
+            className="osc-inv-pips"
+            ref={pipsRef}
+            role="group"
+            aria-label={`${item.name} uses: ${value} of ${total}`}
+          >
+            {Array.from({ length: total }).map((_, i) => {
+              const n = i + 1;
+              const filled = i < value;
+              // Clicking the last filled pip ticks it OFF (→ n-1); any other pip sets
+              // the count to that pip. So every value, including 0, is reachable.
+              const to = n === value ? value - 1 : n;
+              return canEdit ? (
+                <button
+                  key={i}
+                  type="button"
+                  className={cx("osc-inv-pip", filled && "filled")}
+                  aria-label={`Set ${item.name} to ${to}`}
+                  aria-pressed={filled}
+                  onClick={() => set(to)}
+                />
+              ) : (
+                <span
+                  key={i}
+                  className={cx("osc-inv-pip", filled && "filled")}
+                  aria-hidden="true"
+                />
+              );
+            })}
+          </span>
+          {canEdit ? (
+            <button
+              type="button"
+              className="osc-inv-use1"
+              onClick={() => set(value - 1)}
+              disabled={value <= 0}
+            >
+              Use 1
+            </button>
+          ) : (
+            <span className="osc-inv-uses-count">
+              {value}/{total}
+            </span>
+          )}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/OscSheet/features/inventory/rows/UsesRow.tsx
+++ b/src/OscSheet/features/inventory/rows/UsesRow.tsx
@@ -1,9 +1,9 @@
-// "Uses" line: circular pips for a stackable item's quantity (OG-OSE tick-off) —
-// the shared Vellum <Pips> (same disc as the spell cast rows). Nested under the name
-// (grid col 3) so the flanking cells center across name+uses. Filled = remaining,
-// empty = up to max. Clicking any pip (or the Use pill) consumes one (quantity − 1,
-// floored at 0; no-op at 0). When the strip can't fit, the pips hide (kept
-// measurable) and a "Use" pill takes over.
+// "Uses" line: small square pips for a stackable item's quantity (OG-OSE tick-off) —
+// the shared Vellum <Pips square> (display-only dots). Nested under the name (grid
+// col 3) so the flanking cells center across name+uses. Filled = remaining, empty =
+// up to max. The WHOLE strip is one button: clicking anywhere on it (or the Use pill)
+// consumes one (quantity − 1, floored at 0; no-op/disabled at 0). When the strip
+// can't fit, the pips hide (kept measurable) and a "Use" pill takes over.
 import { useLayoutEffect, useRef, useState } from "react";
 import type { InventoryItemVM } from "@domain/vm-types";
 import { Pips } from "@ui/Pips";
@@ -42,18 +42,36 @@ export function UsesRow({
   return (
     <div className="osc-inv-uses" data-overflow={overflow || undefined}>
       <span className="osc-inv-uses-strip">
-        <Pips
-          ref={pipsRef}
-          className="osc-inv-pips"
-          size="sm"
-          total={total}
-          filled={value}
-          role="group"
-          aria-label={`Uses: ${value} of ${total}`}
-          onPipClick={canEdit ? () => set(value - 1) : undefined}
-          pipLabel={canEdit ? () => `Use one ${item.name}` : undefined}
-          pipDisabled={value <= 0}
-        />
+        {canEdit ? (
+          <button
+            type="button"
+            className="osc-inv-usebtn"
+            onClick={() => set(value - 1)}
+            disabled={value <= 0}
+            aria-label={`Use one ${item.name}`}
+          >
+            <Pips
+              ref={pipsRef}
+              className="osc-inv-pips"
+              size="sm"
+              square
+              total={total}
+              filled={value}
+              aria-hidden="true"
+            />
+          </button>
+        ) : (
+          <Pips
+            ref={pipsRef}
+            className="osc-inv-pips"
+            size="sm"
+            square
+            total={total}
+            filled={value}
+            role="img"
+            aria-label={`Uses: ${value} of ${total}`}
+          />
+        )}
         {canEdit ? (
           <Button
             variant="outline"

--- a/src/OscSheet/features/inventory/rows/UsesRow.tsx
+++ b/src/OscSheet/features/inventory/rows/UsesRow.tsx
@@ -7,7 +7,7 @@
 import { useLayoutEffect, useRef, useState } from "react";
 import type { InventoryItemVM } from "@domain/vm-types";
 import { Pips } from "@ui/Pips";
-import { InlineButton } from "@ui/InlineButton";
+import { Button } from "@ui/Button";
 
 export function UsesRow({
   item,
@@ -55,14 +55,17 @@ export function UsesRow({
           pipDisabled={value <= 0}
         />
         {canEdit ? (
-          <InlineButton
-            className="osc-inv-use1 osc-inv-use"
+          <Button
+            variant="outline"
+            tone="brass"
+            size="xs"
+            className="osc-inv-use1"
             onClick={() => set(value - 1)}
             disabled={value <= 0}
             aria-label={`Use one ${item.name}`}
           >
             Use
-          </InlineButton>
+          </Button>
         ) : (
           <span className="osc-inv-uses-count">
             {value}/{total}

--- a/src/OscSheet/features/inventory/rows/UsesRow.tsx
+++ b/src/OscSheet/features/inventory/rows/UsesRow.tsx
@@ -7,6 +7,7 @@
 import { useLayoutEffect, useRef, useState } from "react";
 import type { InventoryItemVM } from "@domain/vm-types";
 import { Pips } from "@ui/Pips";
+import { InlineButton } from "@ui/InlineButton";
 
 export function UsesRow({
   item,
@@ -54,14 +55,14 @@ export function UsesRow({
           pipDisabled={value <= 0}
         />
         {canEdit ? (
-          <button
-            type="button"
-            className="osc-inv-use1"
+          <InlineButton
+            className="osc-inv-use1 osc-inv-use"
             onClick={() => set(value - 1)}
             disabled={value <= 0}
+            aria-label={`Use one ${item.name}`}
           >
             Use
-          </button>
+          </InlineButton>
         ) : (
           <span className="osc-inv-uses-count">
             {value}/{total}

--- a/src/OscSheet/features/inventory/rows/UsesRow.tsx
+++ b/src/OscSheet/features/inventory/rows/UsesRow.tsx
@@ -1,11 +1,12 @@
-// "Uses" line: box pips for a stackable item's quantity (OG-OSE tick-off). Nested
-// under the name (grid col 3) so the flanking cells center across name+uses.
-// Filled = remaining, empty = up to max. Clicking any pip (or the Use pill) consumes
-// one (quantity − 1, floored at 0; no-op at 0). When the strip can't fit, the pips
-// hide (kept measurable) and a "Use" pill takes over.
+// "Uses" line: circular pips for a stackable item's quantity (OG-OSE tick-off) —
+// the shared Vellum <Pips> (same disc as the spell cast rows). Nested under the name
+// (grid col 3) so the flanking cells center across name+uses. Filled = remaining,
+// empty = up to max. Clicking any pip (or the Use pill) consumes one (quantity − 1,
+// floored at 0; no-op at 0). When the strip can't fit, the pips hide (kept
+// measurable) and a "Use" pill takes over.
 import { useLayoutEffect, useRef, useState } from "react";
 import type { InventoryItemVM } from "@domain/vm-types";
-import { cx } from "@ui/cx";
+import { Pips } from "@ui/Pips";
 
 export function UsesRow({
   item,
@@ -25,7 +26,7 @@ export function UsesRow({
     const el = pipsRef.current;
     if (!el || typeof ResizeObserver === "undefined") return;
     // Pips fill the strip (flex:1); they overflow when their content is wider than
-    // the grid gives them → swap to the Use-1 button. Mirrors HeaderBand's useFitText.
+    // the grid gives them → swap to the Use button. Mirrors HeaderBand's useFitText.
     const measure = () => setOverflow(el.scrollWidth > el.clientWidth + 1);
     measure();
     const ro = new ResizeObserver(measure);
@@ -39,35 +40,19 @@ export function UsesRow({
 
   return (
     <div className="osc-inv-uses" data-overflow={overflow || undefined}>
-      <span className="osc-inv-uses-label">Uses</span>
       <span className="osc-inv-uses-strip">
-        <span
-          className="osc-inv-pips"
+        <Pips
           ref={pipsRef}
+          className="osc-inv-pips"
+          size="sm"
+          total={total}
+          filled={value}
           role="group"
-          aria-label={`${item.name} uses: ${value} of ${total}`}
-        >
-          {Array.from({ length: total }).map((_, i) => {
-            const filled = i < value;
-            // Every pip is a "consume one" button (quantity − 1); no-op at 0.
-            return canEdit ? (
-              <button
-                key={i}
-                type="button"
-                className={cx("osc-inv-pip", filled && "filled")}
-                aria-label={`Use one ${item.name}`}
-                onClick={() => set(value - 1)}
-                disabled={value <= 0}
-              />
-            ) : (
-              <span
-                key={i}
-                className={cx("osc-inv-pip", filled && "filled")}
-                aria-hidden="true"
-              />
-            );
-          })}
-        </span>
+          aria-label={`Uses: ${value} of ${total}`}
+          onPipClick={canEdit ? () => set(value - 1) : undefined}
+          pipLabel={canEdit ? () => `Use one ${item.name}` : undefined}
+          pipDisabled={value <= 0}
+        />
         {canEdit ? (
           <button
             type="button"

--- a/src/OscSheet/features/inventory/rows/UsesRow.tsx
+++ b/src/OscSheet/features/inventory/rows/UsesRow.tsx
@@ -1,8 +1,8 @@
 // "Uses" line: box pips for a stackable item's quantity (OG-OSE tick-off). Nested
 // under the name (grid col 3) so the flanking cells center across name+uses.
-// Filled = remaining, empty = up to max. Click a pip to set that many; click the
-// last filled to tick one off. When the strip can't fit, the pips hide (kept
-// measurable) and a "Use" pill takes over.
+// Filled = remaining, empty = up to max. Clicking any pip (or the Use pill) consumes
+// one (quantity − 1, floored at 0; no-op at 0). When the strip can't fit, the pips
+// hide (kept measurable) and a "Use" pill takes over.
 import { useLayoutEffect, useRef, useState } from "react";
 import type { InventoryItemVM } from "@domain/vm-types";
 import { cx } from "@ui/cx";
@@ -48,19 +48,16 @@ export function UsesRow({
           aria-label={`${item.name} uses: ${value} of ${total}`}
         >
           {Array.from({ length: total }).map((_, i) => {
-            const n = i + 1;
             const filled = i < value;
-            // Clicking the last filled pip ticks it OFF (→ n-1); any other pip sets
-            // the count to that pip. So every value, including 0, is reachable.
-            const to = n === value ? value - 1 : n;
+            // Every pip is a "consume one" button (quantity − 1); no-op at 0.
             return canEdit ? (
               <button
                 key={i}
                 type="button"
                 className={cx("osc-inv-pip", filled && "filled")}
-                aria-label={`Set ${item.name} to ${to}`}
-                aria-pressed={filled}
-                onClick={() => set(to)}
+                aria-label={`Use one ${item.name}`}
+                onClick={() => set(value - 1)}
+                disabled={value <= 0}
               />
             ) : (
               <span

--- a/src/OscSheet/features/inventory/types.ts
+++ b/src/OscSheet/features/inventory/types.ts
@@ -24,6 +24,8 @@ export type Ops = {
   onOpen: (id: string) => void;
   onDelete: (id: string) => void;
   onConsume: (id: string) => void;
+  /** Set a stackable item's quantity (pip tick / Use-1); optimistic, floored at 0. */
+  onSetQty: (id: string, value: number) => void;
   onReorder: (updates: { id: string; sort: number }[]) => void;
   /** Persist the equipped tray's own order (writes the `equippedOrder` flag). */
   onReorderEquipped: (updates: { id: string; sort: number }[]) => void;

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -141,6 +141,8 @@
   grid-template-columns: 18px 30px 1fr;
   align-items: center;
   gap: var(--spacer-2);
+  // Pull up into the centered item row's bottom slack so the pips hug the name.
+  margin-top: calc(-1 * var(--spacer-1));
   padding: 0 var(--spacer-1) var(--spacer-2);
   border-bottom: 1px solid var(--border-soft, #2c2823);
 }
@@ -155,6 +157,7 @@
   flex: none;
   font-family: var(--sans);
   font-size: var(--fs-3xs, 10px);
+  line-height: var(--lh-flush, 1);
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -164,7 +167,7 @@
   position: relative;
   flex: 1;
   min-width: 0;
-  min-height: 16px;
+  min-height: 12px;
   display: flex;
   align-items: center;
 }
@@ -178,10 +181,10 @@
 }
 .osc-inv .osc-inv-pip {
   flex: none;
-  width: 14px;
-  height: 14px;
+  width: 10px;
+  height: 10px;
   padding: 0;
-  border-radius: var(--r-sm, 4px);
+  border-radius: 2px;
   background: transparent;
   border: 1px solid var(--accent-alt, #c89e54);
   opacity: 0.5;

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -124,30 +124,14 @@
   &.drop-after {
     box-shadow: inset 0 -2px 0 0 var(--teal, #1f7575);
   }
-  // A stackable row + its "Uses" sub-row read as one unit: drop the divider/bottom
-  // pad here and let the sub-row carry them.
-  &.has-uses {
-    border-bottom: none;
-    padding-bottom: 0;
-  }
 }
 
-// --- "Uses" sub-row: box pips for a stackable item, Use-1 fallback when too tight ---
-// Aligns its content under the name column (cols 1–2 match the row's fixed widths).
-// Selectors carry the `.osc-inv` ancestor so the pip/Use-1 BUTTONS beat the
-// `.osc-sheet-app` `all: unset` reset (same trick as .osc-inv-name/-drag/-equip).
+// --- "Uses" line: box pips for a stackable item, "Use" fallback when too tight ---
+// Nested inside the name cell (grid col 3) as a second line under the name, so the
+// row grows to name+uses height and `.osc-inv-row { align-items: center }` centers
+// the flanking cells across the whole block. Selectors carry the `.osc-inv` ancestor
+// so the pip/Use BUTTONS beat the `.osc-sheet-app` `all: unset` reset.
 .osc-inv .osc-inv-uses {
-  display: grid;
-  grid-template-columns: 18px 30px 1fr;
-  align-items: center;
-  gap: var(--spacer-2);
-  // Pull up into the centered item row's bottom slack so the pips hug the name.
-  margin-top: calc(-1 * var(--spacer-1));
-  padding: 0 var(--spacer-1) var(--spacer-2);
-  border-bottom: 1px solid var(--border-soft, #2c2823);
-}
-.osc-inv .osc-inv-uses-c {
-  grid-column: 3;
   display: flex;
   align-items: center;
   gap: var(--spacer-2);
@@ -560,11 +544,6 @@
   }
   .osc-inv .osc-inv-uses {
     display: none;
-  }
-  // Sub-row is gone — the item row carries its own divider/bottom pad again.
-  .osc-inv-row.has-uses {
-    border-bottom: 1px solid var(--border-soft, #2c2823);
-    padding-bottom: var(--spacer-2);
   }
   .osc-inv .osc-inv-useinline {
     display: inline-flex;

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -146,12 +146,18 @@
   align-items: center;
 }
 // The dots are the shared Vellum <Pips square sm>; we only re-tint them brass (the
-// shared default is gold) and tighten the gap so the squares sit near-adjacent.
+// shared default is gold), tighten the gap, and shrink them to 7×7 — all scoped to
+// inventory so the spell/cast <Pips size="sm"> stays 9×9.
 .osc-inv .osc-inv-pips {
   flex: 1;
   min-width: 0;
-  gap: 1px;
+  gap: 2px;
   overflow: hidden;
+}
+// Needs the `.sm` class too, to out-specify the shared `.pips.sm .pip` (9×9).
+.osc-inv .osc-inv-pips.sm .pip {
+  width: 7px;
+  height: 7px;
 }
 .osc-inv .osc-inv-pips .pip {
   background: transparent;
@@ -903,7 +909,9 @@
   margin-left: auto;
   white-space: nowrap;
 }
-.osc-inv-sec-head > .menu-host { display: inline-flex; }
+.osc-inv-sec-head > .menu-host {
+  display: inline-flex;
+}
 // translateY is optical: the all-caps label's centre sits above its box centre.
 .osc-inv-sec-head .icon-btn {
   color: var(--text-mute);
@@ -911,7 +919,9 @@
 }
 // hang the box left of the trigger so the caret keeps its natural 14px inset and
 // still lands on the 18px button's centre.
-.osc-inv-sec-head .menu.is-popover.align-start { left: -12px; }
+.osc-inv-sec-head .menu.is-popover.align-start {
+  left: -12px;
+}
 
 // --- Equipped tray: dashed-bordered row of large ink-stamp tiles ---
 .osc-equip-tray {

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -566,6 +566,11 @@
   .osc-inv .osc-inv-useinline {
     display: inline-flex;
   }
+  // name · ×N · Use read as one evenly-spaced run: match the name→tag gap to the
+  // name-row gap (--spacer-1) so nothing sits farther from its neighbour.
+  .osc-inv .osc-inv-name {
+    gap: var(--spacer-1);
+  }
 }
 
 // --- damage die (col 6) ---

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -185,30 +185,17 @@
   top: 50%;
   transform: translateY(-50%);
 }
-// Both "Use" affordances (pip-overflow fallback + xs inline) are a plain brass text
-// link on the shared InlineButton base (`.inline-btn` — no pill/border/bg), not a pill.
-.osc-inv .osc-inv-use {
-  font-family: var(--sans);
-  font-size: var(--fs-2xs, 11px);
-  font-weight: 600;
-  color: var(--accent-alt, #c89e54);
-  &:hover:not(:disabled) {
-    color: var(--accent-alt, #c89e54);
-    text-decoration: underline;
-  }
-  &:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-  }
-}
+// Both "Use" affordances (pip-overflow fallback + xs inline) render as the shared
+// Vellum Button (`variant="outline" tone="brass" size="xs"`); these classes only carry
+// their positioning/visibility — the pill look comes from `.btn`.
 .osc-inv .osc-inv-uses-count {
   font-family: var(--mono);
   font-size: var(--fs-2xs, 11px);
   color: var(--text-mute, #8a8270);
 }
 
-// xs inline "Use" link on the item row (name column). Hidden until the xs container
-// query swaps out the pip sub-row; look comes from `.osc-inv-use` + `.inline-btn`.
+// xs inline "Use" pill on the item row (name column). Hidden until the xs container
+// query swaps out the pip sub-row; the pill look comes from `.btn` (Button primitive).
 .osc-inv .osc-inv-useinline {
   display: none;
   flex: none;

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -253,6 +253,35 @@
   color: var(--text-mute, #8a8270);
 }
 
+// xs inline "Use" pill on the item row (name column). Hidden until the xs
+// container query swaps out the pip sub-row; same brass pill as the Use fallback.
+.osc-inv .osc-inv-useinline {
+  display: none;
+  flex: none;
+  align-items: center;
+  font-family: var(--sans);
+  font-size: var(--fs-3xs, 10px);
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent-alt, #c89e54);
+  background: transparent;
+  border: 1px solid var(--accent-alt, #c89e54);
+  border-radius: 999px;
+  padding: 2px var(--spacer-2);
+  cursor: pointer;
+  transition:
+    background 0.12s,
+    color 0.12s;
+  &:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--accent-alt, #c89e54) 15%, transparent);
+  }
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+
 // --- sortable column-header row (table head) ---
 .osc-inv-headrow {
   padding-top: 0;
@@ -506,7 +535,8 @@
   text-align: right;
 }
 
-// xs / mobile (bottom-tabs layout): drop the Type column to save width.
+// xs / mobile (bottom-tabs layout): drop the Type column to save width, and swap
+// the "Uses" pip sub-row for the inline Use pill on the item row.
 @container app (max-width: 479px) {
   .osc-inv-row {
     grid-template-columns: 18px 30px 1fr 44px 44px;
@@ -514,6 +544,17 @@
   .osc-inv-rowcat,
   .osc-inv .osc-inv-th-cat {
     display: none;
+  }
+  .osc-inv .osc-inv-uses {
+    display: none;
+  }
+  // Sub-row is gone — the item row carries its own divider/bottom pad again.
+  .osc-inv-row.has-uses {
+    border-bottom: 1px solid var(--border-soft, #2c2823);
+    padding-bottom: var(--spacer-2);
+  }
+  .osc-inv .osc-inv-useinline {
+    display: inline-flex;
   }
 }
 

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -213,9 +213,11 @@
 
 // xs inline "Use" pill on the item row (name column). Hidden until the xs container
 // query swaps out the pip sub-row; the pill look comes from `.btn` (Button primitive).
+// A little left margin gives it breathing room off the ×N tag (looser than change 6).
 .osc-inv .osc-inv-useinline {
   display: none;
   flex: none;
+  margin-left: var(--spacer-2);
 }
 
 // --- sortable column-header row (table head) ---

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -137,57 +137,31 @@
   gap: var(--spacer-2);
   min-width: 0;
 }
-.osc-inv .osc-inv-uses-label {
-  flex: none;
-  font-family: var(--sans);
-  font-size: var(--fs-3xs, 10px);
-  line-height: var(--lh-flush, 1);
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-faint, #6a6354);
-}
 .osc-inv .osc-inv-uses-strip {
   position: relative;
   flex: 1;
   min-width: 0;
-  min-height: 12px;
+  min-height: 10px;
   display: flex;
   align-items: center;
 }
+// The discs are the shared Vellum <Pips> (`.pips.sm .pip` — same as the spell cast
+// rows). The strip fills the row and clips so an oversized run is measured and swaps
+// to the Use pill; the interactive states below are the only pip CSS we add, since
+// ours render as tick-off buttons.
 .osc-inv .osc-inv-pips {
   flex: 1;
   min-width: 0;
-  display: flex;
-  align-items: center;
-  gap: var(--spacer-1);
   overflow: hidden;
 }
-.osc-inv .osc-inv-pip {
-  flex: none;
-  width: 10px;
-  height: 10px;
-  padding: 0;
-  border-radius: 2px;
-  background: transparent;
-  border: 1px solid var(--accent-alt, #c89e54);
-  opacity: 0.5;
-  transition:
-    background 0.12s,
-    opacity 0.12s;
-  &.filled {
-    background: var(--accent-alt, #c89e54);
-    opacity: 1;
-  }
-}
-.osc-inv button.osc-inv-pip {
+.osc-inv button.pip {
   cursor: pointer;
-  &:hover {
-    opacity: 1;
-    background: color-mix(in srgb, var(--accent-alt, #c89e54) 30%, transparent);
+  transition: filter 0.12s;
+  &:hover:not(:disabled) {
+    filter: brightness(1.2);
   }
-  &.filled:hover {
-    background: var(--accent-alt-dim, #a88240);
+  &:disabled {
+    cursor: not-allowed;
   }
   &:focus-visible {
     outline: 2px solid var(--gold);

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -101,7 +101,7 @@
 
 .osc-inv-row {
   display: grid;
-  grid-template-columns: 18px 30px 1fr 52px 44px 44px;
+  grid-template-columns: 18px 30px 1fr 52px 52px 44px;
   align-items: center;
   gap: var(--spacer-2);
   padding: var(--spacer-2) var(--spacer-1);
@@ -312,12 +312,22 @@
     color: var(--text, #e5dec8);
   }
 }
-// header alignment matches the cells below it
-.osc-inv .osc-inv-th-wt {
-  justify-content: flex-end;
-}
+// Right-aligned columns (Type, Wt): shrink the header to the cell's right edge and
+// move the sort caret left of the label (order, not row-reverse — keeps "Wt (cn)"
+// reading order), so the label sits flush over its right-aligned data.
+.osc-inv .osc-inv-th-wt,
 .osc-inv .osc-inv-th-cat {
-  justify-content: flex-end;
+  justify-self: end;
+}
+.osc-inv .osc-inv-th-wt .osc-inv-th-caret,
+.osc-inv .osc-inv-th-cat .osc-inv-th-caret {
+  order: -1;
+}
+.osc-inv .osc-inv-th-unit {
+  text-transform: none;
+  font-weight: 500;
+  letter-spacing: 0;
+  opacity: 0.75;
 }
 // "Item" header spans the image + name columns so it starts at the image edge
 .osc-inv .osc-inv-th-item {
@@ -423,7 +433,7 @@
 // --- name button (col 3) ---
 .osc-inv .osc-inv-name {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: var(--spacer-2);
   flex-wrap: nowrap;
   min-width: 0;
@@ -468,7 +478,7 @@
 }
 .osc-inv-name-row {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: var(--spacer-1);
   min-width: 0;
   max-width: 100%;
@@ -539,7 +549,7 @@
 // the "Uses" pip sub-row for the inline Use pill on the item row.
 @container app (max-width: 479px) {
   .osc-inv-row {
-    grid-template-columns: 18px 30px 1fr 44px 44px;
+    grid-template-columns: 18px 30px 1fr 52px 44px;
   }
   .osc-inv-rowcat,
   .osc-inv .osc-inv-th-cat {

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -124,6 +124,133 @@
   &.drop-after {
     box-shadow: inset 0 -2px 0 0 var(--teal, #1f7575);
   }
+  // A stackable row + its "Uses" sub-row read as one unit: drop the divider/bottom
+  // pad here and let the sub-row carry them.
+  &.has-uses {
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+}
+
+// --- "Uses" sub-row: box pips for a stackable item, Use-1 fallback when too tight ---
+// Aligns its content under the name column (cols 1–2 match the row's fixed widths).
+// Selectors carry the `.osc-inv` ancestor so the pip/Use-1 BUTTONS beat the
+// `.osc-sheet-app` `all: unset` reset (same trick as .osc-inv-name/-drag/-equip).
+.osc-inv .osc-inv-uses {
+  display: grid;
+  grid-template-columns: 18px 30px 1fr;
+  align-items: center;
+  gap: var(--spacer-2);
+  padding: 0 var(--spacer-1) var(--spacer-2);
+  border-bottom: 1px solid var(--border-soft, #2c2823);
+}
+.osc-inv .osc-inv-uses-c {
+  grid-column: 3;
+  display: flex;
+  align-items: center;
+  gap: var(--spacer-2);
+  min-width: 0;
+}
+.osc-inv .osc-inv-uses-label {
+  flex: none;
+  font-family: var(--sans);
+  font-size: var(--fs-3xs, 10px);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-faint, #6a6354);
+}
+.osc-inv .osc-inv-uses-strip {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+  min-height: 16px;
+  display: flex;
+  align-items: center;
+}
+.osc-inv .osc-inv-pips {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--spacer-1);
+  overflow: hidden;
+}
+.osc-inv .osc-inv-pip {
+  flex: none;
+  width: 14px;
+  height: 14px;
+  padding: 0;
+  border-radius: var(--r-sm, 4px);
+  background: transparent;
+  border: 1px solid var(--accent-alt, #c89e54);
+  opacity: 0.5;
+  transition:
+    background 0.12s,
+    opacity 0.12s;
+  &.filled {
+    background: var(--accent-alt, #c89e54);
+    opacity: 1;
+  }
+}
+.osc-inv button.osc-inv-pip {
+  cursor: pointer;
+  &:hover {
+    opacity: 1;
+    background: color-mix(in srgb, var(--accent-alt, #c89e54) 30%, transparent);
+  }
+  &.filled:hover {
+    background: var(--accent-alt-dim, #a88240);
+  }
+  &:focus-visible {
+    outline: 2px solid var(--gold);
+    outline-offset: 1px;
+  }
+}
+// Overflow: hide the pips (kept measurable via visibility) and surface the fallback.
+.osc-inv .osc-inv-uses[data-overflow] .osc-inv-pips {
+  visibility: hidden;
+}
+.osc-inv .osc-inv-use1,
+.osc-inv .osc-inv-uses-count {
+  display: none;
+}
+.osc-inv .osc-inv-uses[data-overflow] .osc-inv-use1,
+.osc-inv .osc-inv-uses[data-overflow] .osc-inv-uses-count {
+  display: inline-flex;
+  align-items: center;
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+}
+.osc-inv .osc-inv-use1 {
+  font-family: var(--sans);
+  font-size: var(--fs-3xs, 10px);
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent-alt, #c89e54);
+  background: transparent;
+  border: 1px solid var(--accent-alt, #c89e54);
+  border-radius: 999px;
+  padding: 2px var(--spacer-2);
+  cursor: pointer;
+  transition:
+    background 0.12s,
+    color 0.12s;
+  &:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--accent-alt, #c89e54) 15%, transparent);
+  }
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+.osc-inv .osc-inv-uses-count {
+  font-family: var(--mono);
+  font-size: var(--fs-2xs, 11px);
+  color: var(--text-mute, #8a8270);
 }
 
 // --- sortable column-header row (table head) ---

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -145,32 +145,49 @@
   display: flex;
   align-items: center;
 }
-// The discs are the shared Vellum <Pips> (`.pips.sm .pip` — same as the spell cast
-// rows). The strip fills the row and clips so an oversized run is measured and swaps
-// to the Use pill; the interactive states below are the only pip CSS we add, since
-// ours render as tick-off buttons.
+// The dots are the shared Vellum <Pips square sm>; we only re-tint them brass (the
+// shared default is gold) and tighten the gap so the squares sit near-adjacent.
 .osc-inv .osc-inv-pips {
   flex: 1;
   min-width: 0;
+  gap: 1px;
   overflow: hidden;
 }
-.osc-inv button.pip {
+.osc-inv .osc-inv-pips .pip {
+  background: transparent;
+  border-color: var(--accent-alt, #c89e54);
+  opacity: 0.5;
+}
+.osc-inv .osc-inv-pips .pip.filled {
+  background: var(--accent-alt, #c89e54);
+  opacity: 1;
+}
+// The whole pip strip is ONE button — clicking anywhere on it consumes one.
+.osc-inv .osc-inv-usebtn {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  align-items: center;
+  padding: 0;
+  background: transparent;
+  border: none;
   cursor: pointer;
-  transition: filter 0.12s;
-  &:hover:not(:disabled) {
-    filter: brightness(1.2);
-  }
   &:disabled {
-    cursor: not-allowed;
+    cursor: default;
   }
   &:focus-visible {
     outline: 2px solid var(--gold);
-    outline-offset: 1px;
+    outline-offset: 2px;
+    border-radius: var(--r-sm, 4px);
   }
 }
-// Overflow: hide the pips (kept measurable via visibility) and surface the fallback.
+// Overflow: hide the pips (kept measurable via visibility) and neutralise the strip
+// button so the absolutely-positioned Use fallback owns the clicks.
 .osc-inv .osc-inv-uses[data-overflow] .osc-inv-pips {
   visibility: hidden;
+}
+.osc-inv .osc-inv-uses[data-overflow] .osc-inv-usebtn {
+  pointer-events: none;
 }
 .osc-inv .osc-inv-use1,
 .osc-inv .osc-inv-uses-count {

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -185,23 +185,16 @@
   top: 50%;
   transform: translateY(-50%);
 }
-.osc-inv .osc-inv-use1 {
+// Both "Use" affordances (pip-overflow fallback + xs inline) are a plain brass text
+// link on the shared InlineButton base (`.inline-btn` — no pill/border/bg), not a pill.
+.osc-inv .osc-inv-use {
   font-family: var(--sans);
-  font-size: var(--fs-3xs, 10px);
+  font-size: var(--fs-2xs, 11px);
   font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
   color: var(--accent-alt, #c89e54);
-  background: transparent;
-  border: 1px solid var(--accent-alt, #c89e54);
-  border-radius: 999px;
-  padding: 2px var(--spacer-2);
-  cursor: pointer;
-  transition:
-    background 0.12s,
-    color 0.12s;
   &:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--accent-alt, #c89e54) 15%, transparent);
+    color: var(--accent-alt, #c89e54);
+    text-decoration: underline;
   }
   &:disabled {
     opacity: 0.4;
@@ -214,33 +207,11 @@
   color: var(--text-mute, #8a8270);
 }
 
-// xs inline "Use" pill on the item row (name column). Hidden until the xs
-// container query swaps out the pip sub-row; same brass pill as the Use fallback.
+// xs inline "Use" link on the item row (name column). Hidden until the xs container
+// query swaps out the pip sub-row; look comes from `.osc-inv-use` + `.inline-btn`.
 .osc-inv .osc-inv-useinline {
   display: none;
   flex: none;
-  align-items: center;
-  font-family: var(--sans);
-  font-size: var(--fs-3xs, 10px);
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--accent-alt, #c89e54);
-  background: transparent;
-  border: 1px solid var(--accent-alt, #c89e54);
-  border-radius: 999px;
-  padding: 2px var(--spacer-2);
-  cursor: pointer;
-  transition:
-    background 0.12s,
-    color 0.12s;
-  &:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--accent-alt, #c89e54) 15%, transparent);
-  }
-  &:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-  }
 }
 
 // --- sortable column-header row (table head) ---

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -101,7 +101,7 @@
 
 .osc-inv-row {
   display: grid;
-  grid-template-columns: 18px 30px 1fr 52px 52px 44px;
+  grid-template-columns: 18px 30px 1fr 52px 44px 44px;
   align-items: center;
   gap: var(--spacer-2);
   padding: var(--spacer-2) var(--spacer-1);
@@ -300,8 +300,8 @@
   }
 }
 // Right-aligned columns (Type, Wt): shrink the header to the cell's right edge and
-// move the sort caret left of the label (order, not row-reverse — keeps "Wt (cn)"
-// reading order), so the label sits flush over its right-aligned data.
+// move the sort caret left of the label (order, not row-reverse), so the label sits
+// flush over its right-aligned data.
 .osc-inv .osc-inv-th-wt,
 .osc-inv .osc-inv-th-cat {
   justify-self: end;
@@ -309,12 +309,6 @@
 .osc-inv .osc-inv-th-wt .osc-inv-th-caret,
 .osc-inv .osc-inv-th-cat .osc-inv-th-caret {
   order: -1;
-}
-.osc-inv .osc-inv-th-unit {
-  text-transform: none;
-  font-weight: 500;
-  letter-spacing: 0;
-  opacity: 0.75;
 }
 // "Item" header spans the image + name columns so it starts at the image edge
 .osc-inv .osc-inv-th-item {
@@ -536,7 +530,7 @@
 // the "Uses" pip sub-row for the inline Use pill on the item row.
 @container app (max-width: 479px) {
   .osc-inv-row {
-    grid-template-columns: 18px 30px 1fr 52px 44px;
+    grid-template-columns: 18px 30px 1fr 44px 44px;
   }
   .osc-inv-rowcat,
   .osc-inv .osc-inv-th-cat {

--- a/src/OscSheet/styles/vellum/components.css
+++ b/src/OscSheet/styles/vellum/components.css
@@ -564,6 +564,8 @@
 .pip.filled { background: var(--gold); border-color: var(--gold); }
 /* sm — cast dots */
 .pips.sm .pip { width: 9px; height: 9px; }
+/* square — squared dots instead of the disc (e.g. inventory uses) */
+.pips.square .pip { border-radius: 2px; }
 /* hollow — bordered ring holding an optional glyph (slot pips) */
 .pips.hollow .pip {
   background: transparent;

--- a/src/OscSheet/styles/vellum/components.css
+++ b/src/OscSheet/styles/vellum/components.css
@@ -564,8 +564,8 @@
 .pip.filled { background: var(--gold); border-color: var(--gold); }
 /* sm — cast dots */
 .pips.sm .pip { width: 9px; height: 9px; }
-/* square — squared dots instead of the disc (e.g. inventory uses) */
-.pips.square .pip { border-radius: 2px; }
+/* square — sharp-cornered dots instead of the disc (e.g. inventory uses) */
+.pips.square .pip { border-radius: 0; }
 /* hollow — bordered ring holding an optional glyph (slot pips) */
 .pips.hollow .pip {
   background: transparent;

--- a/src/OscSheet/styles/vellum/tokens.scss
+++ b/src/OscSheet/styles/vellum/tokens.scss
@@ -950,6 +950,12 @@ body {
 .btn.danger:hover:not(:disabled) { background: oklch(0.56 0.15 25 / 0.15); }
 .btn.ghost { background: transparent; border-color: var(--border-soft); color: var(--text-dim); }
 .btn.sm { font-size: var(--fs-3xs); padding: 5px 9px 4px; }
+.btn.xs {
+  font-size: var(--fs-3xs);
+  line-height: 1;
+  padding: 3px 7px 2px;
+  letter-spacing: 0.06em;
+}
 
 /* Colored outline tones — compose with variant="outline" (e.g. tone="brass" for
    the brass-gold Attack button). Tone names match the Vellum color vocabulary;


### PR DESCRIPTION
Inline quantity control for stacked/consumable items — the "little boxes to tick off" from the OG sheets.

- Stackable rows grow a **"Uses" sub-row** beneath the item: box pips (filled = remaining, brass `--accent-alt`; empty = outline up to `max`). Reads as one unit with the row.
- Click pip N → set qty to N; click the last filled pip → tick one off (reaches 0). Optimistic; encumbrance/movement recompute live.
- **Fit-based fallback:** a `ResizeObserver` measures the pip strip (scrollWidth vs clientWidth, mirroring HeaderBand's `useFitText`); when it can't fit, pips hide (kept measurable via `visibility`) and a **`Use 1`** pill takes over (one click = −1). Big stacks / narrow (xs) layouts show `Use 1`.
- VM: relaxed `hasQty` to gate on `max` so the control (and the right-click "Consume one") persists to the **last unit**, not just >1.
- `onSetQty(id, value)` added in SheetShell (optimistic `writeItem`, floored at 0); threaded through `index.tsx` → SortableRow/ContainerRow (children inherit it). Read-only renders static pips + a `value/total` count, no buttons.
- `×N` count tag stays on the item row; non-stacked items get no Uses row.
- a11y: pips are real buttons (`aria-label` "Set {name} to N", `aria-pressed`); `Use 1` labeled; keyboard-reachable.

Tests: relaxed `hasQty` predicate (last-unit stackable, singleton, max-less multi); UsesRow rendering, pip-click math (set / tick-off / stop-at-0), read-only static, Use-1 decrement + disable-at-0.

Verified: `pnpm build`, `pnpm lint`, `pnpm test` (178 passing) all green; rendered against the built CSS to confirm pips-fit / Use-1-overflow / read-only states.
