### PR TITLE
Inventory drag polish: stable drop line + drag cursor (OSC-126)

### DIFF
--- a/src/OscSheet/features/inventory/EquippedTray.tsx
+++ b/src/OscSheet/features/inventory/EquippedTray.tsx
@@ -117,7 +117,13 @@ export function EquippedTray({
           : undefined
       }
     >
-      {items.map((item, i) => (
+      {items.map((item, i) => {
+        const rp = dnd.rowProps(EQUIPPED, i, {
+          ownZone: EQUIPPED,
+          axis: "x",
+          dragPayload: () => itemDragData(item.id),
+        });
+        return (
         <div
           key={item.id}
           className={cx(
@@ -126,11 +132,7 @@ export function EquippedTray({
             dnd.rowClass(EQUIPPED, i),
           )}
           onContextMenu={(e) => onContext(e, item)}
-          {...dnd.rowProps(EQUIPPED, i, {
-            ownZone: EQUIPPED,
-            axis: "x",
-            dragPayload: () => itemDragData(item.id),
-          })}
+          {...rp}
         >
           <button
             type="button"
@@ -173,7 +175,8 @@ export function EquippedTray({
             )}
           </span>
         </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/src/OscSheet/features/inventory/ItemImage.tsx
+++ b/src/OscSheet/features/inventory/ItemImage.tsx
@@ -3,11 +3,17 @@ import { Monogram } from "@ui/Monogram";
 /** Inventory thumbnail: the item's art in an ink-black rounded square, or a
  *  monogram fallback. Shared by item rows and the wealth coin table so coins get
  *  identical treatment. Owns the `.osc-inv-img` box; routes the art-or-letter
- *  branch through Monogram. */
+ *  branch through Monogram. The inner <img> is `draggable={false}` so grabbing it
+ *  doesn't start a native image-drag — the whole row owns the drag. */
 export function ItemImage({ img, monogram }: { img: string; monogram: string }) {
   return (
     <span className="osc-inv-img" aria-hidden="true">
-      <Monogram img={img} monogram={monogram} className={img ? "" : "mono"} />
+      <Monogram
+        img={img}
+        monogram={monogram}
+        className={img ? "" : "mono"}
+        draggable={false}
+      />
     </span>
   );
 }

--- a/src/OscSheet/features/inventory/WealthRow.tsx
+++ b/src/OscSheet/features/inventory/WealthRow.tsx
@@ -38,27 +38,26 @@ export function WealthRow({
   onQtyCommitClose?: () => void;
 }) {
   const isCoin = row.kind === "coin";
-  // One dnd list for the whole table: every row both initiates and receives a
-  // drag through the same mechanism, so coins and valuables reorder identically.
-  const rp = dnd.rowProps("wealth", index, { dragPayload: () => itemDragData(row.id) });
+  // One dnd list for the whole table: the whole row is draggable and a drop
+  // target — so coins and valuables reorder identically to item rows.
+  const rp = dnd.rowProps("wealth", index, {
+    dragPayload: () => itemDragData(row.id),
+  });
   return (
     <div
       className={cx("osc-coin-row", dnd.rowClass("wealth", index))}
-      onDragOver={rp.onDragOver}
-      onDrop={rp.onDrop}
-      onDragEnd={rp.onDragEnd}
+      {...rp}
       // coins/valuables are real items: right-click → View / Delete (no equip/consume)
       onContextMenu={(e) =>
-        onContext(e, { id: row.id, name: row.name, equipped: null, quantity: null })
+        onContext(e, {
+          id: row.id,
+          name: row.name,
+          equipped: null,
+          quantity: null,
+        })
       }
     >
-      <span
-        className="osc-inv-drag"
-        title="Drag to reorder"
-        draggable={canEdit}
-        onDragStart={rp.onDragStart}
-        onDragEnd={rp.onDragEnd}
-      >
+      <span className="osc-inv-drag" title="Drag to reorder">
         <i className="fa-solid fa-grip-lines" aria-hidden="true" />
       </span>
       <ItemImage img={row.img} monogram={row.monogram} />
@@ -89,7 +88,9 @@ export function WealthRow({
           disabled={!canEdit}
           onChange={(e) => onQtyChange?.(e.target.value)}
           onFocus={(e) => e.currentTarget.select()}
-          onKeyDown={(e) => { if (e.key === "Enter") onQtyCommitClose?.(); }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") onQtyCommitClose?.();
+          }}
           onBlur={() => onQtyCommit?.()}
         />
       ) : (

--- a/src/OscSheet/features/inventory/dragHandle.test.tsx
+++ b/src/OscSheet/features/inventory/dragHandle.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+// Whole-row drag + treasure drag payload:
+//  - treasure (coin/valuable) rows must put Foundry item JSON on text/plain (not the
+//    `wealth:<idx>` reorder token) so drops land in Item Piles / the hotbar (#100);
+//  - the whole item row is the drag initiator (and stays a drop target).
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { OscSheetContext } from "@app/context";
+import { useDragReorder } from "@features/inventory/useDragReorder";
+import { WealthRow } from "@features/inventory/WealthRow";
+import { SortableRow } from "@features/inventory/rows/SortableRow";
+import { ROOT } from "@features/inventory/groups";
+import type { CoinWealthRow, InventoryItemVM } from "@domain/vm-types";
+import type { OscSheetContextValue } from "@domain/types";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const coin: CoinWealthRow = {
+  kind: "coin", id: "gp", denom: "GP", gpEach: 1, name: "Gold Pieces",
+  img: "", monogram: "GP", qty: 5, weight: 5, value: 5,
+};
+
+const mkItem = (id: string): InventoryItemVM => ({
+  id, name: id, img: "", category: "Gear", categoryRank: 2, damage: "", tags: [],
+  monogram: id[0]!, weight: 1, cost: 0, armorClass: null, sort: 100, equippedSort: 100,
+  equipped: false, quantity: null, isContainer: false, children: [],
+});
+
+const noop = () => {};
+const ctx = { canEdit: true } as OscSheetContextValue;
+
+let container: HTMLDivElement;
+let root: Root;
+
+const transfer = () => ({
+  setData: vi.fn(), setDragImage: vi.fn(), effectAllowed: "", dropEffect: "",
+});
+
+// jsdom has no DragEvent; a bubbling Event + a dataTransfer stub drives React's
+// synthetic drag handlers.
+function fire(el: Element, type: string, dt: ReturnType<typeof transfer>) {
+  const e = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(e, "dataTransfer", { value: dt });
+  act(() => { el.dispatchEvent(e); });
+}
+
+const render = (node: React.ReactNode) =>
+  act(() => root.render(<OscSheetContext.Provider value={ctx}>{node}</OscSheetContext.Provider>));
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function WealthHarness({ itemDragData }: { itemDragData: (id: string) => string | undefined }) {
+  const dnd = useDragReorder({ enabled: true, onReorder: noop });
+  return (
+    <WealthRow
+      row={coin} index={0} canEdit dnd={dnd} itemDragData={itemDragData}
+      inputValue="5" onOpen={noop} onContext={noop}
+      onQtyChange={noop} onQtyCommit={noop} onQtyCommitClose={noop}
+    />
+  );
+}
+
+describe("treasure row drag payload (#100)", () => {
+  it("writes the Foundry item JSON on text/plain, not the wealth:<idx> token", () => {
+    const json = '{"type":"Item","uuid":"Actor.a.Item.gp"}';
+    const itemDragData = vi.fn(() => json);
+    render(<WealthHarness itemDragData={itemDragData} />);
+    const grip = container.querySelector(".osc-inv-drag")!;
+    const dt = transfer();
+    fire(grip, "dragstart", dt);
+    expect(itemDragData).toHaveBeenCalledWith("gp");
+    expect(dt.setData).toHaveBeenCalledWith("text/plain", json);
+    expect(dt.setData).not.toHaveBeenCalledWith("text/plain", "wealth:0");
+  });
+});
+
+const onReorder = vi.fn();
+function ItemHarness() {
+  const dnd = useDragReorder({ enabled: true, onReorder, onNest: noop });
+  return (
+    <div>
+      {[mkItem("a"), mkItem("b")].map((item, i) => (
+        <SortableRow
+          key={item.id} item={item} index={i} group={ROOT} depth={0}
+          dnd={dnd} itemDragData={() => undefined} canEdit
+          onEquip={noop} onOpen={noop} onContext={noop} onSetQty={noop}
+        />
+      ))}
+    </div>
+  );
+}
+
+describe("SortableRow — the whole row is draggable", () => {
+  beforeEach(() => onReorder.mockClear());
+
+  it("marks the row draggable, not the grip", () => {
+    render(<ItemHarness />);
+    const rows = [...container.querySelectorAll(".osc-inv-row")];
+    expect(rows[0]!.getAttribute("draggable")).toBe("true");
+    expect(rows[0]!.querySelector(".osc-inv-drag")!.getAttribute("draggable")).toBeNull();
+  });
+
+  it("a dragstart on the row body initiates the drag; the row also receives the drop", () => {
+    render(<ItemHarness />);
+    const rows = [...container.querySelectorAll(".osc-inv-row")];
+    fire(rows[0]!, "dragstart", transfer());
+    fire(rows[1]!, "dragover", transfer());
+    fire(rows[1]!, "drop", transfer());
+    expect(onReorder).toHaveBeenCalledWith(expect.objectContaining({ group: ROOT, from: 0 }));
+  });
+});

--- a/src/OscSheet/features/inventory/dragNest.test.tsx
+++ b/src/OscSheet/features/inventory/dragNest.test.tsx
@@ -50,10 +50,11 @@ function Harness({ collapsed }: { collapsed: boolean }) {
   const byId = indexById(items);
   const noop = () => {};
   const drag = () => undefined;
+  // stand-in for an equipped-tray tile (whole-tile draggable): its drags must never nest
+  const tray = dnd.rowProps(EQUIPPED, 0, { axis: "x" });
   return (
     <div>
-      {/* stand-in for an equipped-tray tile: its drags must never nest */}
-      <div data-testid="tray" {...dnd.rowProps(EQUIPPED, 0, { axis: "x" })} />
+      <div data-testid="tray" {...tray} />
       <SortableRow
         item={rope}
         index={0}
@@ -110,8 +111,11 @@ function fire(el: Element, type: string) {
   });
 }
 
+// The grip (.osc-inv-drag) is the drag initiator; a tray tile is draggable whole,
+// so fall back to the element itself when it has no grip.
 function dragOnto(source: Element, target: Element) {
-  fire(source, "dragstart");
+  const handle = source.querySelector(".osc-inv-drag") ?? source;
+  fire(handle, "dragstart");
   fire(target, "dragover");
   fire(target, "drop");
 }

--- a/src/OscSheet/features/inventory/rows/ContainerRow.tsx
+++ b/src/OscSheet/features/inventory/rows/ContainerRow.tsx
@@ -39,6 +39,15 @@ export function ContainerRow({
 }) {
   const group = gkey(item.id);
   const count = item.children.length;
+  // The whole header row is draggable; it reorders among root items AND accepts
+  // items dropped onto it (nest).
+  const rp = dnd.rowProps(ROOT, index, {
+    container: true,
+    containerZone: item.id,
+    ownZone: ROOT,
+    acceptCrossGroup: (from) => from !== EQUIPPED,
+    dragPayload: () => itemDragData(item.id),
+  });
   // Open or shut, the whole container is one nest target: its header row, its child
   // rows, and (when empty) its body all resolve to a drop-into on this container.
   const isDropTarget =
@@ -57,7 +66,6 @@ export function ContainerRow({
 
   return (
     <div className={cx("osc-inv-container", isDropTarget && "is-drop-target")}>
-      {/* The header row reorders among root items AND accepts items dropped onto it (nest). */}
       <div
         className={cx(
           "osc-inv-row",
@@ -66,13 +74,7 @@ export function ContainerRow({
           dnd.rowClass(ROOT, index),
         )}
         onContextMenu={(e) => onContext(e, item)}
-        {...dnd.rowProps(ROOT, index, {
-          container: true,
-          containerZone: item.id,
-          ownZone: ROOT,
-          acceptCrossGroup: (from) => from !== EQUIPPED,
-          dragPayload: () => itemDragData(item.id),
-        })}
+        {...rp}
       >
         <span className="osc-inv-drag" aria-hidden="true">
           <i className="fa-solid fa-grip-lines" />

--- a/src/OscSheet/features/inventory/rows/SortableRow.tsx
+++ b/src/OscSheet/features/inventory/rows/SortableRow.tsx
@@ -144,31 +144,29 @@ export function SortableRow({
   onContext: OnContext;
   onSetQty: (id: string, value: number) => void;
 }) {
-  // No handle: the whole row is draggable. Clicks on the inner buttons/inputs still
-  // fire (a click is a press without movement), so name/equip/qty stay interactive.
+  // The whole row is draggable (and stays a drop target). Clicks on the inner
+  // buttons/inputs still fire — a click is a press without movement — so
+  // name/equip/qty stay interactive.
+  // Root rows accept a container child dropped among them (un-nest); a container's
+  // child rows accept a foreign item (nest into that container). Neither accepts a
+  // tray tile — equipped-tray drags onto the list are routed to unequip instead.
+  const rp = dnd.rowProps(group, index, {
+    ownZone: group,
+    nestZone,
+    acceptCrossGroup: (from) => from !== EQUIPPED,
+    dragPayload: () => itemDragData(item.id),
+  });
   return (
     <>
       <div
-        className={cx(
-          "osc-inv-row",
-          "is-sortable",
-          dnd.rowClass(group, index),
-        )}
+        className={cx("osc-inv-row", "is-sortable", dnd.rowClass(group, index))}
         style={
           depth > 0
             ? ({ "--osc-inv-depth": depth } as React.CSSProperties)
             : undefined
         }
         onContextMenu={(e) => onContext(e, item)}
-        // Root rows accept a container child dropped among them (un-nest); a container's
-        // child rows accept a foreign item (nest into that container). Neither accepts a
-        // tray tile — equipped-tray drags onto the list are routed to unequip instead.
-        {...dnd.rowProps(group, index, {
-          ownZone: group,
-          nestZone,
-          acceptCrossGroup: (from) => from !== EQUIPPED,
-          dragPayload: () => itemDragData(item.id),
-        })}
+        {...rp}
       >
         <span className="osc-inv-drag" aria-hidden="true">
           <i className="fa-solid fa-grip-lines" />

--- a/src/OscSheet/features/inventory/useDragReorder.ts
+++ b/src/OscSheet/features/inventory/useDragReorder.ts
@@ -8,15 +8,39 @@
 //
 // Reorders are constrained to a single `group` (items in different groups can't
 // interleave); nesting (into / out of a container) is intentionally cross-group.
-import { useState, type DragEvent } from "react";
+import { useRef, useState, type DragEvent } from "react";
 
 export type DropWhere = "before" | "after" | "into";
 
 type DragState = { group: string; idx: number };
 type OverState = { group: string; idx: number; where: DropWhere };
 
-export type ReorderArgs = { group: string; from: number; to: number; where: DropWhere; targetIdx: number; zone?: string };
-export type NestArgs = { fromGroup: string; from: number; targetIdx: number; zone: string | null };
+// Effective insertion index for a reorder drop; -1 for a container "into" drop.
+const dropIndex = (o: OverState): number =>
+  o.where === "into" ? -1 : o.where === "after" ? o.idx + 1 : o.idx;
+
+// Two `over` states preview the SAME drop: same group and same effective target
+// ("after N" ≡ "before N+1"; "into" matches only "into" on the same row).
+const sameDropPosition = (a: OverState, b: OverState): boolean =>
+  a.group === b.group &&
+  (a.where === "into" || b.where === "into"
+    ? a.where === "into" && b.where === "into" && a.idx === b.idx
+    : dropIndex(a) === dropIndex(b));
+
+export type ReorderArgs = {
+  group: string;
+  from: number;
+  to: number;
+  where: DropWhere;
+  targetIdx: number;
+  zone?: string;
+};
+export type NestArgs = {
+  fromGroup: string;
+  from: number;
+  targetIdx: number;
+  zone: string | null;
+};
 
 type RowOpts = {
   /** This row is also a drop-into target (a container). */
@@ -45,6 +69,7 @@ type RowOpts = {
   onEnd?: () => void;
 };
 
+/** The whole row is draggable AND a drop target — one flat set of DnD handlers. */
 type Handlers = {
   draggable?: boolean;
   onDragStart?: (e: DragEvent<HTMLElement>) => void;
@@ -53,31 +78,48 @@ type Handlers = {
   onDrop?: (e: DragEvent<HTMLElement>) => void;
 };
 
-export function useDragReorder(opts: {
-  onReorder?: (a: ReorderArgs) => void;
-  onNest?: (a: NestArgs) => void;
-  /** When false (read-only sheet), the whole hook is inert: rows aren't
-   *  draggable and reject drops, so no reorder/nest can fire. Default true. */
-  enabled?: boolean;
-} = {}) {
+export function useDragReorder(
+  opts: {
+    onReorder?: (a: ReorderArgs) => void;
+    onNest?: (a: NestArgs) => void;
+    /** When false (read-only sheet), the whole hook is inert: rows aren't
+     *  draggable and reject drops, so no reorder/nest can fire. Default true. */
+    enabled?: boolean;
+  } = {},
+) {
   const { onReorder, onNest, enabled = true } = opts;
   const [drag, setDrag] = useState<DragState | null>(null);
   const [over, setOver] = useState<OverState | null>(null);
-  const clear = () => { setDrag(null); setOver(null); };
+  // Sheet root flagged for the drag's lifetime so the grabbing cursor persists
+  // everywhere, not just while the pointer is still pressing the source row.
+  const dndHost = useRef<HTMLElement | null>(null);
+  const clear = () => {
+    setDrag(null);
+    setOver(null);
+    dndHost.current?.classList.remove("osc-dnd-active");
+    dndHost.current = null;
+  };
 
   // before/after from the pointer's position within the hovered row, along `axis`
   const edgeWhere = (e: DragEvent<HTMLElement>, axis: "x" | "y"): DropWhere => {
     const r = e.currentTarget.getBoundingClientRect();
     return axis === "x"
-      ? e.clientX < r.left + r.width / 2 ? "before" : "after"
-      : e.clientY < r.top + r.height / 2 ? "before" : "after";
+      ? e.clientX < r.left + r.width / 2
+        ? "before"
+        : "after"
+      : e.clientY < r.top + r.height / 2
+        ? "before"
+        : "after";
   };
 
   // Whether this row accepts a cross-group drop from `fromGroup`.
   const accepts = (o: RowOpts, fromGroup: string): boolean =>
-    typeof o.acceptCrossGroup === "function" ? o.acceptCrossGroup(fromGroup) : !!o.acceptCrossGroup;
+    typeof o.acceptCrossGroup === "function"
+      ? o.acceptCrossGroup(fromGroup)
+      : !!o.acceptCrossGroup;
 
-  // Draggable + droppable row. Inert (non-draggable, drop-rejecting) when disabled.
+  // The whole row is draggable AND a drop target. Inert (non-draggable,
+  // drop-rejecting) when disabled.
   const rowProps = (group: string, idx: number, o: RowOpts = {}): Handlers => {
     if (!enabled) return { draggable: false };
     return {
@@ -86,10 +128,24 @@ export function useDragReorder(opts: {
         setDrag({ group, idx });
         e.dataTransfer.effectAllowed = "move";
         const payload = o.dragPayload?.() ?? `${group}:${idx}`;
-        try { e.dataTransfer.setData("text/plain", payload); } catch { /* IE guard */ }
+        try {
+          e.dataTransfer.setData("text/plain", payload);
+        } catch {
+          /* IE guard */
+        }
+        // Keep the grabbing cursor for the whole drag, not just over the source.
+        const host = e.currentTarget.closest<HTMLElement>(".osc-sheet-app");
+        if (host) {
+          host.classList.add("osc-dnd-active");
+          dndHost.current = host;
+        }
+        // Drag image: the browser's default (a snapshot of the dragged row).
         o.onStart?.();
       },
-      onDragEnd: () => { clear(); o.onEnd?.(); },
+      onDragEnd: () => {
+        clear();
+        o.onEnd?.();
+      },
       onDragOver: (e) => {
         if (!drag) return;
         const isSelf = drag.group === group && drag.idx === idx;
@@ -101,32 +157,64 @@ export function useDragReorder(opts: {
         const nestHere = crossGroup && !!o.nestZone; // a row inside a container: drop = nest into it
         e.preventDefault();
         e.dataTransfer.dropEffect = "move";
-        const where: DropWhere = into || nestHere ? "into" : edgeWhere(e, o.axis ?? "y");
-        if (!over || over.group !== group || over.idx !== idx || over.where !== where)
-          setOver({ group, idx, where });
+        const where: DropWhere =
+          into || nestHere ? "into" : edgeWhere(e, o.axis ?? "y");
+        const next = { group, idx, where };
+        // Only re-render the indicator when the *effective* drop position
+        // changes: "after N" and "before N+1" are the same insertion index, so
+        // the line stays put across that boundary instead of hopping.
+        if (!over || !sameDropPosition(over, next)) setOver(next);
       },
       onDrop: (e) => {
-        if (!drag) { clear(); return; }
+        if (!drag) {
+          clear();
+          return;
+        }
         const isSelf = drag.group === group && drag.idx === idx;
         const into = !!o.container && !isSelf;
         const crossGroup = !into && drag.group !== group;
-        if (crossGroup && !accepts(o, drag.group)) { clear(); return; }
+        if (crossGroup && !accepts(o, drag.group)) {
+          clear();
+          return;
+        }
         e.preventDefault();
         if (into) {
-          onNest?.({ fromGroup: drag.group, from: drag.idx, targetIdx: idx, zone: o.containerZone ?? null });
+          onNest?.({
+            fromGroup: drag.group,
+            from: drag.idx,
+            targetIdx: idx,
+            zone: o.containerZone ?? null,
+          });
         } else if (crossGroup && o.nestZone) {
-          onNest?.({ fromGroup: drag.group, from: drag.idx, targetIdx: idx, zone: o.nestZone });
+          onNest?.({
+            fromGroup: drag.group,
+            from: drag.idx,
+            targetIdx: idx,
+            zone: o.nestZone,
+          });
         } else if (crossGroup) {
           // Un-nest: drop the foreign row among this group's rows at the drop edge.
           // No self-shift — the item leaves a different group, so `to` isn't perturbed.
           const where: DropWhere = over ? over.where : "after";
           const to = where === "after" ? idx + 1 : idx;
-          onNest?.({ fromGroup: drag.group, from: drag.idx, targetIdx: to, zone: null });
+          onNest?.({
+            fromGroup: drag.group,
+            from: drag.idx,
+            targetIdx: to,
+            zone: null,
+          });
         } else {
           const where: DropWhere = over ? over.where : "after";
           let to = where === "after" ? idx + 1 : idx;
           if (drag.idx < to) to -= 1; // account for the gap the removed item leaves
-          onReorder?.({ group, from: drag.idx, to, where, targetIdx: idx, zone: o.ownZone });
+          onReorder?.({
+            group,
+            from: drag.idx,
+            to,
+            where,
+            targetIdx: idx,
+            zone: o.ownZone,
+          });
         }
         clear();
       },
@@ -135,20 +223,34 @@ export function useDragReorder(opts: {
 
   // Drop target for an empty container body (nest with no sibling rows to hover).
   // Inert (no drop handlers) when disabled.
-  const nestProps = (group: string, idx: number, zone: string | null): Pick<Handlers, "onDragOver" | "onDrop"> => {
+  const nestProps = (
+    group: string,
+    idx: number,
+    zone: string | null,
+  ): Pick<Handlers, "onDragOver" | "onDrop"> => {
     if (!enabled) return {};
     return {
       onDragOver: (e) => {
         if (!drag) return;
         e.preventDefault();
         e.dataTransfer.dropEffect = "move";
-        if (!over || over.group !== group || over.idx !== idx || over.where !== "into")
+        if (
+          !over ||
+          over.group !== group ||
+          over.idx !== idx ||
+          over.where !== "into"
+        )
           setOver({ group, idx, where: "into" });
       },
       onDrop: (e) => {
         if (!drag) return;
         e.preventDefault();
-        onNest?.({ fromGroup: drag.group, from: drag.idx, targetIdx: idx, zone });
+        onNest?.({
+          fromGroup: drag.group,
+          from: drag.idx,
+          targetIdx: idx,
+          zone,
+        });
         clear();
       },
     };
@@ -159,7 +261,12 @@ export function useDragReorder(opts: {
     let s = "";
     if (drag && drag.group === group && drag.idx === idx) s += " dragging";
     if (over && over.group === group && over.idx === idx)
-      s += over.where === "after" ? " drop-after" : over.where === "into" ? " drop-into" : " drop-before";
+      s +=
+        over.where === "after"
+          ? " drop-after"
+          : over.where === "into"
+            ? " drop-into"
+            : " drop-before";
     return s;
   };
 

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -112,21 +112,42 @@
   border-bottom: 1px solid var(--border-soft, #2c2823);
   transition: background 0.1s;
 
-  &.is-dragging,
-  &.dragging {
+  // Fade the row's content, not the row element itself — the drop insertion line
+  // is a box-shadow on the row, and a dragged row can also be the drop target
+  // (dragging + drop-after), so fading the element would render the teal line
+  // semi-transparent. Fading only children keeps the line solid.
+  &.is-dragging > *,
+  &.dragging > * {
     opacity: 0.4;
   }
   &.is-drop-target {
     border-bottom-color: var(--teal, #1f7575);
     background: color-mix(in srgb, var(--teal, #1f7575) 8%, transparent);
   }
-  // Insertion line — a 2px rule painted on the hovered row's leading/trailing edge.
-  // box-shadow (not border) so it overlays without shifting the grid: no reflow.
-  &.drop-before {
-    box-shadow: inset 0 2px 0 0 var(--teal, #1f7575);
-  }
+  // Insertion line — a single 2px rule centred on the row edge via an overlay
+  // pseudo-element (not box-shadow, which the row's border splits into a double
+  // line). "after N" and "before N+1" both land on the exact same border pixel,
+  // so it stays put until the insertion index actually changes — no hop, no
+  // reflow. The pseudo isn't a child, so the dragging fade (`> *`) leaves it solid.
+  &.drop-before,
   &.drop-after {
-    box-shadow: inset 0 -2px 0 0 var(--teal, #1f7575);
+    position: relative;
+  }
+  &.drop-before::before,
+  &.drop-after::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: var(--teal, #1f7575);
+    pointer-events: none;
+  }
+  &.drop-before::before {
+    top: -1px;
+  }
+  &.drop-after::after {
+    bottom: -1px;
   }
 }
 
@@ -307,7 +328,6 @@
   align-items: center;
   justify-content: center;
   color: var(--text-faint, #6a6354);
-  cursor: grab;
   font-size: var(--fs-xs, 12px);
   line-height: 1;
   padding: var(--spacer-1);
@@ -608,12 +628,19 @@
   background: color-mix(in oklab, var(--accent-alt) 9%, transparent);
 }
 
-// the whole row is draggable (buttons inside still take clicks)
-.osc-inv-row.is-sortable {
-  cursor: grab;
-  &:active {
-    cursor: grabbing;
-  }
+// The whole row is draggable, but reads as a normal row at rest — regular cursor
+// on hover, the grabbing fist only while a drag is held. Interactive children
+// (name button, qty input, equip/use controls) keep their own cursors.
+.osc-inv-row.is-sortable:active,
+.osc-coin-row:active {
+  cursor: grabbing;
+}
+// While a drag is in flight the source row is no longer under the pointer, so
+// :active drops — flag the sheet root for the drag's lifetime and force the
+// grabbing cursor everywhere until drop/end.
+.osc-sheet-app.osc-dnd-active,
+.osc-sheet-app.osc-dnd-active * {
+  cursor: grabbing !important;
 }
 
 // Dragging an equipped tray tile down into the list → unequip drop target.
@@ -766,13 +793,27 @@
   border-bottom: 1px solid var(--border-soft, #2c2823);
 }
 // drop-line affordance (matches the items rows)
-.osc-coin-row.drop-before {
-  box-shadow: inset 0 2px 0 0 var(--teal, #1f7575);
-}
+.osc-coin-row.drop-before,
 .osc-coin-row.drop-after {
-  box-shadow: inset 0 -2px 0 0 var(--teal, #1f7575);
+  position: relative;
 }
-.osc-coin-row.dragging {
+.osc-coin-row.drop-before::before,
+.osc-coin-row.drop-after::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--teal, #1f7575);
+  pointer-events: none;
+}
+.osc-coin-row.drop-before::before {
+  top: -1px;
+}
+.osc-coin-row.drop-after::after {
+  bottom: -1px;
+}
+.osc-coin-row.dragging > * {
   opacity: 0.4;
 }
 .osc-inv .osc-coin-qty {
@@ -993,14 +1034,12 @@
 .osc-equip-tcard {
   position: relative;
 }
-// tiles drag to reorder within the tray (own order)
-.osc-equip-tcard.is-sortable {
-  cursor: grab;
-  &:active {
-    cursor: grabbing;
-  }
+// tiles drag to reorder within the tray (own order) — regular at rest, the
+// grabbing fist only while a drag is held.
+.osc-equip-tcard.is-sortable:active {
+  cursor: grabbing;
 }
-.osc-equip-tcard.dragging {
+.osc-equip-tcard.dragging > * {
   opacity: 0.4;
 }
 // horizontal insertion line on the leading/trailing edge of the hovered tile (teal)


### PR DESCRIPTION
Whole-row draggable (grip + image), a stable drop insertion line that no longer hops across row boundaries, and a grab cursor only while dragging. Uses the browser's default drag ghost.