### PR TITLE
Custom class entry via Combobox (Edit modal)

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,6 @@
+<!-- Foundry provides Font Awesome at runtime; load it from a CDN so icon
+     classes (fa-solid …) render in Storybook too. -->
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.7.2/css/all.min.css"
+/>

--- a/src/OscSheet/components/ui/Combobox.stories.tsx
+++ b/src/OscSheet/components/ui/Combobox.stories.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import { Combobox, type ComboOption, type ComboboxProps } from "./Combobox";
+
+export default { title: "Controls / Combobox" };
+
+const CLASSES: ComboOption[] = [
+  { value: "assassin", label: "Assassin" },
+  { value: "bard", label: "Bard" },
+  { value: "cleric", label: "Cleric" },
+  { value: "druid", label: "Druid" },
+  { value: "fighter", label: "Fighter" },
+  { value: "magic-user", label: "Magic User" },
+  { value: "paladin", label: "Paladin" },
+  { value: "ranger", label: "Ranger" },
+  { value: "thief", label: "Thief" },
+];
+
+// Combobox is controlled (value + onCommit), so stories drive it with local state.
+function Demo({ initial = "", options = CLASSES, ...rest }: Partial<ComboboxProps> & { initial?: string }) {
+  const [v, setV] = useState(initial);
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 6, maxWidth: 280, minHeight: 300 }}>
+      <Combobox {...rest} value={v} options={options} onCommit={setV} placeholder={rest.placeholder ?? "Class…"} />
+      <span style={{ fontSize: 11, opacity: 0.6 }}>committed: {v || "—"}</span>
+    </div>
+  );
+}
+
+export const Default = () => <Demo />;
+export const Preselected = () => <Demo initial="fighter" />;
+export const CustomValue = () => <Demo initial="Warlock" />;
+export const EmptyOptions = () => <Demo options={[]} placeholder="Type to add a class…" />;
+export const Disabled = () => <Demo initial="cleric" disabled />;
+export const NoCreate = () => <Demo allowCreate={false} />;
+
+// The class-field configuration: leading hint before typing + "Custom: <x>" create row.
+export const CustomCreateLabel = () => (
+  <Demo newOptionLabel={(q) => `Custom: ${q}`} createHint="Type to add a custom class" />
+);
+
+// Per-option JSX via `node` (label still drives filtering + input text).
+export const RichOptions = () => (
+  <Demo
+    options={CLASSES.map((o) => ({
+      ...o,
+      node: (
+        <span style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
+          {o.label}
+          <em style={{ opacity: 0.5 }}>class</em>
+        </span>
+      ),
+    }))}
+  />
+);

--- a/src/OscSheet/components/ui/Combobox.test.tsx
+++ b/src/OscSheet/components/ui/Combobox.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Combobox, type ComboOption, type ComboboxProps } from "./Combobox";
+import { filterOptions, shouldShowCreate } from "./comboboxFilter";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const OPTIONS: ComboOption[] = [
+  { value: "assassin", label: "Assassin" },
+  { value: "cleric", label: "Cleric" },
+  { value: "fighter", label: "Fighter" },
+  { value: "magic-user", label: "Magic User" },
+];
+
+describe("filterOptions", () => {
+  it("returns all options for an empty query", () => {
+    expect(filterOptions(OPTIONS, "  ")).toHaveLength(OPTIONS.length);
+  });
+  it("narrows case-insensitively by label substring", () => {
+    expect(filterOptions(OPTIONS, "as").map((o) => o.value)).toEqual(["assassin"]);
+    expect(filterOptions(OPTIONS, "GHT").map((o) => o.value)).toEqual(["fighter"]);
+  });
+});
+
+describe("shouldShowCreate", () => {
+  it("hides on empty query, exact label match, or when disallowed", () => {
+    expect(shouldShowCreate(OPTIONS, "", true)).toBe(false);
+    expect(shouldShowCreate(OPTIONS, "fighter", true)).toBe(false); // exact (ci) match
+    expect(shouldShowCreate(OPTIONS, "Warlock", false)).toBe(false);
+  });
+  it("shows for a novel non-empty label", () => {
+    expect(shouldShowCreate(OPTIONS, "Warlock", true)).toBe(true);
+  });
+});
+
+// ── Interactive (jsdom) ───────────────────────────────────────────────
+let container: HTMLDivElement;
+let root: Root;
+const onCommit = vi.fn();
+
+function Harness(props: Partial<ComboboxProps>) {
+  const [v, setV] = useState(props.value ?? "");
+  return (
+    <Combobox
+      {...props}
+      value={v}
+      options={props.options ?? OPTIONS}
+      onCommit={(next) => { onCommit(next); setV(next); }}
+    />
+  );
+}
+
+const render = (props: Partial<ComboboxProps> = {}) =>
+  act(() => root.render(<Harness {...props} />));
+
+const input = () => container.querySelector("input") as HTMLInputElement;
+const rows = () => Array.from(container.querySelectorAll('[role="option"]')) as HTMLElement[];
+const optionRows = () => rows().filter((r) => !r.className.includes("combobox-create"));
+
+function setValue(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+  setter.call(el, value);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}
+const key = (el: HTMLElement, k: string) =>
+  el.dispatchEvent(new KeyboardEvent("keydown", { key: k, bubbles: true, cancelable: true }));
+
+beforeEach(() => {
+  onCommit.mockClear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("Combobox", () => {
+  it("filters options as the query narrows", () => {
+    render();
+    act(() => input().focus());
+    expect(rows()).toHaveLength(OPTIONS.length);
+    act(() => setValue(input(), "fig"));
+    expect(optionRows().map((r) => r.textContent)).toEqual(["Fighter"]);
+  });
+
+  it("commits the option's value (not its label) on click", () => {
+    render();
+    act(() => input().focus());
+    act(() => setValue(input(), "magic"));
+    act(() => rows()[0].click());
+    expect(onCommit).toHaveBeenCalledExactlyOnceWith("magic-user");
+  });
+
+  it("commits the trimmed typed text via the Create row", () => {
+    render();
+    act(() => input().focus());
+    act(() => setValue(input(), "  Warlock  "));
+    const create = rows().find((r) => r.className.includes("combobox-create"))!;
+    expect(create.textContent).toContain("Warlock");
+    act(() => create.click());
+    expect(onCommit).toHaveBeenCalledExactlyOnceWith("Warlock");
+  });
+
+  it("commits the highlighted option with ArrowDown + Enter", () => {
+    render();
+    act(() => input().focus());
+    act(() => key(input(), "ArrowDown")); // highlight moves 0 → 1 (Cleric)
+    act(() => key(input(), "Enter"));
+    expect(onCommit).toHaveBeenCalledExactlyOnceWith("cleric");
+  });
+
+  it("reverts to the committed value on Escape without committing", () => {
+    render({ value: "fighter" });
+    act(() => input().focus());
+    act(() => setValue(input(), "zzz"));
+    act(() => key(input(), "Escape"));
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(input().value).toBe("Fighter");
+  });
+
+  it("reverts on blur without committing typed text", () => {
+    render({ value: "cleric" });
+    act(() => input().focus());
+    act(() => setValue(input(), "Warl"));
+    act(() => input().blur());
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(input().value).toBe("Cleric");
+  });
+
+  it("hides the Create row when allowCreate is false", () => {
+    render({ allowCreate: false });
+    act(() => input().focus());
+    act(() => setValue(input(), "Warlock"));
+    expect(rows()).toHaveLength(0);
+    expect(rows().some((r) => r.className.includes("combobox-create"))).toBe(false);
+  });
+
+  it("renders a custom create-row label via newOptionLabel", () => {
+    render({ newOptionLabel: (q) => `Custom: ${q}` });
+    act(() => input().focus());
+    act(() => setValue(input(), "Warlock"));
+    const create = rows().find((r) => r.className.includes("combobox-create"))!;
+    expect(create.textContent).toContain("Custom: Warlock");
+    act(() => create.click());
+    expect(onCommit).toHaveBeenCalledExactlyOnceWith("Warlock");
+  });
+
+  it("renders a per-option node while filtering by label", () => {
+    const opts: ComboOption[] = OPTIONS.map((o) => ({ ...o, node: <span data-test={o.value}>{o.label} ·</span> }));
+    render({ options: opts });
+    act(() => input().focus());
+    act(() => setValue(input(), "fig"));
+    expect(optionRows()).toHaveLength(1);
+    expect(optionRows()[0].querySelector("[data-test=fighter]")).not.toBeNull();
+  });
+
+  it("highlights the current value when opened", () => {
+    render({ value: "fighter" });
+    act(() => input().focus());
+    const highlighted = rows().find((r) => r.className.includes("is-highlighted"));
+    expect(highlighted?.textContent).toBe("Fighter");
+  });
+
+  it("closes on re-click when untouched, keeping the value", () => {
+    render({ value: "fighter" });
+    act(() => input().focus()); // first focus opens
+    expect(container.querySelector(".combobox-pop")).not.toBeNull();
+    act(() => input().dispatchEvent(new MouseEvent("mousedown", { bubbles: true })));
+    expect(container.querySelector(".combobox-pop")).toBeNull();
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(input().value).toBe("Fighter");
+  });
+
+  it("blurs the input after a commit", () => {
+    render();
+    act(() => input().focus());
+    expect(document.activeElement).toBe(input());
+    act(() => setValue(input(), "magic"));
+    act(() => rows()[0].click());
+    expect(document.activeElement).not.toBe(input());
+  });
+});

--- a/src/OscSheet/components/ui/Combobox.test.tsx
+++ b/src/OscSheet/components/ui/Combobox.test.tsx
@@ -5,7 +5,9 @@ import { createRoot, type Root } from "react-dom/client";
 import { Combobox, type ComboOption, type ComboboxProps } from "./Combobox";
 import { filterOptions, shouldShowCreate } from "./comboboxFilter";
 
-(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
 
 const OPTIONS: ComboOption[] = [
   { value: "assassin", label: "Assassin" },
@@ -19,8 +21,12 @@ describe("filterOptions", () => {
     expect(filterOptions(OPTIONS, "  ")).toHaveLength(OPTIONS.length);
   });
   it("narrows case-insensitively by label substring", () => {
-    expect(filterOptions(OPTIONS, "as").map((o) => o.value)).toEqual(["assassin"]);
-    expect(filterOptions(OPTIONS, "GHT").map((o) => o.value)).toEqual(["fighter"]);
+    expect(filterOptions(OPTIONS, "as").map((o) => o.value)).toEqual([
+      "assassin",
+    ]);
+    expect(filterOptions(OPTIONS, "GHT").map((o) => o.value)).toEqual([
+      "fighter",
+    ]);
   });
 });
 
@@ -47,7 +53,10 @@ function Harness(props: Partial<ComboboxProps>) {
       {...props}
       value={v}
       options={props.options ?? OPTIONS}
-      onCommit={(next) => { onCommit(next); setV(next); }}
+      onCommit={(next) => {
+        onCommit(next);
+        setV(next);
+      }}
     />
   );
 }
@@ -56,16 +65,27 @@ const render = (props: Partial<ComboboxProps> = {}) =>
   act(() => root.render(<Harness {...props} />));
 
 const input = () => container.querySelector("input") as HTMLInputElement;
-const rows = () => Array.from(container.querySelectorAll('[role="option"]')) as HTMLElement[];
-const optionRows = () => rows().filter((r) => !r.className.includes("combobox-create"));
+const rows = () =>
+  Array.from(document.querySelectorAll('[role="option"]')) as HTMLElement[];
+const optionRows = () =>
+  rows().filter((r) => !r.className.includes("combobox-create"));
 
 function setValue(el: HTMLInputElement, value: string) {
-  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  )!.set!;
   setter.call(el, value);
   el.dispatchEvent(new Event("input", { bubbles: true }));
 }
 const key = (el: HTMLElement, k: string) =>
-  el.dispatchEvent(new KeyboardEvent("keydown", { key: k, bubbles: true, cancelable: true }));
+  el.dispatchEvent(
+    new KeyboardEvent("keydown", { key: k, bubbles: true, cancelable: true }),
+  );
+const pointerDown = (el: HTMLElement, button = 0) =>
+  el.dispatchEvent(
+    new MouseEvent("pointerdown", { bubbles: true, cancelable: true, button }),
+  );
 
 beforeEach(() => {
   onCommit.mockClear();
@@ -87,12 +107,20 @@ describe("Combobox", () => {
     expect(optionRows().map((r) => r.textContent)).toEqual(["Fighter"]);
   });
 
-  it("commits the option's value (not its label) on click", () => {
+  it("commits the option's value (not its label) on pointerdown", () => {
     render();
     act(() => input().focus());
     act(() => setValue(input(), "magic"));
-    act(() => rows()[0].click());
+    act(() => pointerDown(optionRows()[0]));
     expect(onCommit).toHaveBeenCalledExactlyOnceWith("magic-user");
+  });
+
+  it("ignores non-primary pointer buttons on an option", () => {
+    render();
+    act(() => input().focus());
+    act(() => setValue(input(), "magic"));
+    act(() => pointerDown(optionRows()[0], 2));
+    expect(onCommit).not.toHaveBeenCalled();
   });
 
   it("commits the trimmed typed text via the Create row", () => {
@@ -101,7 +129,7 @@ describe("Combobox", () => {
     act(() => setValue(input(), "  Warlock  "));
     const create = rows().find((r) => r.className.includes("combobox-create"))!;
     expect(create.textContent).toContain("Warlock");
-    act(() => create.click());
+    act(() => pointerDown(create));
     expect(onCommit).toHaveBeenCalledExactlyOnceWith("Warlock");
   });
 
@@ -136,7 +164,9 @@ describe("Combobox", () => {
     act(() => input().focus());
     act(() => setValue(input(), "Warlock"));
     expect(rows()).toHaveLength(0);
-    expect(rows().some((r) => r.className.includes("combobox-create"))).toBe(false);
+    expect(rows().some((r) => r.className.includes("combobox-create"))).toBe(
+      false,
+    );
   });
 
   it("renders a custom create-row label via newOptionLabel", () => {
@@ -145,12 +175,15 @@ describe("Combobox", () => {
     act(() => setValue(input(), "Warlock"));
     const create = rows().find((r) => r.className.includes("combobox-create"))!;
     expect(create.textContent).toContain("Custom: Warlock");
-    act(() => create.click());
+    act(() => pointerDown(create));
     expect(onCommit).toHaveBeenCalledExactlyOnceWith("Warlock");
   });
 
   it("renders a per-option node while filtering by label", () => {
-    const opts: ComboOption[] = OPTIONS.map((o) => ({ ...o, node: <span data-test={o.value}>{o.label} ·</span> }));
+    const opts: ComboOption[] = OPTIONS.map((o) => ({
+      ...o,
+      node: <span data-test={o.value}>{o.label} ·</span>,
+    }));
     render({ options: opts });
     act(() => input().focus());
     act(() => setValue(input(), "fig"));
@@ -161,17 +194,62 @@ describe("Combobox", () => {
   it("highlights the current value when opened", () => {
     render({ value: "fighter" });
     act(() => input().focus());
-    const highlighted = rows().find((r) => r.className.includes("is-highlighted"));
+    const highlighted = rows().find((r) =>
+      r.className.includes("is-highlighted"),
+    );
     expect(highlighted?.textContent).toBe("Fighter");
   });
 
   it("closes on re-click when untouched, keeping the value", () => {
     render({ value: "fighter" });
     act(() => input().focus()); // first focus opens
-    expect(container.querySelector(".combobox-pop")).not.toBeNull();
-    act(() => input().dispatchEvent(new MouseEvent("mousedown", { bubbles: true })));
-    expect(container.querySelector(".combobox-pop")).toBeNull();
+    expect(document.querySelector(".combobox-pop")).not.toBeNull();
+    act(() =>
+      input().dispatchEvent(new MouseEvent("mousedown", { bubbles: true })),
+    );
+    expect(document.querySelector(".combobox-pop")).toBeNull();
     expect(onCommit).not.toHaveBeenCalled();
+    expect(input().value).toBe("Fighter");
+  });
+
+  it("renders the value as a chip at rest, hidden text, when renderValue is given", () => {
+    render({
+      value: "fighter",
+      renderValue: (v) => <span data-test="chip">{v}!</span>,
+    });
+    const chip = container.querySelector(".combobox-chip");
+    expect(chip).not.toBeNull();
+    expect(chip?.querySelector("[data-test=chip]")?.textContent).toBe(
+      "fighter!",
+    );
+    expect(input().classList.contains("is-chip")).toBe(true);
+  });
+
+  it("reveals the raw input value on focus, replacing the chip", () => {
+    render({
+      value: "fighter",
+      renderValue: (v) => <span data-test="chip">{v}!</span>,
+    });
+    expect(container.querySelector(".combobox-chip")).not.toBeNull();
+    act(() => input().focus());
+    // Focus swaps the chip for the editable value so it can be selected/typed over.
+    expect(container.querySelector(".combobox-chip")).toBeNull();
+    expect(input().classList.contains("is-chip")).toBe(false);
+    expect(input().value).toBe("Fighter");
+    act(() => setValue(input(), "War"));
+    expect(input().value).toBe("War");
+  });
+
+  it("shows no chip for an empty value, falling back to placeholder", () => {
+    render({ value: "", renderValue: (v) => <span>{v}</span> });
+    expect(container.querySelector(".combobox-chip")).toBeNull();
+    expect(input().classList.contains("is-chip")).toBe(false);
+  });
+
+  it("renders plain input text when renderValue is omitted", () => {
+    render({ value: "fighter" });
+    expect(container.querySelector(".combobox-chip")).toBeNull();
+    expect(input().classList.contains("is-chip")).toBe(false);
     expect(input().value).toBe("Fighter");
   });
 
@@ -180,7 +258,7 @@ describe("Combobox", () => {
     act(() => input().focus());
     expect(document.activeElement).toBe(input());
     act(() => setValue(input(), "magic"));
-    act(() => rows()[0].click());
+    act(() => pointerDown(rows()[0]));
     expect(document.activeElement).not.toBe(input());
   });
 });

--- a/src/OscSheet/components/ui/Combobox.tsx
+++ b/src/OscSheet/components/ui/Combobox.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useId, useMemo, useRef, useState, type ReactNode } from "react";
+import { cx } from "./cx";
+import { filterOptions, labelForValue, shouldShowCreate, type ComboOption } from "./comboboxFilter";
+
+export type { ComboOption };
+
+export type ComboboxProps = {
+  value: string;
+  options: ComboOption[];
+  onCommit: (value: string) => void;
+  allowCreate?: boolean;
+  /** Label for the create row given the typed query. Default: `Create "x"`. */
+  newOptionLabel?: (query: string) => ReactNode;
+  /** Leading non-interactive prompt shown before typing when creation is allowed. Defaults to a
+   *  generic prompt; pass custom copy to tailor it, or `null` to hide it. */
+  createHint?: ReactNode;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+};
+
+const defaultNewOptionLabel = (q: string) => `Create “${q}”`;
+
+/**
+ * Create-or-select combobox: an editable text input over a filterable option
+ * list. Selecting an option commits its `value`; when `allowCreate`, a novel
+ * typed label commits verbatim (trimmed). Custom values not in `options` show
+ * their raw text. Blur/Escape revert to the committed value — creation is
+ * explicit via Enter or click only.
+ * @category Controls
+ */
+export function Combobox({
+  value,
+  options,
+  onCommit,
+  allowCreate = true,
+  newOptionLabel = defaultNewOptionLabel,
+  createHint = "Type to add…",
+  placeholder,
+  disabled,
+  className,
+}: ComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const [query, setQuery] = useState("");
+  const [highlight, setHighlight] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listId = useId();
+
+  const filtered = useMemo(() => (dirty ? filterOptions(options, query) : options), [dirty, options, query]);
+  const showCreate = dirty && shouldShowCreate(options, query, allowCreate);
+  const total = filtered.length + (showCreate ? 1 : 0);
+  const createIndex = showCreate ? filtered.length : -1;
+
+  useEffect(() => {
+    if (open && !dirty) {
+      const i = filtered.findIndex((o) => o.value === value);
+      setHighlight(i >= 0 ? i : 0);
+    } else {
+      setHighlight(0);
+    }
+  }, [open, dirty, query, value, filtered]);
+
+  const displayText = open && dirty ? query : labelForValue(options, value);
+  const rowId = (i: number) => `${listId}-opt-${i}`;
+  const activeId = open && total > 0 ? rowId(highlight) : undefined;
+
+  useEffect(() => {
+    const el = activeId ? document.getElementById(activeId) : null;
+    try { el?.scrollIntoView({ block: "nearest" }); } catch { /* jsdom: no layout engine */ }
+  }, [activeId]);
+
+  const reset = () => {
+    setOpen(false);
+    setDirty(false);
+    setQuery("");
+  };
+
+  const commitAt = (i: number) => {
+    if (i === createIndex) {
+      onCommit(query.trim());
+    } else if (i >= 0 && i < filtered.length) {
+      onCommit(filtered[i].value);
+    } else {
+      reset();
+      return;
+    }
+    reset();
+    inputRef.current?.blur();
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (disabled) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (!open) return setOpen(true);
+      if (total > 0) setHighlight((h) => (h + 1) % total);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (open && total > 0) setHighlight((h) => (h - 1 + total) % total);
+    } else if (e.key === "Enter") {
+      if (open && total > 0) {
+        e.preventDefault();
+        commitAt(highlight);
+      }
+    } else if (e.key === "Escape") {
+      if (open) {
+        e.preventDefault();
+        e.stopPropagation();
+        reset();
+      }
+    }
+  };
+
+  return (
+    <div className={cx("combobox", open && "is-open", dirty && "is-typing", className)}>
+      <input
+        ref={inputRef}
+        type="text"
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={listId}
+        aria-autocomplete="list"
+        aria-activedescendant={activeId}
+        className="input combobox-input"
+        value={displayText}
+        placeholder={placeholder}
+        disabled={disabled}
+        onFocus={() => !disabled && setOpen(true)}
+        onMouseDown={(e) => {
+          if (disabled || document.activeElement !== inputRef.current) return;
+          if (open && !dirty) {
+            e.preventDefault();
+            reset();
+          } else {
+            setOpen(true);
+          }
+        }}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setDirty(true);
+          setOpen(true);
+        }}
+        onBlur={reset}
+        onKeyDown={onKeyDown}
+      />
+      <span className="combobox-caret" aria-hidden="true">
+        <i className="fa-solid fa-chevron-down" />
+      </span>
+      {open && (
+        <div className="combobox-pop" id={listId} role="listbox">
+          {createHint && allowCreate && !dirty && (
+            <div className="combobox-opt combobox-hint" aria-disabled onMouseDown={(e) => e.preventDefault()}>
+              <span className="combobox-create-plus">+</span> {createHint}
+            </div>
+          )}
+          {filtered.map((o, i) => (
+            <div
+              key={o.value}
+              id={rowId(i)}
+              role="option"
+              aria-selected={i === highlight}
+              className={cx("combobox-opt", i === highlight && "is-highlighted")}
+              onMouseDown={(e) => e.preventDefault()}
+              onMouseEnter={() => setHighlight(i)}
+              onClick={() => commitAt(i)}
+            >
+              {o.node ?? o.label}
+            </div>
+          ))}
+          {showCreate && (
+            <div
+              id={rowId(createIndex)}
+              role="option"
+              aria-selected={highlight === createIndex}
+              className={cx("combobox-opt", "combobox-create", highlight === createIndex && "is-highlighted")}
+              onMouseDown={(e) => e.preventDefault()}
+              onMouseEnter={() => setHighlight(createIndex)}
+              onClick={() => commitAt(createIndex)}
+            >
+              <span className="combobox-create-plus">+</span> {newOptionLabel(query.trim())}
+            </div>
+          )}
+          {total === 0 && (
+            <div className="combobox-empty" aria-disabled>
+              {allowCreate ? "Type to add…" : "No matches"}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/OscSheet/components/ui/Combobox.tsx
+++ b/src/OscSheet/components/ui/Combobox.tsx
@@ -1,6 +1,20 @@
-import { useEffect, useId, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
 import { cx } from "./cx";
-import { filterOptions, labelForValue, shouldShowCreate, type ComboOption } from "./comboboxFilter";
+import {
+  filterOptions,
+  labelForValue,
+  shouldShowCreate,
+  type ComboOption,
+} from "./comboboxFilter";
 
 export type { ComboOption };
 
@@ -14,6 +28,9 @@ export type ComboboxProps = {
   /** Leading non-interactive prompt shown before typing when creation is allowed. Defaults to a
    *  generic prompt; pass custom copy to tailor it, or `null` to hide it. */
   createHint?: ReactNode;
+  /** Renders the committed value as a chip overlay while at rest (not typing); the raw input is
+   *  revealed on edit. Receives the raw `value`; omit for plain input text. */
+  renderValue?: (value: string) => ReactNode;
   placeholder?: string;
   disabled?: boolean;
   className?: string;
@@ -36,6 +53,7 @@ export function Combobox({
   allowCreate = true,
   newOptionLabel = defaultNewOptionLabel,
   createHint = "Type to add…",
+  renderValue,
   placeholder,
   disabled,
   className,
@@ -45,12 +63,46 @@ export function Combobox({
   const [query, setQuery] = useState("");
   const [highlight, setHighlight] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
   const listId = useId();
 
-  const filtered = useMemo(() => (dirty ? filterOptions(options, query) : options), [dirty, options, query]);
+  // The listbox is portaled out of the control's scroll/stacking context so it
+  // can't be clipped by an overflow ancestor (e.g. a modal body) or sink behind
+  // a sibling. Anchored via fixed positioning to the control's viewport rect.
+  const [popRect, setPopRect] = useState<{
+    top: number;
+    left: number;
+    width: number;
+  } | null>(null);
+  const portalTarget = () =>
+    wrapRef.current?.closest<HTMLElement>(".modal-scrim") ??
+    wrapRef.current?.closest<HTMLElement>(".osc-sheet-app") ??
+    (typeof document !== "undefined" ? document.body : null);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    const place = () => {
+      const r = wrapRef.current?.getBoundingClientRect();
+      if (r) setPopRect({ top: r.bottom, left: r.left, width: r.width });
+    };
+    place();
+    window.addEventListener("scroll", place, true);
+    window.addEventListener("resize", place);
+    return () => {
+      window.removeEventListener("scroll", place, true);
+      window.removeEventListener("resize", place);
+    };
+  }, [open]);
+
+  const filtered = useMemo(
+    () => (dirty ? filterOptions(options, query) : options),
+    [dirty, options, query],
+  );
   const showCreate = dirty && shouldShowCreate(options, query, allowCreate);
-  const total = filtered.length + (showCreate ? 1 : 0);
-  const createIndex = showCreate ? filtered.length : -1;
+  // The Create row sits at the top (index 0); options follow, offset by one.
+  const createIndex = showCreate ? 0 : -1;
+  const optOffset = showCreate ? 1 : 0;
+  const total = filtered.length + optOffset;
 
   useEffect(() => {
     if (open && !dirty) {
@@ -62,12 +114,17 @@ export function Combobox({
   }, [open, dirty, query, value, filtered]);
 
   const displayText = open && dirty ? query : labelForValue(options, value);
+  const showChip = !!renderValue && !open && value !== "";
   const rowId = (i: number) => `${listId}-opt-${i}`;
   const activeId = open && total > 0 ? rowId(highlight) : undefined;
 
   useEffect(() => {
     const el = activeId ? document.getElementById(activeId) : null;
-    try { el?.scrollIntoView({ block: "nearest" }); } catch { /* jsdom: no layout engine */ }
+    try {
+      el?.scrollIntoView({ block: "nearest" });
+    } catch {
+      /* jsdom: no layout engine */
+    }
   }, [activeId]);
 
   const reset = () => {
@@ -77,10 +134,11 @@ export function Combobox({
   };
 
   const commitAt = (i: number) => {
+    const fi = i - optOffset;
     if (i === createIndex) {
       onCommit(query.trim());
-    } else if (i >= 0 && i < filtered.length) {
-      onCommit(filtered[i].value);
+    } else if (fi >= 0 && fi < filtered.length) {
+      onCommit(filtered[fi].value);
     } else {
       reset();
       return;
@@ -112,8 +170,18 @@ export function Combobox({
     }
   };
 
+  const target = open ? portalTarget() : null;
+
   return (
-    <div className={cx("combobox", open && "is-open", dirty && "is-typing", className)}>
+    <div
+      ref={wrapRef}
+      className={cx(
+        "combobox",
+        open && "is-open",
+        dirty && "is-typing",
+        className,
+      )}
+    >
       <input
         ref={inputRef}
         type="text"
@@ -122,11 +190,16 @@ export function Combobox({
         aria-controls={listId}
         aria-autocomplete="list"
         aria-activedescendant={activeId}
-        className="input combobox-input"
+        className={cx("input combobox-input", showChip && "is-chip")}
         value={displayText}
         placeholder={placeholder}
         disabled={disabled}
-        onFocus={() => !disabled && setOpen(true)}
+        onFocus={() => {
+          if (disabled) return;
+          setOpen(true);
+          const el = inputRef.current;
+          requestAnimationFrame(() => el?.select());
+        }}
         onMouseDown={(e) => {
           if (disabled || document.activeElement !== inputRef.current) return;
           if (open && !dirty) {
@@ -144,50 +217,91 @@ export function Combobox({
         onBlur={reset}
         onKeyDown={onKeyDown}
       />
+      {showChip && (
+        <span className="combobox-chip" aria-hidden="true">
+          {renderValue!(value)}
+        </span>
+      )}
       <span className="combobox-caret" aria-hidden="true">
         <i className="fa-solid fa-chevron-down" />
       </span>
-      {open && (
-        <div className="combobox-pop" id={listId} role="listbox">
-          {createHint && allowCreate && !dirty && (
-            <div className="combobox-opt combobox-hint" aria-disabled onMouseDown={(e) => e.preventDefault()}>
+      {open &&
+        popRect &&
+        target &&
+        createPortal(
+          <div
+            className="combobox-pop"
+            id={listId}
+            role="listbox"
+            style={{
+              position: "fixed",
+              top: `${popRect.top}px`,
+              left: `${popRect.left}px`,
+              width: `${popRect.width}px`,
+              right: "auto",
+            }}
+          >
+            {createHint && allowCreate && !dirty && (
+            <div
+              className="combobox-opt combobox-hint"
+              aria-disabled
+              onMouseDown={(e) => e.preventDefault()}
+            >
               <span className="combobox-create-plus">+</span> {createHint}
             </div>
           )}
-          {filtered.map((o, i) => (
-            <div
-              key={o.value}
-              id={rowId(i)}
-              role="option"
-              aria-selected={i === highlight}
-              className={cx("combobox-opt", i === highlight && "is-highlighted")}
-              onMouseDown={(e) => e.preventDefault()}
-              onMouseEnter={() => setHighlight(i)}
-              onClick={() => commitAt(i)}
-            >
-              {o.node ?? o.label}
-            </div>
-          ))}
           {showCreate && (
             <div
               id={rowId(createIndex)}
               role="option"
               aria-selected={highlight === createIndex}
-              className={cx("combobox-opt", "combobox-create", highlight === createIndex && "is-highlighted")}
-              onMouseDown={(e) => e.preventDefault()}
+              className={cx(
+                "combobox-opt",
+                "combobox-create",
+                highlight === createIndex && "is-highlighted",
+              )}
+              onPointerDown={(e) => {
+                if (e.button !== 0) return;
+                e.preventDefault();
+                commitAt(createIndex);
+              }}
               onMouseEnter={() => setHighlight(createIndex)}
-              onClick={() => commitAt(createIndex)}
             >
-              <span className="combobox-create-plus">+</span> {newOptionLabel(query.trim())}
+              <span className="combobox-create-plus">+</span>{" "}
+              {newOptionLabel(query.trim())}
             </div>
           )}
-          {total === 0 && (
-            <div className="combobox-empty" aria-disabled>
-              {allowCreate ? "Type to add…" : "No matches"}
-            </div>
-          )}
-        </div>
-      )}
+          {filtered.map((o, i) => {
+            const idx = i + optOffset;
+            return (
+              <div
+                key={o.value}
+                id={rowId(idx)}
+                role="option"
+                aria-selected={idx === highlight}
+                className={cx(
+                  "combobox-opt",
+                  idx === highlight && "is-highlighted",
+                )}
+                onPointerDown={(e) => {
+                  if (e.button !== 0) return;
+                  e.preventDefault();
+                  commitAt(idx);
+                }}
+                onMouseEnter={() => setHighlight(idx)}
+              >
+                {o.node ?? o.label}
+              </div>
+            );
+          })}
+            {total === 0 && (
+              <div className="combobox-empty" aria-disabled>
+                {allowCreate ? "Type to add…" : "No matches"}
+              </div>
+            )}
+          </div>,
+          target,
+        )}
     </div>
   );
 }

--- a/src/OscSheet/components/ui/Tag.tsx
+++ b/src/OscSheet/components/ui/Tag.tsx
@@ -5,6 +5,8 @@ type Props = HTMLAttributes<HTMLSpanElement> & {
   intent?: "teal" | "crimson" | "forest" | "mustard" | "brass" | "solid" | "count";
   /** `chip` = the square, dark, icon-first weapon-tag box (default = pill). */
   variant?: "chip";
+  /** `xs` = tighter, lower-profile pill (default = standard). */
+  size?: "xs";
   /** FontAwesome glyph class (e.g. "fa-sword") rendered before the label. */
   icon?: string;
   /** Hover popover content (reuses the shared `.tag-pop` treatment). */
@@ -19,6 +21,7 @@ type Props = HTMLAttributes<HTMLSpanElement> & {
 export function Tag({
   intent,
   variant,
+  size,
   icon,
   tooltip,
   onRemove,
@@ -28,7 +31,7 @@ export function Tag({
   ...rest
 }: Props) {
   return (
-    <span className={cx("tag", variant, intent, className)} {...rest}>
+    <span className={cx("tag", variant, intent, size, className)} {...rest}>
       {icon && <i className={cx("fa-solid", icon)} aria-hidden="true" />}
       {children}
       {tooltip != null && (

--- a/src/OscSheet/components/ui/comboboxFilter.ts
+++ b/src/OscSheet/components/ui/comboboxFilter.ts
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+
+/** `label` drives filtering + the input's display text; optional `node` overrides how the row renders. */
+export type ComboOption = { value: string; label: string; node?: ReactNode };
+
+/** Options whose label case-insensitively contains the (trimmed) query. */
+export function filterOptions(options: ComboOption[], query: string): ComboOption[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return options;
+  return options.filter((o) => o.label.toLowerCase().includes(q));
+}
+
+/** A Create row shows only when creation is allowed and the query is a novel, non-empty label. */
+export function shouldShowCreate(options: ComboOption[], query: string, allowCreate = true): boolean {
+  if (!allowCreate) return false;
+  const q = query.trim();
+  if (!q) return false;
+  return !options.some((o) => o.label.toLowerCase() === q.toLowerCase());
+}
+
+export function labelForValue(options: ComboOption[], value: string): string {
+  return options.find((o) => o.value === value)?.label ?? value;
+}

--- a/src/OscSheet/components/ui/index.ts
+++ b/src/OscSheet/components/ui/index.ts
@@ -15,6 +15,7 @@ export { Textarea } from "./Textarea";
 export { ProseMirrorEditor } from "./ProseMirrorEditor";
 export { RichText } from "./RichText";
 export { Select } from "./Select";
+export { Combobox } from "./Combobox";
 export { Stepper } from "./Stepper";
 export { Toggle } from "./Toggle";
 export { Check } from "./Check";

--- a/src/OscSheet/domain/classRules.test.ts
+++ b/src/OscSheet/domain/classRules.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { selectClassDefaults, normalizeClassName } from "@domain/classRules";
+import {
+  selectClassDefaults,
+  normalizeClassName,
+  classSource,
+} from "@domain/classRules";
 import type { OSEActor } from "@domain/types";
 
 const FIGHTER = {
@@ -26,7 +30,9 @@ const MAGIC_USER = {
 
 beforeEach(() => {
   (globalThis as unknown as { CONFIG: unknown }).CONFIG = {
-    OSE: { classes: { classic: { Fighter: FIGHTER, "Magic-User": MAGIC_USER } } },
+    OSE: {
+      classes: { classic: { Fighter: FIGHTER, "Magic-User": MAGIC_USER } },
+    },
   };
 });
 afterEach(() => {
@@ -34,7 +40,7 @@ afterEach(() => {
 });
 
 const actorAt = (cls: string, level: number) =>
-  ({ system: { details: { class: cls, level } } } as unknown as OSEActor);
+  ({ system: { details: { class: cls, level } } }) as unknown as OSEActor;
 
 describe("normalizeClassName", () => {
   it("matches case-insensitively", () => {
@@ -58,7 +64,13 @@ describe("selectClassDefaults", () => {
     expect(d.maxLevel).toBe(2);
     expect(d.hd).toBe("1d8");
     expect(d.nextXp).toBe(2000);
-    expect(d.saves).toEqual({ death: 12, wand: 13, paralysis: 14, breath: 15, spell: 16 });
+    expect(d.saves).toEqual({
+      death: 12,
+      wand: 13,
+      paralysis: 14,
+      breath: 15,
+      spell: 16,
+    });
   });
   it("returns null nextXp at max level", () => {
     expect(selectClassDefaults(actorAt("Fighter", 2)).nextXp).toBeNull();
@@ -75,7 +87,13 @@ describe("selectClassDefaults", () => {
     expect(d.matched).toBe(true);
     expect(d.hd).toBe("1d4");
     expect(d.nextXp).toBe(2500);
-    expect(d.saves).toEqual({ death: 13, wand: 14, paralysis: 13, breath: 16, spell: 15 });
+    expect(d.saves).toEqual({
+      death: 13,
+      wand: 14,
+      paralysis: 13,
+      breath: 16,
+      spell: 15,
+    });
   });
 });
 
@@ -89,7 +107,13 @@ describe("selectClassDefaults — advanced classes", () => {
     ],
   };
   // Advanced Fighter with a different XP table than the classic FIGHTER above.
-  const ADV_FIGHTER = { name: "Fighter", levels: [{ xp: 0, hd: "1d8", saves: [12, 13, 14, 15, 16] }, { xp: 2200, hd: "2d8", saves: [10, 11, 12, 13, 14] }] };
+  const ADV_FIGHTER = {
+    name: "Fighter",
+    levels: [
+      { xp: 0, hd: "1d8", saves: [12, 13, 14, 15, 16] },
+      { xp: 2200, hd: "2d8", saves: [10, 11, 12, 13, 14] },
+    ],
+  };
 
   beforeEach(() => {
     (globalThis as unknown as { CONFIG: unknown }).CONFIG = {
@@ -113,5 +137,40 @@ describe("selectClassDefaults — advanced classes", () => {
     // classic Fighter L1→L2 = 2000; advanced Fighter = 2200
     expect(selectClassDefaults(actorAt("Fighter", 1)).nextXp).toBe(2200);
     expect(normalizeClassName("Bard")).toBe("Bard");
+  });
+});
+
+describe("classSource", () => {
+  beforeEach(() => {
+    (globalThis as unknown as { CONFIG: unknown }).CONFIG = {
+      OSE: {
+        classes: {
+          classic: { Fighter: FIGHTER, "Magic-User": MAGIC_USER },
+          advanced: { Bard: {}, Fighter: {} },
+        },
+      },
+    };
+  });
+
+  it("classifies classic-only classes", () => {
+    expect(classSource("Magic-User")).toBe("classic");
+  });
+  it("classifies advanced-only classes", () => {
+    expect(classSource("Bard")).toBe("advanced");
+  });
+  it("classifies unknown classes as custom", () => {
+    expect(classSource("Hangman")).toBe("custom");
+    expect(classSource("")).toBe("custom");
+  });
+  it("canonicalizes before matching (case + hyphen/space)", () => {
+    expect(classSource("magic user")).toBe("classic");
+    expect(classSource("bard")).toBe("advanced");
+  });
+  it("prefers advanced over classic when a name is in both", () => {
+    expect(classSource("Fighter")).toBe("advanced");
+  });
+  it("is custom when no CONFIG maps exist", () => {
+    (globalThis as unknown as { CONFIG: unknown }).CONFIG = { OSE: {} };
+    expect(classSource("Fighter")).toBe("custom");
   });
 });

--- a/src/OscSheet/domain/classRules.ts
+++ b/src/OscSheet/domain/classRules.ts
@@ -21,7 +21,11 @@ export type ClassDefaults = {
   requirements: Record<string, number>;
 };
 
-const canon = (s: string) => (s ?? "").trim().toLowerCase().replace(/[-\s]+/g, " ");
+const canon = (s: string) =>
+  (s ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[-\s]+/g, " ");
 
 /**
  * Class-definition maps to search, in priority order. Advanced Fantasy classes
@@ -31,7 +35,10 @@ const canon = (s: string) => (s ?? "").trim().toLowerCase().replace(/[-\s]+/g, "
  * defaults. Falls back to classic; both maps are absent → no defaults.
  */
 function classMaps(): Record<string, ClassDef>[] {
-  const c = (CONFIG.OSE?.classes ?? {}) as { advanced?: unknown; classic?: unknown };
+  const c = (CONFIG.OSE?.classes ?? {}) as {
+    advanced?: unknown;
+    classic?: unknown;
+  };
   return [c.advanced, c.classic].filter(Boolean) as Record<string, ClassDef>[];
 }
 
@@ -50,6 +57,25 @@ export function normalizeClassName(raw: string): string | null {
   return findClass(raw)?.key ?? null;
 }
 
+/**
+ * Provenance of a class name: `advanced` (Advanced Fantasy tome), `classic`
+ * (core rules), or `custom` (not in either CONFIG map). Advanced wins when a
+ * name lives in both, mirroring `classMaps` priority.
+ */
+export function classSource(name: string): "classic" | "advanced" | "custom" {
+  const want = canon(name);
+  if (!want) return "custom";
+  const c = (CONFIG.OSE?.classes ?? {}) as {
+    advanced?: unknown;
+    classic?: unknown;
+  };
+  const has = (m: unknown) =>
+    !!m && Object.keys(m as object).some((k) => canon(k) === want);
+  if (has(c.advanced)) return "advanced";
+  if (has(c.classic)) return "classic";
+  return "custom";
+}
+
 /** All class names available in CONFIG.OSE.classes (advanced + classic), unique + sorted. */
 export function availableClassNames(): string[] {
   const names = new Set<string>();
@@ -60,12 +86,23 @@ export function availableClassNames(): string[] {
 export function selectClassDefaults(actor: OSEActor): ClassDefaults {
   const { class: cls, level } = actor.system.details;
   const def = findClass(cls)?.def;
-  if (!def) return { matched: false, maxLevel: 14, hd: null, levelXp: null, nextXp: null, saves: null, requirements: {} };
+  if (!def)
+    return {
+      matched: false,
+      maxLevel: 14,
+      hd: null,
+      levelXp: null,
+      nextXp: null,
+      saves: null,
+      requirements: {},
+    };
 
   const row = def.levels[level - 1];
   const nextRow = def.levels[level]; // 0-indexed: index `level` is the next level
   const saves = row
-    ? (Object.fromEntries(SAVE_ORDER.map((k, i) => [k, row.saves[i]])) as Record<OSESave, number>)
+    ? (Object.fromEntries(
+        SAVE_ORDER.map((k, i) => [k, row.saves[i]]),
+      ) as Record<OSESave, number>)
     : null;
   return {
     matched: true,

--- a/src/OscSheet/features/edit/EditModal.tsx
+++ b/src/OscSheet/features/edit/EditModal.tsx
@@ -1,11 +1,43 @@
 import { useState } from "react";
+import type { ReactNode } from "react";
 import {
-  Modal, Button, SectionTitle, ConfirmDialog, OverrideValue,
-  StampCell, InlineButton, PortraitField, NumberInput, ValidatedInput,
+  Modal,
+  Button,
+  SectionTitle,
+  ConfirmDialog,
+  OverrideValue,
+  StampCell,
+  InlineButton,
+  PortraitField,
+  NumberInput,
+  ValidatedInput,
+  Combobox,
+  Tag,
 } from "@src/OscSheet/components/ui";
 import { useOscSheetContext } from "@app/context";
-import { selectClassDefaults, availableClassNames } from "@domain/classRules";
+import {
+  selectClassDefaults,
+  availableClassNames,
+  classSource,
+} from "@domain/classRules";
 import type { OSEActor, OSESave } from "@domain/types";
+
+const SOURCE_TAG = {
+  advanced: ["Advanced", "teal"],
+  classic: ["Classic", "brass"],
+  custom: ["Custom", "mustard"],
+} as const;
+
+// One face for both dropdown rows and the at-rest chip, so they stay identical.
+function classFace(name: string): ReactNode {
+  const [text, intent] = SOURCE_TAG[classSource(name)];
+  return (
+    <>
+      <span className="combobox-optlabel">{name.replace(/-/g, " ")}</span>
+      <Tag intent={intent} size="xs">{text}</Tag>
+    </>
+  );
+}
 
 // A hit-die formula must be a valid Roll AND actually contain a die term.
 const validateHd = (v: string) =>
@@ -15,7 +47,12 @@ const validateHd = (v: string) =>
 // ValidatedInput), committing only when valid; the roll button uses the
 // last committed value.
 function HitDiceField({
-  actor, hdVal, hdDefault, hdOverridden, onCommit, onResetRequest,
+  actor,
+  hdVal,
+  hdDefault,
+  hdOverridden,
+  onCommit,
+  onResetRequest,
 }: {
   actor: OSEActor;
   hdVal: string;
@@ -26,14 +63,20 @@ function HitDiceField({
 }) {
   const rollHd = () => {
     const speaker = ChatMessage.getSpeaker({ actor });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    void new Roll(hdVal).toMessage({ speaker, flavor: `Hit Dice — ${hdVal}` } as any);
+    void new Roll(hdVal).toMessage(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { speaker, flavor: `Hit Dice — ${hdVal}` } as any,
+    );
   };
 
   return (
     <div className="ed-field" style={{ gridColumn: "7 / span 3" }}>
       <span className="lab">Hit Dice</span>
-      <InlineButton className="ed-rollbtn" title={`Roll ${hdVal} hit points`} onClick={rollHd}>
+      <InlineButton
+        className="ed-rollbtn"
+        title={`Roll ${hdVal} hit points`}
+        onClick={rollHd}
+      >
         <i className="fa-solid fa-dice-d20" aria-hidden="true" />
       </InlineButton>
       <ValidatedInput
@@ -42,20 +85,23 @@ function HitDiceField({
         validate={validateHd}
         onCommit={onCommit}
         spellCheck={false}
-        hint={hdDefault != null ? (
-          <OverrideValue
-            overridden={hdOverridden}
-            defaultText={`default · ${hdDefault}`}
-            onResetRequest={onResetRequest}
-          />
-        ) : undefined}
+        hint={
+          hdDefault != null ? (
+            <OverrideValue
+              overridden={hdOverridden}
+              defaultText={`default · ${hdDefault}`}
+              onResetRequest={onResetRequest}
+            />
+          ) : undefined
+        }
       />
     </div>
   );
 }
 
 const fmtMod = (n: number) => (n >= 0 ? "+" : "") + n;
-const clamp = (n: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, n));
+const clamp = (n: number, lo: number, hi: number) =>
+  Math.max(lo, Math.min(hi, n));
 
 // Mirrors the sheet's plaque order (features/actions/abilities.ts) — editing scores in a
 // different order than they're displayed invites typing a value into the wrong field.
@@ -77,16 +123,24 @@ const SKILL_DEFS: { k: "ld" | "od" | "sd" | "ft"; n: string }[] = [
 
 type ConfirmState = { title: string; body: string; fn: () => void } | null;
 
-export function EditModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+export function EditModal({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
   const { actor, updateActor } = useOscSheetContext();
   const [confirm, setConfirm] = useState<ConfirmState>(null);
-  const requestConfirm = (title: string, body: string, fn: () => void) => setConfirm({ title, body, fn });
+  const requestConfirm = (title: string, body: string, fn: () => void) =>
+    setConfirm({ title, body, fn });
 
   if (!open) return null;
 
   const sys = actor.system;
   const defaults = selectClassDefaults(actor);
-  const set = (key: string, value: string | number) => void updateActor({ [key]: value });
+  const set = (key: string, value: string | number) =>
+    void updateActor({ [key]: value });
 
   // --- Identity / progression ---
   // GMs can re-class a character; players see the class as static header text.
@@ -103,17 +157,34 @@ export function EditModal({ open, onClose }: { open: boolean; onClose: () => voi
   const hdDefault = defaults.hd;
   const hdOverridden = !!hdDefault && hdVal !== hdDefault;
 
-  const footer = <Button variant="primary" onClick={onClose}>Close</Button>;
+  const footer = (
+    <Button variant="primary" onClick={onClose}>
+      Close
+    </Button>
+  );
 
   return (
-    <Modal open={open} title="Edit Character" onClose={onClose} footer={footer} className="fe-modal">
+    <Modal
+      open={open}
+      title="Edit Character"
+      onClose={onClose}
+      footer={footer}
+      className="fe-modal"
+    >
       <div className="fe-modal-body">
-
         {/* Identity */}
         <div className="ed-sec">
-          <SectionTitle>Identity &amp; Vitals: <em className="ed-id-class">{sys.details.class.replace(/-/g, " ")}</em></SectionTitle>
+          <SectionTitle>
+            Identity &amp; Vitals:{" "}
+            <em className="ed-id-class">
+              {sys.details.class.replace(/-/g, " ")}
+            </em>
+          </SectionTitle>
           <div className="ed-id-top">
-            <PortraitField src={actor.img} onPick={(path) => set("img", path)} />
+            <PortraitField
+              src={actor.img}
+              onPick={(path) => set("img", path)}
+            />
             <div className="ed-id-grid">
               <label className="ed-field" style={{ gridColumn: "1 / span 8" }}>
                 <span className="lab">Name</span>
@@ -138,37 +209,78 @@ export function EditModal({ open, onClose }: { open: boolean; onClose: () => voi
           <div className="ed-idgrid">
             <label className="ed-field" style={{ gridColumn: "1 / span 3" }}>
               <span className="lab">Alignment</span>
-              <select className="ed-input" value={sys.details.alignment} onChange={(e) => set("system.details.alignment", e.target.value)}>
-                {ALIGNMENTS.map((a) => <option key={a}>{a}</option>)}
+              <select
+                className="ed-input"
+                value={sys.details.alignment}
+                onChange={(e) =>
+                  set("system.details.alignment", e.target.value)
+                }
+              >
+                {ALIGNMENTS.map((a) => (
+                  <option key={a}>{a}</option>
+                ))}
               </select>
             </label>
             <label className="ed-field" style={{ gridColumn: "4 / span 3" }}>
               <span className="lab">Level</span>
-              <NumberInput className="ed-input mono" value={level} min={1} max={defaults.maxLevel} onCommit={(n) => set("system.details.level", n)} />
+              <NumberInput
+                className="ed-input mono"
+                value={level}
+                min={1}
+                max={defaults.maxLevel}
+                onCommit={(n) => set("system.details.level", n)}
+              />
             </label>
             <label className="ed-field" style={{ gridColumn: "7 / span 3" }}>
               <span className="lab">Current XP</span>
-              <NumberInput className="ed-input mono" value={sys.details.xp.value} min={0} onCommit={(n) => set("system.details.xp.value", n)} />
+              <NumberInput
+                className="ed-input mono"
+                value={sys.details.xp.value}
+                min={0}
+                onCommit={(n) => set("system.details.xp.value", n)}
+              />
             </label>
             <label className="ed-field" style={{ gridColumn: "10 / span 3" }}>
               <span className="lab">Next Level</span>
-              <NumberInput className="ed-input mono" value={sys.details.xp.next} min={0} onCommit={(n) => set("system.details.xp.next", n)} />
+              <NumberInput
+                className="ed-input mono"
+                value={sys.details.xp.next}
+                min={0}
+                onCommit={(n) => set("system.details.xp.next", n)}
+              />
               {nextXp != null && (
                 <OverrideValue
                   overridden={sys.details.xp.next !== nextXp}
                   defaultText={`default · ${nextXp.toLocaleString()}`}
-                  onResetRequest={() => requestConfirm("Reset Next Level?", `Revert to the class default of ${nextXp.toLocaleString()} XP.`, () => set("system.details.xp.next", nextXp))}
+                  onResetRequest={() =>
+                    requestConfirm(
+                      "Reset Next Level?",
+                      `Revert to the class default of ${nextXp.toLocaleString()} XP.`,
+                      () => set("system.details.xp.next", nextXp),
+                    )
+                  }
                 />
               )}
             </label>
 
             <label className="ed-field" style={{ gridColumn: "1 / span 3" }}>
               <span className="lab">Current HP</span>
-              <NumberInput className="ed-input mono" value={sys.hp.value} min={0} max={sys.hp.max} onCommit={(n) => set("system.hp.value", n)} />
+              <NumberInput
+                className="ed-input mono"
+                value={sys.hp.value}
+                min={0}
+                max={sys.hp.max}
+                onCommit={(n) => set("system.hp.value", n)}
+              />
             </label>
             <label className="ed-field" style={{ gridColumn: "4 / span 3" }}>
               <span className="lab">Max HP</span>
-              <NumberInput className="ed-input mono" value={sys.hp.max} min={1} onCommit={(n) => set("system.hp.max", n)} />
+              <NumberInput
+                className="ed-input mono"
+                value={sys.hp.max}
+                min={1}
+                onCommit={(n) => set("system.hp.max", n)}
+              />
             </label>
             <HitDiceField
               actor={actor}
@@ -177,30 +289,50 @@ export function EditModal({ open, onClose }: { open: boolean; onClose: () => voi
               hdOverridden={hdOverridden}
               onCommit={(v) => set("system.hp.hd", v)}
               onResetRequest={() =>
-                requestConfirm("Reset Hit Dice?", `Revert to the class default of ${hdDefault}.`, () => set("system.hp.hd", hdDefault!))
+                requestConfirm(
+                  "Reset Hit Dice?",
+                  `Revert to the class default of ${hdDefault}.`,
+                  () => set("system.hp.hd", hdDefault!),
+                )
               }
             />
             <div className="ed-field" style={{ gridColumn: "10 / span 3" }}>
               <span className="lab">Initiative Mod</span>
-              <NumberInput className="ed-input mono" value={initEff} onCommit={(n) => set("system.initiative.mod", n - dexInit)} />
+              <NumberInput
+                className="ed-input mono"
+                value={initEff}
+                onCommit={(n) => set("system.initiative.mod", n - dexInit)}
+              />
               <OverrideValue
                 overridden={initMod !== 0}
                 defaultText={`DEX ${fmtMod(dexInit)}`}
-                onResetRequest={() => requestConfirm("Reset Initiative?", `Revert to the rule default of DEX ${fmtMod(dexInit)}.`, () => set("system.initiative.mod", 0))}
+                onResetRequest={() =>
+                  requestConfirm(
+                    "Reset Initiative?",
+                    `Revert to the rule default of DEX ${fmtMod(dexInit)}.`,
+                    () => set("system.initiative.mod", 0),
+                  )
+                }
               />
             </div>
 
             {isGM && classNames.length > 0 && (
               <label className="ed-field" style={{ gridColumn: "1 / span 6" }}>
-                <span className="lab">Class <span className="hint">GM</span></span>
-                <select className="ed-input" value={sys.details.class} onChange={(e) => set("system.details.class", e.target.value)}>
-                  {!classNames.includes(sys.details.class) && (
-                    <option value={sys.details.class}>{sys.details.class.replace(/-/g, " ")}</option>
-                  )}
-                  {classNames.map((c) => (
-                    <option key={c} value={c}>{c.replace(/-/g, " ")}</option>
-                  ))}
-                </select>
+                <span className="lab">
+                  Class <span className="hint">GM</span>
+                </span>
+                <Combobox
+                  value={sys.details.class}
+                  options={classNames.map((c) => ({
+                    value: c,
+                    label: c.replace(/-/g, " "),
+                    node: classFace(c),
+                  }))}
+                  onCommit={(v) => set("system.details.class", v)}
+                  renderValue={classFace}
+                  createHint="Type to set a custom class"
+                  newOptionLabel={(q) => `Custom: “${q}”`}
+                />
               </label>
             )}
           </div>
@@ -218,12 +350,20 @@ export function EditModal({ open, onClose }: { open: boolean; onClose: () => voi
                   key={k}
                   stampKey={k.toUpperCase()}
                   value={sys.scores[k].value}
-                  onChange={(n) => set(`system.scores.${k}.value`, clamp(n, 1, 20))}
+                  onChange={(n) =>
+                    set(`system.scores.${k}.value`, clamp(n, 1, 20))
+                  }
                   min={1}
                   max={20}
                   warn={below}
-                  warnTitle={below ? `${sys.details.class} requires ${k.toUpperCase()} ${req}+` : undefined}
-                  caption={below ? `needs ${req}+` : `mod ${fmtMod(sys.scores[k].mod)}`}
+                  warnTitle={
+                    below
+                      ? `${sys.details.class} requires ${k.toUpperCase()} ${req}+`
+                      : undefined
+                  }
+                  caption={
+                    below ? `needs ${req}+` : `mod ${fmtMod(sys.scores[k].mod)}`
+                  }
                 />
               );
             })}
@@ -232,7 +372,9 @@ export function EditModal({ open, onClose }: { open: boolean; onClose: () => voi
 
         {/* Saving Throws */}
         <div className="ed-sec">
-          <SectionTitle hint="roll ≥ target · default shown">Saving Throws</SectionTitle>
+          <SectionTitle hint="roll ≥ target · default shown">
+            Saving Throws
+          </SectionTitle>
           <div className="ed-cells ed-save">
             {SAVE_DEFS.map(({ k, n }) => {
               const def = defaults.saves?.[k] ?? null;
@@ -249,7 +391,16 @@ export function EditModal({ open, onClose }: { open: boolean; onClose: () => voi
                   max={20}
                   caption={def != null ? `default ${def}` : ""}
                   overridden={overridden}
-                  onResetRequest={def != null ? () => requestConfirm(`Reset ${n}?`, `Revert to the rule default of ${def}.`, () => set(`system.saves.${k}.value`, def)) : undefined}
+                  onResetRequest={
+                    def != null
+                      ? () =>
+                          requestConfirm(
+                            `Reset ${n}?`,
+                            `Revert to the rule default of ${def}.`,
+                            () => set(`system.saves.${k}.value`, def),
+                          )
+                      : undefined
+                  }
                 />
               );
             })}
@@ -263,8 +414,18 @@ export function EditModal({ open, onClose }: { open: boolean; onClose: () => voi
             {SKILL_DEFS.map(({ k, n }) => (
               <label className="ed-field" key={k}>
                 <span className="lab">{n}</span>
-                <select className="ed-input mono" value={sys.exploration[k]} onChange={(e) => set(`system.exploration.${k}`, Number(e.target.value))}>
-                  {[1, 2, 3, 4, 5, 6].map((x) => <option key={x} value={x}>{x}-in-6</option>)}
+                <select
+                  className="ed-input mono"
+                  value={sys.exploration[k]}
+                  onChange={(e) =>
+                    set(`system.exploration.${k}`, Number(e.target.value))
+                  }
+                >
+                  {[1, 2, 3, 4, 5, 6].map((x) => (
+                    <option key={x} value={x}>
+                      {x}-in-6
+                    </option>
+                  ))}
                 </select>
               </label>
             ))}
@@ -278,7 +439,10 @@ export function EditModal({ open, onClose }: { open: boolean; onClose: () => voi
         body={confirm?.body ?? ""}
         confirmLabel="Reset"
         variant="primary"
-        onConfirm={() => { confirm?.fn(); setConfirm(null); }}
+        onConfirm={() => {
+          confirm?.fn();
+          setConfirm(null);
+        }}
         onCancel={() => setConfirm(null)}
       />
     </Modal>

--- a/src/OscSheet/features/edit/EditModalClass.test.tsx
+++ b/src/OscSheet/features/edit/EditModalClass.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import OscSheetProvider from "@app/OscSheetProvider";
+import { EditModal } from "./EditModal";
+import type { OSEActor } from "@domain/types";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function deepSet(obj: Record<string, unknown>, path: string, value: unknown) {
+  const parts = path.split(".");
+  let cur = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    cur[parts[i]] ??= {};
+    cur = cur[parts[i]] as Record<string, unknown>;
+  }
+  cur[parts[parts.length - 1]] = value;
+}
+
+const g = globalThis as Record<string, unknown>;
+g.foundry = { utils: { debounce: (fn: unknown) => fn } };
+g.game = { user: { isGM: true } };
+g.Roll = { validate: () => true };
+g.ChatMessage = { getSpeaker: () => ({}) };
+g.CONFIG = {
+  OSE: {
+    classes: {
+      classic: {
+        cleric: { levels: [{ xp: 0, hd: "1d6", saves: [1, 2, 3, 4, 5] }] },
+        fighter: { levels: [{ xp: 0, hd: "1d8", saves: [1, 2, 3, 4, 5] }] },
+      },
+    },
+  },
+};
+
+function makeActor(): OSEActor {
+  const actor: Record<string, unknown> = {
+    name: "Test",
+    img: "x.png",
+    system: {
+      details: {
+        class: "fighter",
+        title: "",
+        alignment: "Neutral",
+        level: 1,
+        xp: { value: 0, next: 2000 },
+      },
+      scores: {
+        str: { value: 10, mod: 0 },
+        int: { value: 10, mod: 0 },
+        wis: { value: 10, mod: 0 },
+        dex: { value: 10, mod: 0, init: 0 },
+        con: { value: 10, mod: 0 },
+        cha: { value: 10, mod: 0 },
+      },
+      hp: { value: 5, max: 5, hd: "1d8" },
+      saves: {
+        death: { value: 12 },
+        wand: { value: 13 },
+        paralysis: { value: 14 },
+        breath: { value: 15 },
+        spell: { value: 16 },
+      },
+      exploration: { ld: 1, od: 2, sd: 1, ft: 1 },
+      initiative: { mod: 0 },
+    },
+    items: { contents: [] },
+  };
+  actor.update = vi.fn(async (data: Record<string, unknown>) => {
+    for (const [k, v] of Object.entries(data)) deepSet(actor, k, v);
+    // Foundry re-renders the sheet from a fresh snapshot; mirror that so controlled inputs follow.
+    return {
+      ...actor,
+      system: { ...(actor.system as object) },
+    } as unknown as OSEActor;
+  });
+  return actor as unknown as OSEActor;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+const connector = { onUpdate: vi.fn(), tearDown: vi.fn() } as never;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+const classInput = () =>
+  Array.from(container.querySelectorAll<HTMLElement>(".ed-field"))
+    .find((f) => f.querySelector(".lab")?.textContent?.startsWith("Class"))
+    ?.querySelector("input") as HTMLInputElement;
+
+describe("EditModal class combobox", () => {
+  it("reflects the selected class after commit", async () => {
+    const actor = makeActor();
+    act(() =>
+      root.render(
+        <OscSheetProvider
+          initialActor={actor}
+          source={actor}
+          contextConnector={connector}
+          canEdit
+        >
+          <EditModal open onClose={() => {}} />
+        </OscSheetProvider>,
+      ),
+    );
+
+    const input = classInput();
+    expect(input.value).toBe("fighter");
+
+    act(() => input.focus());
+    const clericRow = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).find(
+      (r) => r.querySelector(".combobox-optlabel")?.textContent === "cleric",
+    )!;
+    await act(async () => {
+      clericRow.dispatchEvent(
+        new MouseEvent("pointerdown", {
+          bubbles: true,
+          cancelable: true,
+          button: 0,
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(actor.update as ReturnType<typeof vi.fn>).toHaveBeenCalledWith({
+      "system.details.class": "cleric",
+    });
+    expect(actor.system.details.class).toBe("cleric");
+    expect(classInput().value).toBe("cleric"); // display must follow the committed value
+  });
+});

--- a/src/OscSheet/styles/styles.scss
+++ b/src/OscSheet/styles/styles.scss
@@ -203,7 +203,11 @@
 // Repo-local (this sheet only) — the shared @osc/vellum package stays untouched.
 // Values preserve the existing sticky-head number (7); everything popover-and-up
 // is new headroom above it.
-.osc-sheet {
+// Defined on both the window frame (.osc-sheet) and the app root (.osc-sheet-app):
+// modals/popovers portal to .osc-sheet-app, outside the .osc-sheet frame, and must
+// still resolve these tokens (else z-index falls back to auto and dropdowns sink).
+.osc-sheet,
+.osc-sheet-app {
   --z-base: 0; // normal flow
   --z-raised: 1; // small inline lifts (carets, chevrons)
   --z-sticky: 7; // sticky section heads inside the scroll body

--- a/src/OscSheet/styles/vellum/components.css
+++ b/src/OscSheet/styles/vellum/components.css
@@ -44,7 +44,9 @@
   padding: 8px 10px;
   border-radius: var(--r-sm);
   outline: none;
-  transition: border-color 0.12s, background 0.12s;
+  transition:
+    border-color 0.12s,
+    background 0.12s;
   width: 100%;
 }
 .input:focus,
@@ -69,7 +71,9 @@
 .select.is-error {
   border-color: var(--crimson);
 }
-.input.mono { font-family: var(--mono); }
+.input.mono {
+  font-family: var(--mono);
+}
 
 .textarea {
   font-family: var(--serif);
@@ -117,7 +121,10 @@
   cursor: pointer;
   padding: 0;
 }
-.stepper button:hover { color: var(--text); background: var(--surface); }
+.stepper button:hover {
+  color: var(--text);
+  background: var(--surface);
+}
 .stepper input {
   background: transparent;
   border: none;
@@ -144,7 +151,11 @@
   font-size: var(--fs-sm);
   color: var(--text);
 }
-.toggle input { position: absolute; opacity: 0; pointer-events: none; }
+.toggle input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
 .toggle .track {
   width: 34px;
   height: 18px;
@@ -163,7 +174,9 @@
   height: 14px;
   background: var(--text-mute);
   border-radius: 50%;
-  transition: transform 0.15s, background 0.15s;
+  transition:
+    transform 0.15s,
+    background 0.15s;
 }
 .toggle input:checked + .track {
   background: var(--teal);
@@ -174,7 +187,8 @@
   background: var(--on-accent);
 }
 
-.check, .radio {
+.check,
+.radio {
   display: inline-flex;
   align-items: center;
   gap: 9px;
@@ -184,13 +198,20 @@
   font-size: var(--fs-sm);
   color: var(--text);
 }
-.check input, .radio input { position: absolute; opacity: 0; pointer-events: none; }
+.check input,
+.radio input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
 .check .box {
-  width: 16px; height: 16px;
+  width: 16px;
+  height: 16px;
   border: 1.5px solid var(--border);
   background: var(--bg-2);
   border-radius: 3px;
-  display: grid; place-items: center;
+  display: grid;
+  place-items: center;
   transition: all 0.12s;
 }
 .check input:checked + .box {
@@ -205,11 +226,13 @@
   line-height: 1;
 }
 .radio .dot {
-  width: 16px; height: 16px;
+  width: 16px;
+  height: 16px;
   border: 1.5px solid var(--border);
   background: var(--bg-2);
   border-radius: 50%;
-  display: grid; place-items: center;
+  display: grid;
+  place-items: center;
   transition: all 0.12s;
 }
 .radio input:checked + .dot {
@@ -217,7 +240,8 @@
 }
 .radio input:checked + .dot::after {
   content: "";
-  width: 8px; height: 8px;
+  width: 8px;
+  height: 8px;
   background: var(--teal);
   border-radius: 50%;
 }
@@ -249,7 +273,9 @@
   background: var(--surface-3);
   color: var(--text);
 }
-.segmented button:hover:not(.on) { color: var(--text-dim); }
+.segmented button:hover:not(.on) {
+  color: var(--text-dim);
+}
 
 /* ─── Pill select — wrapping discrete single-select pills with counts ─────
    Level tabs etc. Unlike `.segmented` (connected, filled active), pills are
@@ -273,7 +299,10 @@
   padding: 4px 11px;
   border-radius: 999px;
   cursor: pointer;
-  transition: color 0.12s, border-color 0.12s, background 0.12s;
+  transition:
+    color 0.12s,
+    border-color 0.12s,
+    background 0.12s;
 }
 /* count → a flat, muted circle (level slot count). Token-only, so the DS decides the
    per-theme shade: inactive recedes (--bg-2), active stands out (--border, the more
@@ -293,7 +322,10 @@
   letter-spacing: 0;
   color: var(--text-mute);
 }
-.pill-select .pill:hover:not(.on) { color: var(--text-dim); border-color: var(--text-faint); }
+.pill-select .pill:hover:not(.on) {
+  color: var(--text-dim);
+  border-color: var(--text-faint);
+}
 .pill-select .pill.on {
   color: var(--accent-alt);
   border-color: var(--accent-alt);
@@ -322,20 +354,41 @@
   font-size: var(--fs-2xs);
   line-height: 1;
   cursor: pointer;
-  transition: color 0.12s, background 0.12s, border-color 0.12s;
+  transition:
+    color 0.12s,
+    background 0.12s,
+    border-color 0.12s;
 }
-.icon-btn:hover:not(:disabled) { color: var(--text-dim); }
-.icon-btn:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
-.icon-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.icon-btn:hover:not(:disabled) {
+  color: var(--text-dim);
+}
+.icon-btn:focus-visible {
+  outline: 2px solid var(--gold);
+  outline-offset: 2px;
+}
+.icon-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
 
 /* compact box for inline carets / × / trash glyphs */
-.icon-btn.sm { width: 18px; height: 18px; font-size: var(--fs-3xs); }
+.icon-btn.sm {
+  width: 18px;
+  height: 18px;
+  font-size: var(--fs-3xs);
+}
 
 /* danger — delete / remove / × (faint → crimson) */
-.icon-btn.danger:hover:not(:disabled) { color: var(--crimson); }
+.icon-btn.danger:hover:not(:disabled) {
+  color: var(--crimson);
+}
 /* accent — add / edit affordances (faint → brass); `.on` = toggled active */
-.icon-btn.accent:hover:not(:disabled) { color: var(--accent-alt); }
-.icon-btn.on { color: var(--accent-alt); }
+.icon-btn.accent:hover:not(:disabled) {
+  color: var(--accent-alt);
+}
+.icon-btn.on {
+  color: var(--accent-alt);
+}
 /* round — brass-outline add affordance that fills on hover */
 .icon-btn.round {
   border-radius: 999px;
@@ -353,7 +406,9 @@
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--r-md);
-  box-shadow: 0 8px 24px oklch(0 0 0 / 0.35), 0 2px 4px oklch(0 0 0 / 0.2);
+  box-shadow:
+    0 8px 24px oklch(0 0 0 / 0.35),
+    0 2px 4px oklch(0 0 0 / 0.2);
   min-width: 200px;
   padding: 4px 0;
 }
@@ -368,8 +423,12 @@
   cursor: pointer;
   transition: background 0.1s;
 }
-.menu-item:hover { background: var(--surface-2); }
-.menu-item.danger { color: var(--crimson); }
+.menu-item:hover {
+  background: var(--surface-2);
+}
+.menu-item.danger {
+  color: var(--crimson);
+}
 .menu-item .ic {
   width: 14px;
   color: var(--text-mute);
@@ -409,23 +468,38 @@
   top: calc(100% + 8px);
   right: 0;
 }
-.menu.is-popover.is-open { display: block; }
+.menu.is-popover.is-open {
+  display: block;
+}
 .menu.is-popover::before {
   content: "";
   position: absolute;
   top: -7px;
   right: 14px;
-  width: 12px; height: 12px;
+  width: 12px;
+  height: 12px;
   background: var(--surface);
   border-left: 1px solid var(--border);
   border-top: 1px solid var(--border);
   transform: rotate(45deg);
 }
-.menu.is-popover.align-start { right: auto; left: 0; }
-.menu.is-popover.align-start::before { right: auto; left: 14px; }
+.menu.is-popover.align-start {
+  right: auto;
+  left: 0;
+}
+.menu.is-popover.align-start::before {
+  right: auto;
+  left: 14px;
+}
 /* Anchored off the right edge (overlaps slightly into neighbour gutter) */
-.menu.is-popover.align-overhang { right: auto; left: calc(100% - 28px); }
-.menu.is-popover.align-overhang::before { right: auto; left: 14px; }
+.menu.is-popover.align-overhang {
+  right: auto;
+  left: calc(100% - 28px);
+}
+.menu.is-popover.align-overhang::before {
+  right: auto;
+  left: 14px;
+}
 
 /* When the trigger is .card-corner (positioned at top:8px right:8px, 28px tall),
    anchor the popover just under it instead of below the entire card. */
@@ -434,10 +508,12 @@
   right: 8px;
 }
 .menu-host:has(> .menu-trigger.card-corner) > .menu.is-popover.align-start {
-  left: 8px; right: auto;
+  left: 8px;
+  right: auto;
 }
 .menu-host:has(> .menu-trigger.card-corner) > .menu.is-popover.align-overhang {
-  left: calc(100% - 28px); right: auto;
+  left: calc(100% - 28px);
+  right: auto;
 }
 
 /* ─── Combobox — create-or-select ───────────────────────────────────── */
@@ -451,6 +527,31 @@
 }
 .combobox.is-typing .combobox-input {
   cursor: text;
+}
+.combobox-input.is-chip {
+  color: transparent;
+}
+.combobox-chip {
+  position: absolute;
+  top: 50%;
+  left: 10px;
+  right: var(--spacer-8);
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: var(--spacer-2);
+  overflow: hidden;
+  font-family: var(--sans);
+  font-size: var(--fs-sm);
+  color: var(--text);
+  pointer-events: none;
+}
+.combobox-optlabel {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 .combobox-caret {
   position: absolute;
@@ -485,15 +586,26 @@
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--r-md);
-  box-shadow: 0 8px 24px oklch(0 0 0 / 0.35), 0 2px 4px oklch(0 0 0 / 0.2);
+  box-shadow:
+    0 8px 24px oklch(0 0 0 / 0.35),
+    0 2px 4px oklch(0 0 0 / 0.2);
   padding: var(--spacer-1) 0;
 }
 .combobox-opt {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacer-3);
   padding: var(--spacer-2) var(--spacer-3);
   font-family: var(--sans);
   font-size: var(--fs-sm);
   color: var(--text);
   cursor: pointer;
+}
+.combobox-opt.combobox-hint,
+.combobox-opt.combobox-create {
+  justify-content: flex-start;
+  gap: var(--spacer-2);
 }
 .combobox-opt.is-highlighted {
   background: color-mix(in srgb, var(--teal) 18%, transparent);
@@ -518,7 +630,8 @@
 /* ─── Menu trigger — circular ⋯ chip ────────────────────────────────── */
 
 .menu-trigger {
-  width: 28px; height: 28px;
+  width: 28px;
+  height: 28px;
   display: inline-grid;
   place-items: center;
   background: oklch(0 0 0 / 0.4);
@@ -531,13 +644,21 @@
   border-radius: 50%;
   cursor: pointer;
   padding: 0;
-  transition: background 0.15s, opacity 0.15s;
+  transition:
+    background 0.15s,
+    opacity 0.15s;
 }
 .menu-trigger:focus-visible {
-  box-shadow: 0 0 0 2px var(--surface), 0 0 0 4px var(--teal);
+  box-shadow:
+    0 0 0 2px var(--surface),
+    0 0 0 4px var(--teal);
 }
-.menu-trigger:hover { background: oklch(0 0 0 / 0.7); }
-.menu-trigger.is-open { background: oklch(0 0 0 / 0.7); }
+.menu-trigger:hover {
+  background: oklch(0 0 0 / 0.7);
+}
+.menu-trigger.is-open {
+  background: oklch(0 0 0 / 0.7);
+}
 
 /* Light variant — for use over flat surfaces, not imagery */
 .menu-trigger.light {
@@ -553,14 +674,22 @@
 
 /* Host pattern: parent of trigger + popover should declare .menu-host.
    Optional .on-hover modifier on the trigger hides it until the host is hovered. */
-.menu-host { position: relative; }
-.menu-host .menu-trigger.on-hover { opacity: 0; }
+.menu-host {
+  position: relative;
+}
+.menu-host .menu-trigger.on-hover {
+  opacity: 0;
+}
 .menu-host:hover .menu-trigger.on-hover,
 .menu-host:focus-within .menu-trigger.on-hover,
-.menu-host .menu-trigger.on-hover.is-open { opacity: 1; }
+.menu-host .menu-trigger.on-hover.is-open {
+  opacity: 1;
+}
 
 /* When the popover is open, lift the host above siblings */
-.menu-host:has(.menu.is-popover.is-open) { z-index: 50; }
+.menu-host:has(.menu.is-popover.is-open) {
+  z-index: 50;
+}
 
 /* Overflow trigger positioned over the top-right corner of a card.
    Apply to .menu-trigger inside a .menu-host that has imagery up top. */
@@ -587,14 +716,56 @@
   letter-spacing: 0.02em;
   line-height: 1.3;
 }
-.tag.teal    { color: var(--teal);    border-color: var(--teal); background: color-mix(in oklab, var(--teal) 10%, transparent); }
-.tag.crimson { color: var(--crimson); border-color: var(--crimson); background: color-mix(in oklab, var(--crimson) 10%, transparent); }
-.tag.forest  { color: var(--forest);  border-color: var(--forest);  background: color-mix(in oklab, var(--forest) 12%, transparent); }
-.tag.mustard { color: var(--mustard); border-color: var(--mustard); background: color-mix(in oklab, var(--mustard) 12%, transparent); }
-.tag.brass   { color: var(--accent-alt); border-color: var(--accent-alt); background: color-mix(in oklab, var(--accent-alt) 12%, transparent); }
-.tag.solid   { background: var(--ink); color: var(--stamp-text); border-color: var(--ink); font-family: var(--display); font-size: var(--fs-2xs); letter-spacing: 0.08em; text-transform: uppercase; padding: 4px 10px 2px; }
+.tag.xs {
+  gap: 3px;
+  padding: 1px 6px;
+  line-height: 1.2;
+}
+.tag.teal {
+  color: var(--teal);
+  border-color: var(--teal);
+  background: color-mix(in oklab, var(--teal) 10%, transparent);
+}
+.tag.crimson {
+  color: var(--crimson);
+  border-color: var(--crimson);
+  background: color-mix(in oklab, var(--crimson) 10%, transparent);
+}
+.tag.forest {
+  color: var(--forest);
+  border-color: var(--forest);
+  background: color-mix(in oklab, var(--forest) 12%, transparent);
+}
+.tag.mustard {
+  color: var(--mustard);
+  border-color: var(--mustard);
+  background: color-mix(in oklab, var(--mustard) 12%, transparent);
+}
+.tag.brass {
+  color: var(--accent-alt);
+  border-color: var(--accent-alt);
+  background: color-mix(in oklab, var(--accent-alt) 12%, transparent);
+}
+.tag.solid {
+  background: var(--ink);
+  color: var(--stamp-text);
+  border-color: var(--ink);
+  font-family: var(--display);
+  font-size: var(--fs-2xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 4px 10px 2px;
+}
 /* count — brass-solid numeric pill (container item counts, etc.) */
-.tag.count   { background: var(--accent-alt-dim); border-color: var(--accent-alt-dim); color: var(--on-accent); font-size: var(--fs-2xs); padding: 1px 7px; min-width: 16px; justify-content: center; }
+.tag.count {
+  background: var(--accent-alt-dim);
+  border-color: var(--accent-alt-dim);
+  color: var(--on-accent);
+  font-size: var(--fs-2xs);
+  padding: 1px 7px;
+  min-width: 16px;
+  justify-content: center;
+}
 
 /* chip — the square, dark, icon-first weapon-tag box (quality / attack-kind
    tags), ported verbatim from the retired `.fvtt-tag` in actions.scss. `.tag.chip`
@@ -619,10 +790,18 @@
   white-space: nowrap;
   cursor: default;
 }
-.tag.chip i { font-size: var(--fs-xs); }
-.tag.chip .tag-txt { padding: 0 var(--spacer-1); }
-.tag.chip.melee i { color: var(--gold); }
-.tag.chip.missile i { color: var(--teal); }
+.tag.chip i {
+  font-size: var(--fs-xs);
+}
+.tag.chip .tag-txt {
+  padding: 0 var(--spacer-1);
+}
+.tag.chip.melee i {
+  color: var(--gold);
+}
+.tag.chip.missile i {
+  color: var(--teal);
+}
 
 /* ─── Tooltip popover — `.tag-pop` ───────────────────────────────────────
    Shared hover tooltip: absolutely positioned above its host, hidden until the
@@ -654,7 +833,9 @@
 }
 .tag.chip:hover .tag-pop,
 .kind-seg:hover .tag-pop,
-.wstat:hover .tag-pop { opacity: 1; }
+.wstat:hover .tag-pop {
+  opacity: 1;
+}
 
 /* ─── SectionHeader — title row + optional right-aligned control ─────────
    The SectionHeader component's layout (was `.osc-feat-head` in features.scss):
@@ -671,7 +852,12 @@
   padding-bottom: var(--spacer-1);
   border-bottom: 2px solid var(--border);
 }
-.section-header .section-title { flex: 1; margin: 0; padding-bottom: 0; border-bottom: none; }
+.section-header .section-title {
+  flex: 1;
+  margin: 0;
+  padding-bottom: 0;
+  border-bottom: none;
+}
 
 /* ─── Pips — dot-meter (spell casts / slot pips) ─────────────────────────
    Vellum-native, fully self-contained (Wave 2). Two variants cover both call
@@ -682,7 +868,11 @@
        (the level-head slot diamonds); fills gold with an on-accent glyph.
    Raw px (dot sizes, 1.5px ring, 8px glyph) are intentional and vellum-exempt
    from the SCSS px guardrail. */
-.pips { display: inline-flex; align-items: center; gap: var(--spacer-1); }
+.pips {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacer-1);
+}
 .pip {
   width: 16px;
   height: 16px;
@@ -690,11 +880,19 @@
   background: var(--gold-soft);
   border: 1px solid var(--gold-soft);
 }
-.pip.filled { background: var(--gold); border-color: var(--gold); }
+.pip.filled {
+  background: var(--gold);
+  border-color: var(--gold);
+}
 /* sm — cast dots */
-.pips.sm .pip { width: 9px; height: 9px; }
+.pips.sm .pip {
+  width: 9px;
+  height: 9px;
+}
 /* square — sharp-cornered dots instead of the disc (e.g. inventory uses) */
-.pips.square .pip { border-radius: 0; }
+.pips.square .pip {
+  border-radius: 0;
+}
 /* hollow — bordered ring holding an optional glyph (slot pips) */
 .pips.hollow .pip {
   background: transparent;
@@ -731,7 +929,9 @@
    outranked by `.stamp.sm`). The Actions XS overrides (`.osc-sheet-app
    .plaque-ability …` in actions.scss) load after this file, so they still win
    at ≤479px. */
-.plaque { text-align: center; }
+.plaque {
+  text-align: center;
+}
 
 /* ── Ability plaque ─────────────────────────────────────────────────────── */
 .plaque-ability {
@@ -774,10 +974,18 @@
     linear-gradient(var(--gold), var(--gold)) 100% 100% / 9px 1.5px no-repeat,
     linear-gradient(var(--gold), var(--gold)) 100% 100% / 1.5px 9px no-repeat;
 }
-[data-theme="cream"] .plaque-ability { background: var(--surface); }
-[data-theme="cream"] .plaque-ability.rollable:hover { background: var(--surface-2); }
+[data-theme="cream"] .plaque-ability {
+  background: var(--surface);
+}
+[data-theme="cream"] .plaque-ability.rollable:hover {
+  background: var(--surface-2);
+}
 /* Stamp: stretched ink label near the top (padding/font-size left to .stamp.sm) */
-.plaque-ability .pk { align-self: stretch; margin: 1px 7px 0; width: auto; }
+.plaque-ability .pk {
+  align-self: stretch;
+  margin: 1px 7px 0;
+  width: auto;
+}
 /* Big serif value fills the middle */
 .plaque-ability .pv {
   position: relative;
@@ -812,9 +1020,19 @@
   color: var(--ink);
 }
 /* rollable affordance (gold border + focus ring) */
-.plaque-ability.rollable { cursor: pointer; transition: border-color 0.12s, box-shadow 0.12s; }
-.plaque-ability.rollable:hover { border-color: var(--gold); }
-.plaque-ability.rollable:focus-visible { outline: 2px solid var(--gold); outline-offset: -2px; }
+.plaque-ability.rollable {
+  cursor: pointer;
+  transition:
+    border-color 0.12s,
+    box-shadow 0.12s;
+}
+.plaque-ability.rollable:hover {
+  border-color: var(--gold);
+}
+.plaque-ability.rollable:focus-visible {
+  outline: 2px solid var(--gold);
+  outline-offset: -2px;
+}
 
 /* ── Save plaque ────────────────────────────────────────────────────────── */
 .plaque-save {
@@ -823,11 +1041,21 @@
   border-radius: var(--r-md);
   padding: var(--spacer-2) var(--spacer-1) 7px;
   text-align: center;
-  transition: border-color 0.12s, background 0.12s;
+  transition:
+    border-color 0.12s,
+    background 0.12s;
 }
-.plaque-save.rollable { cursor: pointer; }
-.plaque-save.rollable:hover { border-color: var(--gold); background: var(--surface-2); }
-.plaque-save.rollable:focus-visible { outline: 2px solid var(--gold); outline-offset: -2px; }
+.plaque-save.rollable {
+  cursor: pointer;
+}
+.plaque-save.rollable:hover {
+  border-color: var(--gold);
+  background: var(--surface-2);
+}
+.plaque-save.rollable:focus-visible {
+  outline: 2px solid var(--gold);
+  outline-offset: -2px;
+}
 /* 22px ink stamp (folds in the old .fvtt-save .stamp.sk reconciliation) */
 .plaque-save .pk {
   width: 22px;
@@ -867,7 +1095,9 @@
   padding: 40px;
   z-index: 100;
 }
-[data-theme="cream"] .modal-scrim { background: oklch(0 0 0 / 0.35); }
+[data-theme="cream"] .modal-scrim {
+  background: oklch(0 0 0 / 0.35);
+}
 
 .modal {
   position: relative;
@@ -905,7 +1135,9 @@
   display: grid;
   place-items: center;
 }
-.modal-head .x:hover { color: var(--text); }
+.modal-head .x:hover {
+  color: var(--text);
+}
 .modal-body {
   padding: 18px 22px;
   overflow-y: auto;
@@ -914,8 +1146,12 @@
   color: var(--text-dim);
   line-height: 1.55;
 }
-.modal-body p { margin: 0 0 10px; }
-.modal-body p:last-child { margin-bottom: 0; }
+.modal-body p {
+  margin: 0 0 10px;
+}
+.modal-body p:last-child {
+  margin-bottom: 0;
+}
 .modal-foot {
   padding: 14px 22px;
   border-top: 1px solid var(--border-soft);
@@ -969,8 +1205,13 @@
   place-items: center;
   color: var(--teal);
 }
-.toast .body { flex: 1 1 auto; min-width: 0; }
-.toast .x { flex: none; }
+.toast .body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.toast .x {
+  flex: none;
+}
 .toast .ttl {
   font-family: var(--display);
   font-size: var(--fs-md);
@@ -994,12 +1235,24 @@
   padding: 0;
   line-height: 1;
 }
-.toast.success { border-left-color: var(--forest); }
-.toast.success .ic { color: var(--forest); }
-.toast.danger { border-left-color: var(--crimson); }
-.toast.danger .ic { color: var(--crimson); }
-.toast.warning { border-left-color: var(--mustard); }
-.toast.warning .ic { color: var(--mustard); }
+.toast.success {
+  border-left-color: var(--forest);
+}
+.toast.success .ic {
+  color: var(--forest);
+}
+.toast.danger {
+  border-left-color: var(--crimson);
+}
+.toast.danger .ic {
+  color: var(--crimson);
+}
+.toast.warning {
+  border-left-color: var(--mustard);
+}
+.toast.warning .ic {
+  color: var(--mustard);
+}
 
 /* ─── Empty / loading state ─────────────────────────────────────────── */
 
@@ -1034,17 +1287,23 @@
 
 /* Loading skeleton */
 .skel {
-  background: linear-gradient(90deg,
+  background: linear-gradient(
+    90deg,
     var(--surface) 0%,
     var(--surface-2) 50%,
-    var(--surface) 100%);
+    var(--surface) 100%
+  );
   background-size: 200% 100%;
   animation: skel 1.2s ease-in-out infinite;
   border-radius: 3px;
 }
 @keyframes skel {
-  0%   { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
 }
 
 /* ─── Data table ────────────────────────────────────────────────────── */
@@ -1063,7 +1322,7 @@
   color: var(--stamp-text);
   font-family: var(--display);
   font-size: var(--fs-2xs);
-  letter-spacing: 0.10em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
   padding: 9px 12px;
   text-align: left;
@@ -1076,97 +1335,245 @@
   color: var(--text);
   border-top: 1px solid var(--border-soft);
 }
-.table tbody tr:first-child td { border-top: none; }
-.table tbody tr:nth-child(even) td { background: color-mix(in oklab, var(--surface-2) 60%, transparent); }
-.table tbody tr:hover td { background: var(--surface-2); }
-.table td.num, .table th.num { font-family: var(--mono); font-size: var(--fs-xs); text-align: right; }
-.table td.dim { color: var(--text-mute); }
+.table tbody tr:first-child td {
+  border-top: none;
+}
+.table tbody tr:nth-child(even) td {
+  background: color-mix(in oklab, var(--surface-2) 60%, transparent);
+}
+.table tbody tr:hover td {
+  background: var(--surface-2);
+}
+.table td.num,
+.table th.num {
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  text-align: right;
+}
+.table td.dim {
+  color: var(--text-mute);
+}
 
 /* InlineButton — transparent inline action (teal → brass) */
 .inline-btn {
-  display: inline-grid; place-items: center;
-  padding: 0; background: transparent; border: none; cursor: pointer;
+  display: inline-grid;
+  place-items: center;
+  padding: 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
   color: var(--teal);
 }
-.inline-btn:hover { color: var(--accent-alt); }
-.inline-btn:active { transform: translateY(0.5px); }
-.inline-btn:focus { outline: none; }
-.inline-btn:focus-visible { outline: 2px solid var(--teal); outline-offset: 2px; border-radius: var(--r-sm); }
+.inline-btn:hover {
+  color: var(--accent-alt);
+}
+.inline-btn:active {
+  transform: translateY(0.5px);
+}
+.inline-btn:focus {
+  outline: none;
+}
+.inline-btn:focus-visible {
+  outline: 2px solid var(--teal);
+  outline-offset: 2px;
+  border-radius: var(--r-sm);
+}
 
 /* ConfirmDialog — in-window confirm in the Vellum language */
 .ed-confirm-scrim {
-  position: absolute; inset: 0; z-index: 30;
-  display: grid; place-items: center; padding: 18px;
-  background: oklch(0 0 0 / 0.5); border-radius: inherit;
+  position: absolute;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  padding: 18px;
+  background: oklch(0 0 0 / 0.5);
+  border-radius: inherit;
 }
 .ed-confirm {
-  width: 100%; max-width: 320px;
-  background: var(--surface); border: 1px solid var(--border);
-  border-radius: var(--r-md); overflow: hidden;
+  width: 100%;
+  max-width: 320px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  overflow: hidden;
   box-shadow: 0 18px 48px oklch(0 0 0 / 0.5);
 }
 .ed-confirm-head {
-  font-family: var(--display); font-size: var(--fs-lg); letter-spacing: 0.02em;
-  color: var(--stamp-text); background: var(--ink);
-  padding: 10px 16px; border-bottom: 1px solid var(--border);
+  font-family: var(--display);
+  font-size: var(--fs-lg);
+  letter-spacing: 0.02em;
+  color: var(--stamp-text);
+  background: var(--ink);
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
 }
 .ed-confirm-body {
-  font-family: var(--sans); font-size: var(--fs-md);
-  color: var(--text); line-height: 1.5; padding: 16px;
+  font-family: var(--sans);
+  font-size: var(--fs-md);
+  color: var(--text);
+  line-height: 1.5;
+  padding: 16px;
 }
-.ed-confirm-foot { display: flex; justify-content: flex-end; gap: 8px; padding: 10px 16px 14px; }
+.ed-confirm-foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 10px 16px 14px;
+}
 
 /* OverrideValue — mono default / teal dotted reset link */
 .ed-resetlink {
-  font-family: var(--mono); font-size: var(--fs-3xs);
-  color: var(--teal); background: transparent; border: none; padding: 0;
-  cursor: pointer; line-height: 1.4; align-self: flex-start; text-align: left;
-  text-decoration: underline; text-decoration-style: dotted; text-underline-offset: 2px;
+  font-family: var(--mono);
+  font-size: var(--fs-3xs);
+  color: var(--teal);
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  line-height: 1.4;
+  align-self: flex-start;
+  text-align: left;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 2px;
 }
-.ed-resetlink.ed-meta-center, .hint.ed-meta-center { text-align: center; align-self: center; }
-.ed-resetlink:hover { color: var(--teal); text-decoration-style: solid; }
-.ed-resetlink:focus { outline: none; }
-.ed-resetlink:focus-visible { outline: 2px solid var(--teal); outline-offset: 2px; border-radius: var(--r-sm); }
+.ed-resetlink.ed-meta-center,
+.hint.ed-meta-center {
+  text-align: center;
+  align-self: center;
+}
+.ed-resetlink:hover {
+  color: var(--teal);
+  text-decoration-style: solid;
+}
+.ed-resetlink:focus {
+  outline: none;
+}
+.ed-resetlink:focus-visible {
+  outline: 2px solid var(--teal);
+  outline-offset: 2px;
+  border-radius: var(--r-sm);
+}
 
 /* StampCell — ink-stamp numeric cell */
-.ed-cell { position: relative; display: flex; flex-direction: column; align-items: stretch; gap: 5px; min-width: 0; }
+.ed-cell {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 5px;
+  min-width: 0;
+}
 .ed-cell .ck {
-  text-align: center; padding: 4px 0 3px;
-  background: var(--ink); color: var(--stamp-text); border-radius: var(--r-sm);
-  font-family: var(--display); font-size: var(--fs-2xs); letter-spacing: 0.08em;
+  text-align: center;
+  padding: 4px 0 3px;
+  background: var(--ink);
+  color: var(--stamp-text);
+  border-radius: var(--r-sm);
+  font-family: var(--display);
+  font-size: var(--fs-2xs);
+  letter-spacing: 0.08em;
 }
 .ed-cell .num {
-  background: var(--bg-2); border: 1px solid var(--border); color: var(--text);
-  font-family: var(--mono); font-size: var(--fs-lg); text-align: center;
-  padding: 8px 2px; border-radius: var(--r-sm); width: 100%; min-width: 0; box-sizing: border-box;
-  outline: none; -moz-appearance: textfield;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: var(--fs-lg);
+  text-align: center;
+  padding: 8px 2px;
+  border-radius: var(--r-sm);
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  outline: none;
+  -moz-appearance: textfield;
 }
 .ed-cell .num::-webkit-outer-spin-button,
-.ed-cell .num::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
-.ed-cell .num:focus { border-color: var(--teal); background: var(--bg); }
+.ed-cell .num::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.ed-cell .num:focus {
+  border-color: var(--teal);
+  background: var(--bg);
+}
 .ed-cell .cm {
-  font-family: var(--mono); font-size: var(--fs-3xs); color: var(--text-mute);
-  text-align: center; min-height: 13px; line-height: 1.2;
+  font-family: var(--mono);
+  font-size: var(--fs-3xs);
+  color: var(--text-mute);
+  text-align: center;
+  min-height: 13px;
+  line-height: 1.2;
 }
 /* warn — e.g. an ability score below the class requirement */
-.ed-cell.warn .num { border-color: var(--crimson); }
-.ed-cell.warn .num:focus { border-color: var(--crimson); }
-.ed-cell.warn .cm { color: var(--crimson); }
+.ed-cell.warn .num {
+  border-color: var(--crimson);
+}
+.ed-cell.warn .num:focus {
+  border-color: var(--crimson);
+}
+.ed-cell.warn .cm {
+  color: var(--crimson);
+}
 
 /* PortraitField — framed image with teal corner ticks */
 .ed-portrait {
-  position: relative; aspect-ratio: 1 / 1; width: 84px; flex: 0 0 auto;
-  border: 1px solid var(--border); border-radius: var(--r-sm); overflow: hidden;
-  background: linear-gradient(160deg, oklch(0.34 0.018 60), oklch(0.2 0.012 60));
-  display: grid; place-items: center; cursor: pointer; padding: 0;
+  position: relative;
+  aspect-ratio: 1 / 1;
+  width: 84px;
+  flex: 0 0 auto;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  overflow: hidden;
+  background: linear-gradient(
+    160deg,
+    oklch(0.34 0.018 60),
+    oklch(0.2 0.012 60)
+  );
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  padding: 0;
 }
-[data-theme="cream"] .ed-portrait { background: linear-gradient(160deg, var(--surface-3), var(--surface-2)); }
-.ed-portrait::before, .ed-portrait::after {
-  content: ""; position: absolute; width: 13px; height: 13px;
-  border: 1.5px solid color-mix(in srgb, var(--teal) 75%, transparent); z-index: 2; pointer-events: none;
+[data-theme="cream"] .ed-portrait {
+  background: linear-gradient(160deg, var(--surface-3), var(--surface-2));
 }
-.ed-portrait::before { top: 5px; left: 5px; border-right: none; border-bottom: none; }
-.ed-portrait::after  { bottom: 5px; right: 5px; border-left: none; border-top: none; }
-.ed-portrait img { width: 100%; height: 100%; object-fit: cover; display: block; }
-.ed-portrait-ph { font-family: var(--mono); font-size: var(--fs-3xs); color: var(--text-mute); }
-.ed-portrait:focus-visible { outline: 2px solid var(--teal); outline-offset: 2px; }
+.ed-portrait::before,
+.ed-portrait::after {
+  content: "";
+  position: absolute;
+  width: 13px;
+  height: 13px;
+  border: 1.5px solid color-mix(in srgb, var(--teal) 75%, transparent);
+  z-index: 2;
+  pointer-events: none;
+}
+.ed-portrait::before {
+  top: 5px;
+  left: 5px;
+  border-right: none;
+  border-bottom: none;
+}
+.ed-portrait::after {
+  bottom: 5px;
+  right: 5px;
+  border-left: none;
+  border-top: none;
+}
+.ed-portrait img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.ed-portrait-ph {
+  font-family: var(--mono);
+  font-size: var(--fs-3xs);
+  color: var(--text-mute);
+}
+.ed-portrait:focus-visible {
+  outline: 2px solid var(--teal);
+  outline-offset: 2px;
+}

--- a/src/OscSheet/styles/vellum/components.css
+++ b/src/OscSheet/styles/vellum/components.css
@@ -440,6 +440,81 @@
   left: calc(100% - 28px); right: auto;
 }
 
+/* ─── Combobox — create-or-select ───────────────────────────────────── */
+
+.combobox {
+  position: relative;
+}
+.combobox-input {
+  padding-right: var(--spacer-6);
+  cursor: pointer;
+}
+.combobox.is-typing .combobox-input {
+  cursor: text;
+}
+.combobox-caret {
+  position: absolute;
+  top: 50%;
+  right: var(--spacer-3);
+  transform: translateY(-50%);
+  display: inline-flex;
+  color: var(--text-faint);
+  font-size: var(--fs-2xs);
+  pointer-events: none;
+  transition: color 120ms ease;
+}
+.combobox.is-open .combobox-caret {
+  color: var(--text-dim);
+}
+.combobox-opt.combobox-hint {
+  color: var(--text-faint);
+  cursor: default;
+  border-bottom: 1px solid var(--border-soft);
+}
+.combobox-opt.combobox-hint .combobox-create-plus {
+  color: inherit;
+}
+.combobox-pop {
+  position: absolute;
+  z-index: var(--z-popover);
+  top: calc(100% + var(--spacer-1));
+  left: 0;
+  right: 0;
+  max-height: 240px;
+  overflow-y: auto;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  box-shadow: 0 8px 24px oklch(0 0 0 / 0.35), 0 2px 4px oklch(0 0 0 / 0.2);
+  padding: var(--spacer-1) 0;
+}
+.combobox-opt {
+  padding: var(--spacer-2) var(--spacer-3);
+  font-family: var(--sans);
+  font-size: var(--fs-sm);
+  color: var(--text);
+  cursor: pointer;
+}
+.combobox-opt.is-highlighted {
+  background: color-mix(in srgb, var(--teal) 18%, transparent);
+  color: var(--text);
+}
+.combobox-create {
+  color: var(--text-dim);
+  border-top: 1px solid var(--border-soft);
+}
+.combobox-create-plus {
+  font-family: var(--mono);
+  color: var(--teal);
+}
+.combobox-empty {
+  padding: var(--spacer-2) var(--spacer-3);
+  font-family: var(--sans);
+  font-size: var(--fs-xs);
+  font-style: italic;
+  color: var(--text-faint);
+}
+
 /* ─── Menu trigger — circular ⋯ chip ────────────────────────────────── */
 
 .menu-trigger {


### PR DESCRIPTION
The Edit modal's class field now uses the Combobox: pick a known class or type a custom one. Options and the at-rest value carry a Classic/Advanced/Custom source tag. Dropdown is portaled so it can't be clipped/sunk in the modal.