### PR TITLE
Load Advanced Fantasy classes without OSR Character Builder

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,7 @@ export function initialize() {
     logger("Initializing React application");
     migrateLocalStorage(); // every user; independent of the GM world pass
     await runWorldMigration();
-    installAdvancedClasses();
+    await installAdvancedClasses();
     registerSendItemSocket(); // GM relay for cross-owner "Send Item" transfers
 
     // Debug API. `crashTest()` throws a deliberate error inside any open OSC

--- a/src/util/adaptAdvancedClasses.ts
+++ b/src/util/adaptAdvancedClasses.ts
@@ -12,7 +12,7 @@ import logger from "@src/util/logger";
  */
 
 /** The advanced tome's raw per-class shape (only the fields we consume). */
-interface RawAdvancedClass {
+export interface RawAdvancedClass {
   /** Display name, e.g. "Bard". */
   menu: string;
   /** Slug, e.g. "bard" — fallback when `menu` is missing. */
@@ -111,27 +111,42 @@ type ClassesWithAdvanced = (typeof CONFIG.OSE)["classes"] & {
   advanced: Record<string, OseClass>;
 };
 
-/**
- * Boot-time adapter: if the advanced tome's raw class data is present, adapt
- * every class and store the result at `CONFIG.OSE.classes.advanced`. No-op when
- * the global is absent (tome not installed). Returns the count adapted.
- */
-export function installAdvancedClasses(): number {
-  const advanced = (globalThis as { OSE?: { data?: { classes?: { advanced?: Record<string, RawAdvancedClass> } } } })
-    .OSE?.data?.classes?.advanced;
-  if (!advanced || typeof advanced !== "object") {
-    logger("No OSE.data.classes.advanced found; skipping advanced class adapter");
-    return 0;
-  }
-
+/** Adapt a raw class map into `CONFIG.OSE.classes.advanced`; return the count. */
+function adaptInto(advanced: Record<string, RawAdvancedClass>): number {
   const classes = CONFIG.OSE.classes as ClassesWithAdvanced;
   const target: Record<string, OseClass> = (classes.advanced ??= {});
   for (const raw of Object.values(advanced)) {
     const def = adaptAdvancedClass(raw);
     target[def.name] = def;
   }
-
   const count = Object.keys(target).length;
   logger(`Adapted ${count} advanced classes into CONFIG.OSE.classes.advanced`);
   return count;
+}
+
+/**
+ * Boot-time adapter. Prefers the tome's raw class data on the `OSE` global (set
+ * only when OSR Character Builder is active); otherwise, if the Advanced Fantasy
+ * tome is installed, fetches and extracts the data straight from its script so
+ * advanced classes work without OSRCB. No-op when neither source is available.
+ * Returns the count adapted.
+ */
+export async function installAdvancedClasses(): Promise<number> {
+  const advanced = (globalThis as { OSE?: { data?: { classes?: { advanced?: Record<string, RawAdvancedClass> } } } })
+    .OSE?.data?.classes?.advanced;
+  if (advanced && typeof advanced === "object") {
+    return adaptInto(advanced);
+  }
+
+  if (game.modules?.get("ose-advancedfantasytome")?.active) {
+    const { fetchAdvancedClassesFromTome } = await import("@src/util/fetchTomeClassData");
+    const fetched = await fetchAdvancedClassesFromTome();
+    if (fetched) {
+      logger("Loaded advanced classes from the tome script (OSRCB not active)");
+      return adaptInto(fetched);
+    }
+  }
+
+  logger("No OSE.data.classes.advanced found; skipping advanced class adapter");
+  return 0;
 }

--- a/src/util/fetchTomeClassData.test.ts
+++ b/src/util/fetchTomeClassData.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { extractAdvancedClasses } from "@src/util/fetchTomeClassData";
+import { installAdvancedClasses } from "@src/util/adaptAdvancedClasses";
+
+// Mirrors the real tome wrapper: gated on an 'OSRCB initialized' hook + an
+// OSRCB-active check, merging class defs into OSE.data.classes.advanced. It also
+// references OSRCB (moduleName interpolation + spells.mergedList write) as the
+// real script does — so the sandbox must stub OSRCB or extraction throws.
+const tomeScript = `
+Hooks.once('OSRCB initialized', () => {
+  if (game.modules.get('osr-character-builder')?.active) {
+    OSE.data.classes = foundry.utils.mergeObject(OSE.data.classes || {}, {
+      classic: {},
+      advanced: {
+        acrobat: {
+          name: 'acrobat', menu: 'Acrobat', pack: 'ose-advancedfantasytome.abilities',
+          spellPackName: \`\${OSRCB.moduleName}.osr-srd-spells\`,
+          hdArr: ['1d4'], saves: { '1': [13,14,13,16,15] }, thac0: { '1': [19,0] },
+          xp: [], req: 'None', spellCaster: false, maxLvl: 1,
+        },
+        bard: {
+          name: 'bard', menu: 'Bard', pack: 'ose-advancedfantasytome.abilities',
+          hdArr: ['1d6'], saves: { '1': [13,14,13,16,15] }, thac0: { '1': [19,0] },
+          xp: [], req: 'Minimum DEX 9', spellCaster: false, maxLvl: 1,
+        },
+      },
+    });
+    OSRCB.spells.mergedList = foundry.utils.mergeObject(OSRCB.spells.mergedList, OSE.spellList || {});
+  }
+});
+`;
+
+describe("extractAdvancedClasses", () => {
+  it("returns the advanced class map from a tome-shaped script", () => {
+    const advanced = extractAdvancedClasses(tomeScript);
+    expect(advanced).not.toBeNull();
+    expect(Object.keys(advanced!).sort()).toEqual(["acrobat", "bard"]);
+    expect(advanced!.acrobat.menu).toBe("Acrobat");
+    expect(advanced!.bard.req).toBe("Minimum DEX 9");
+  });
+
+  it("returns null for malformed script text without throwing", () => {
+    expect(extractAdvancedClasses("this is ( not valid javascript {{{")).toBeNull();
+  });
+
+  it("returns null when the script references an unstubbed global (isolation)", () => {
+    const advanced = extractAdvancedClasses(
+      "window.location.href = 'x'; document.title = 'y';",
+    );
+    expect(advanced).toBeNull();
+  });
+
+  it("returns null when the script sets no advanced classes", () => {
+    expect(extractAdvancedClasses("OSE.data.classes = { classic: {} };")).toBeNull();
+  });
+});
+
+describe("installAdvancedClasses", () => {
+  beforeEach(() => {
+    (globalThis as unknown as { CONFIG: unknown }).CONFIG = {
+      OSE: { classes: { advanced: {} } },
+    };
+  });
+  afterEach(() => {
+    delete (globalThis as unknown as { CONFIG?: unknown }).CONFIG;
+    delete (globalThis as unknown as { OSE?: unknown }).OSE;
+    vi.restoreAllMocks();
+  });
+
+  it("uses the existing global and does not fetch when it is present", async () => {
+    (globalThis as unknown as { OSE: unknown }).OSE = {
+      data: {
+        classes: {
+          advanced: {
+            acrobat: {
+              name: "acrobat",
+              menu: "Acrobat",
+              pack: "p",
+              hdArr: ["1d4"],
+              saves: { "1": [13, 14, 13, 16, 15] },
+              thac0: { "1": [19, 0] },
+              xp: [],
+              req: "None",
+              spellCaster: false,
+              maxLvl: 1,
+            },
+          },
+        },
+      },
+    };
+    const fetchSpy = vi.fn();
+    (globalThis as unknown as { fetch: unknown }).fetch = fetchSpy;
+
+    const count = await installAdvancedClasses();
+
+    expect(count).toBe(1);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const classes = (globalThis as unknown as {
+      CONFIG: { OSE: { classes: { advanced: Record<string, { name: string }> } } };
+    }).CONFIG.OSE.classes.advanced;
+    expect(classes.Acrobat.name).toBe("Acrobat");
+  });
+});

--- a/src/util/fetchTomeClassData.ts
+++ b/src/util/fetchTomeClassData.ts
@@ -1,0 +1,61 @@
+import type { RawAdvancedClass } from "@src/util/adaptAdvancedClasses";
+import logger from "@src/util/logger";
+
+const TOME_SCRIPT = "modules/ose-advancedfantasytome/scripts/classData.js";
+
+type MergeObject = (a: Record<string, unknown>, b: Record<string, unknown>) => Record<string, unknown>;
+
+function mergeObjectFallback(): MergeObject {
+  const real = (globalThis as { foundry?: { utils?: { mergeObject?: MergeObject } } })
+    .foundry?.utils?.mergeObject;
+  if (real) return real;
+  return (a, b) => Object.assign(a ?? {}, b);
+}
+
+/**
+ * Run the tome's `classData.js` in an isolated sandbox to extract its advanced
+ * class map. The script gates its data behind an `'OSRCB initialized'` hook and
+ * an OSRCB-active check; the stubs below satisfy both without OSRCB installed.
+ * Never throws — returns `null` on any failure.
+ */
+export function extractAdvancedClasses(
+  scriptText: string,
+): Record<string, RawAdvancedClass> | null {
+  try {
+    const Hooks = {
+      once: (name: string, cb: () => void) => {
+        if (name === "OSRCB initialized") cb();
+      },
+      on() {},
+      call() {},
+      callAll() {},
+    };
+    const game = { modules: { get: () => ({ active: true }) } };
+    const OSE: { data: { classes?: { advanced?: Record<string, RawAdvancedClass> } } } = { data: {} };
+    const foundry = { utils: { mergeObject: mergeObjectFallback() } };
+    // Script interpolates OSRCB.moduleName into pack refs and writes OSRCB.spells.mergedList.
+    const OSRCB = { moduleName: "osr-character-builder", spells: { mergedList: {} } };
+
+    new Function("Hooks", "game", "OSE", "foundry", "OSRCB", scriptText)(Hooks, game, OSE, foundry, OSRCB);
+
+    return OSE.data?.classes?.advanced ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch the Advanced Fantasy tome's `classData.js` and extract its advanced
+ * class map. Never throws — returns `null` on any failure.
+ */
+export async function fetchAdvancedClassesFromTome(): Promise<Record<string, RawAdvancedClass> | null> {
+  try {
+    const path = foundry.utils.getRoute(TOME_SCRIPT);
+    const res = await fetch(path);
+    if (!res.ok) return null;
+    return extractAdvancedClasses(await res.text());
+  } catch (err) {
+    logger("Failed to fetch advanced tome class data", err);
+    return null;
+  }
+}


### PR DESCRIPTION
The Advanced Fantasy tome registers its class data only behind an OSRCB-gated hook, so advanced classes were missing unless OSR Character Builder was active. Sandbox-eval the tome's `classData.js` to extract the advanced class map directly.

Verified live (OSRCB disabled): all 15 advanced classes populate alongside the 7 classic. Tests/build/lint green.