### PR TITLE
fix(inventory): treasure rows carry item drag-data for Item Piles (OSC-120)

### DIFF
--- a/src/OscSheet/features/inventory/WealthRow.tsx
+++ b/src/OscSheet/features/inventory/WealthRow.tsx
@@ -5,7 +5,7 @@
 import type { WealthRow as WealthRowVM } from "@domain/vm-types";
 import { ItemImage } from "@features/inventory/ItemImage";
 import { fmtCoin } from "@features/inventory/fmtCoin";
-import type { Dnd, OnContext } from "@features/inventory/types";
+import type { Dnd, ItemDragData, OnContext } from "@features/inventory/types";
 import { cx } from "@ui/cx";
 
 export function WealthRow({
@@ -13,6 +13,7 @@ export function WealthRow({
   index,
   canEdit,
   dnd,
+  itemDragData,
   inputValue,
   onOpen,
   onContext,
@@ -25,6 +26,9 @@ export function WealthRow({
   index: number;
   canEdit: boolean;
   dnd: Dnd;
+  /** Foundry item drag-data for this row (coins/valuables are real items) so a drag
+   *  carries `{type:"Item",uuid,…}` — droppable onto the hotbar and Item Piles. */
+  itemDragData: ItemDragData;
   /** Controlled coin-input value (draft-aware); coin rows only. */
   inputValue?: string;
   onOpen: (id: string) => void;
@@ -36,7 +40,7 @@ export function WealthRow({
   const isCoin = row.kind === "coin";
   // One dnd list for the whole table: every row both initiates and receives a
   // drag through the same mechanism, so coins and valuables reorder identically.
-  const rp = dnd.rowProps("wealth", index);
+  const rp = dnd.rowProps("wealth", index, { dragPayload: () => itemDragData(row.id) });
   return (
     <div
       className={cx("osc-coin-row", dnd.rowClass("wealth", index))}

--- a/src/OscSheet/features/inventory/WealthSection.tsx
+++ b/src/OscSheet/features/inventory/WealthSection.tsx
@@ -10,7 +10,7 @@ import { useDragReorder } from "@features/inventory/useDragReorder";
 import { WealthRow } from "@features/inventory/WealthRow";
 import { fmtCoin } from "@features/inventory/fmtCoin";
 import { SortHeader } from "@features/inventory/SortHeader";
-import type { OnContext } from "@features/inventory/types";
+import type { ItemDragData, OnContext } from "@features/inventory/types";
 import { useOscSheetContext } from "@app/context";
 import { Button } from "@ui/Button";
 import { cx } from "@ui/cx";
@@ -26,12 +26,15 @@ import { cx } from "@ui/cx";
 export function WealthSection({
   wealth,
   onSetCoin,
+  itemDragData,
   onOpen,
   onContext,
 }: {
   /** Unified row list: coins (canonical order) then non-coin valuables. */
   wealth: WealthRowVM[];
   onSetCoin: (id: string, value: number) => void;
+  /** Foundry item drag-data per row id — lets treasure rows drop onto the hotbar / Item Piles. */
+  itemDragData: ItemDragData;
   /** Click a coin/valuable name → open its item sheet (like an item row). */
   onOpen: (id: string) => void;
   /** Right-click a row → the shared item context menu (View / Delete). */
@@ -185,6 +188,7 @@ export function WealthSection({
                 index={i}
                 canEdit={canEdit}
                 dnd={dnd}
+                itemDragData={itemDragData}
                 inputValue={draft[row.denom] ?? String(row.qty)}
                 onOpen={onOpen}
                 onContext={onContext}
@@ -199,6 +203,7 @@ export function WealthSection({
                 index={i}
                 canEdit={canEdit}
                 dnd={dnd}
+                itemDragData={itemDragData}
                 onOpen={onOpen}
                 onContext={onContext}
               />

--- a/src/OscSheet/features/inventory/index.tsx
+++ b/src/OscSheet/features/inventory/index.tsx
@@ -281,6 +281,7 @@ export function InventoryView({
       <WealthSection
         wealth={wealth}
         onSetCoin={onSetCoin}
+        itemDragData={itemDragData}
         onOpen={onOpen}
         onContext={openMenu}
       />


### PR DESCRIPTION
Treasure-table coin and valuable rows now attach Foundry item drag-data (`{type:"Item",uuid,…}`) via a `dragPayload`, so dragging a coin/gem onto the hotbar or an Item Piles container is accepted instead of silently rejected.

Minimal fix on the existing drag API — no drag-UX refactor here.

Fixes #100.