### PR TITLE
Freeform alignment via Combobox (OSC-125)

### DIFF
--- a/src/OscSheet/components/ui/PortraitField.tsx
+++ b/src/OscSheet/components/ui/PortraitField.tsx
@@ -17,8 +17,13 @@ export function PortraitField({
   const openPicker = () => {
     // foundry.applications.apps.FilePicker.implementation in v13+; fall back to the legacy global.
     const FP =
-      (foundry as unknown as { applications?: { apps?: { FilePicker?: { implementation?: unknown } } } })
-        .applications?.apps?.FilePicker?.implementation ??
+      (
+        foundry as unknown as {
+          applications?: {
+            apps?: { FilePicker?: { implementation?: unknown } };
+          };
+        }
+      ).applications?.apps?.FilePicker?.implementation ??
       (globalThis as unknown as { FilePicker?: unknown }).FilePicker;
     if (!FP) return;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -30,8 +35,18 @@ export function PortraitField({
   };
 
   return (
-    <button type="button" className={cx("ed-portrait", className)} onClick={openPicker} title="Change portrait" aria-label="Change portrait">
-      {src ? <img src={src} alt="" /> : <span className="ed-portrait-ph">{placeholder}</span>}
+    <button
+      type="button"
+      className={cx("ed-portrait", className)}
+      onClick={openPicker}
+      title="Change portrait"
+      aria-label="Change portrait"
+    >
+      {src ? (
+        <img src={src} alt="" />
+      ) : (
+        <span className="ed-portrait-ph">{placeholder}</span>
+      )}
     </button>
   );
 }

--- a/src/OscSheet/features/edit/EditModal.tsx
+++ b/src/OscSheet/features/edit/EditModal.tsx
@@ -209,17 +209,13 @@ export function EditModal({
           <div className="ed-idgrid">
             <label className="ed-field" style={{ gridColumn: "1 / span 3" }}>
               <span className="lab">Alignment</span>
-              <select
-                className="ed-input"
+              <Combobox
                 value={sys.details.alignment}
-                onChange={(e) =>
-                  set("system.details.alignment", e.target.value)
-                }
-              >
-                {ALIGNMENTS.map((a) => (
-                  <option key={a}>{a}</option>
-                ))}
-              </select>
+                options={ALIGNMENTS.map((a) => ({ value: a, label: a }))}
+                onCommit={(v) => set("system.details.alignment", v)}
+                createHint="Type to set a custom alignment"
+                newOptionLabel={(q) => `Custom: “${q}”`}
+              />
             </label>
             <label className="ed-field" style={{ gridColumn: "4 / span 3" }}>
               <span className="lab">Level</span>

--- a/src/OscSheet/features/edit/EditModal.tsx
+++ b/src/OscSheet/features/edit/EditModal.tsx
@@ -7,7 +7,6 @@ import {
   ConfirmDialog,
   OverrideValue,
   StampCell,
-  InlineButton,
   PortraitField,
   NumberInput,
   ValidatedInput,
@@ -20,7 +19,8 @@ import {
   availableClassNames,
   classSource,
 } from "@domain/classRules";
-import type { OSEActor, OSESave } from "@domain/types";
+import type { OSESave } from "@domain/types";
+import { HitDiceField } from "./HitDiceField";
 
 const SOURCE_TAG = {
   advanced: ["Advanced", "teal"],
@@ -34,68 +34,10 @@ function classFace(name: string): ReactNode {
   return (
     <>
       <span className="combobox-optlabel">{name.replace(/-/g, " ")}</span>
-      <Tag intent={intent} size="xs">{text}</Tag>
+      <Tag intent={intent} size="xs">
+        {text}
+      </Tag>
     </>
-  );
-}
-
-// A hit-die formula must be a valid Roll AND actually contain a die term.
-const validateHd = (v: string) =>
-  /d\d/i.test(v) && Roll.validate(v) ? null : "invalid dice formula";
-
-// Freeform hit-dice formula field: validates the roll string on blur (via
-// ValidatedInput), committing only when valid; the roll button uses the
-// last committed value.
-function HitDiceField({
-  actor,
-  hdVal,
-  hdDefault,
-  hdOverridden,
-  onCommit,
-  onResetRequest,
-}: {
-  actor: OSEActor;
-  hdVal: string;
-  hdDefault: string | null | undefined;
-  hdOverridden: boolean;
-  onCommit: (v: string) => void;
-  onResetRequest: () => void;
-}) {
-  const rollHd = () => {
-    const speaker = ChatMessage.getSpeaker({ actor });
-    void new Roll(hdVal).toMessage(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      { speaker, flavor: `Hit Dice — ${hdVal}` } as any,
-    );
-  };
-
-  return (
-    <div className="ed-field" style={{ gridColumn: "7 / span 3" }}>
-      <span className="lab">Hit Dice</span>
-      <InlineButton
-        className="ed-rollbtn"
-        title={`Roll ${hdVal} hit points`}
-        onClick={rollHd}
-      >
-        <i className="fa-solid fa-dice-d20" aria-hidden="true" />
-      </InlineButton>
-      <ValidatedInput
-        className="ed-input mono"
-        value={hdVal}
-        validate={validateHd}
-        onCommit={onCommit}
-        spellCheck={false}
-        hint={
-          hdDefault != null ? (
-            <OverrideValue
-              overridden={hdOverridden}
-              defaultText={`default · ${hdDefault}`}
-              onResetRequest={onResetRequest}
-            />
-          ) : undefined
-        }
-      />
-    </div>
   );
 }
 
@@ -180,34 +122,58 @@ export function EditModal({
               {sys.details.class.replace(/-/g, " ")}
             </em>
           </SectionTitle>
-          <div className="ed-id-top">
+          <div className="ed-id-grid">
             <PortraitField
               src={actor.img}
               onPick={(path) => set("img", path)}
             />
-            <div className="ed-id-grid">
-              <label className="ed-field" style={{ gridColumn: "1 / span 8" }}>
-                <span className="lab">Name</span>
-                <ValidatedInput
-                  className="ed-input"
-                  value={actor.name}
-                  validate={(v) => (v ? null : "name can’t be empty")}
-                  onCommit={(v) => set("name", v)}
-                />
-              </label>
-              <label className="ed-field" style={{ gridColumn: "9 / span 4" }}>
-                <span className="lab">Title</span>
-                <ValidatedInput
-                  className="ed-input"
-                  value={sys.details.title}
-                  validate={() => null}
-                  onCommit={(v) => set("system.details.title", v)}
-                />
-              </label>
-            </div>
-          </div>
-          <div className="ed-idgrid">
-            <label className="ed-field" style={{ gridColumn: "1 / span 3" }}>
+            <label className="ed-field" style={{ gridColumn: "span 3" }}>
+              <span className="lab">Name</span>
+              <ValidatedInput
+                className="input"
+                value={actor.name}
+                validate={(v) => (v ? null : "name can’t be empty")}
+                onCommit={(v) => set("name", v)}
+              />
+            </label>
+            <label className="ed-field" style={{ gridColumn: "span 4" }}>
+              <span className="lab">
+                Class <span className="hint">GM</span>
+              </span>
+              <Combobox
+                disabled={!isGM}
+                value={sys.details.class}
+                options={(classNames ?? []).map((c) => ({
+                  value: c,
+                  label: c.replace(/-/g, " "),
+                  node: classFace(c),
+                }))}
+                onCommit={(v) => set("system.details.class", v)}
+                renderValue={classFace}
+                createHint="Type to set a custom class"
+                newOptionLabel={(q) => `Custom: “${q}”`}
+              />
+            </label>
+            <label className="ed-field" style={{ gridColumn: "span 2" }}>
+              <span className="lab">Level</span>
+              <NumberInput
+                className="input mono"
+                value={level}
+                min={1}
+                max={defaults.maxLevel}
+                onCommit={(n) => set("system.details.level", n)}
+              />
+            </label>
+            <label className="ed-field" style={{ gridColumn: "span 3" }}>
+              <span className="lab">Title</span>
+              <ValidatedInput
+                className="input"
+                value={sys.details.title}
+                validate={() => null}
+                onCommit={(v) => set("system.details.title", v)}
+              />
+            </label>
+            <label className="ed-field" style={{ gridColumn: "span 4" }}>
               <span className="lab">Alignment</span>
               <Combobox
                 value={sys.details.alignment}
@@ -217,29 +183,35 @@ export function EditModal({
                 newOptionLabel={(q) => `Custom: “${q}”`}
               />
             </label>
-            <label className="ed-field" style={{ gridColumn: "4 / span 3" }}>
-              <span className="lab">Level</span>
-              <NumberInput
-                className="ed-input mono"
-                value={level}
-                min={1}
-                max={defaults.maxLevel}
-                onCommit={(n) => set("system.details.level", n)}
-              />
-            </label>
-            <label className="ed-field" style={{ gridColumn: "7 / span 3" }}>
+
+            <HitDiceField
+              style={{ gridColumn: "span 2" }}
+              actor={actor}
+              hdVal={hdVal}
+              hdDefault={hdDefault}
+              hdOverridden={hdOverridden}
+              onCommit={(v) => set("system.hp.hd", v)}
+              onResetRequest={() =>
+                requestConfirm(
+                  "Reset Hit Dice?",
+                  `Revert to the class default of ${hdDefault}.`,
+                  () => set("system.hp.hd", hdDefault!),
+                )
+              }
+            />
+            <label className="ed-field" style={{ gridColumn: "span 3" }}>
               <span className="lab">Current XP</span>
               <NumberInput
-                className="ed-input mono"
+                className="input mono"
                 value={sys.details.xp.value}
                 min={0}
                 onCommit={(n) => set("system.details.xp.value", n)}
               />
             </label>
-            <label className="ed-field" style={{ gridColumn: "10 / span 3" }}>
+            <label className="ed-field" style={{ gridColumn: "span 3" }}>
               <span className="lab">Next Level</span>
               <NumberInput
-                className="ed-input mono"
+                className="input mono"
                 value={sys.details.xp.next}
                 min={0}
                 onCommit={(n) => set("system.details.xp.next", n)}
@@ -258,44 +230,30 @@ export function EditModal({
                 />
               )}
             </label>
-
-            <label className="ed-field" style={{ gridColumn: "1 / span 3" }}>
+            <label className="ed-field" style={{ gridColumn: "span 2" }}>
               <span className="lab">Current HP</span>
               <NumberInput
-                className="ed-input mono"
+                className="input mono"
                 value={sys.hp.value}
                 min={0}
                 max={sys.hp.max}
                 onCommit={(n) => set("system.hp.value", n)}
               />
             </label>
-            <label className="ed-field" style={{ gridColumn: "4 / span 3" }}>
+            <label className="ed-field" style={{ gridColumn: "span 2" }}>
               <span className="lab">Max HP</span>
               <NumberInput
-                className="ed-input mono"
+                className="input mono"
                 value={sys.hp.max}
                 min={1}
                 onCommit={(n) => set("system.hp.max", n)}
               />
             </label>
-            <HitDiceField
-              actor={actor}
-              hdVal={hdVal}
-              hdDefault={hdDefault}
-              hdOverridden={hdOverridden}
-              onCommit={(v) => set("system.hp.hd", v)}
-              onResetRequest={() =>
-                requestConfirm(
-                  "Reset Hit Dice?",
-                  `Revert to the class default of ${hdDefault}.`,
-                  () => set("system.hp.hd", hdDefault!),
-                )
-              }
-            />
-            <div className="ed-field" style={{ gridColumn: "10 / span 3" }}>
+
+            <div className="ed-field" style={{ gridColumn: "span 2" }}>
               <span className="lab">Initiative Mod</span>
               <NumberInput
-                className="ed-input mono"
+                className="input mono"
                 value={initEff}
                 onCommit={(n) => set("system.initiative.mod", n - dexInit)}
               />
@@ -311,26 +269,6 @@ export function EditModal({
                 }
               />
             </div>
-
-            {isGM && classNames.length > 0 && (
-              <label className="ed-field" style={{ gridColumn: "1 / span 6" }}>
-                <span className="lab">
-                  Class <span className="hint">GM</span>
-                </span>
-                <Combobox
-                  value={sys.details.class}
-                  options={classNames.map((c) => ({
-                    value: c,
-                    label: c.replace(/-/g, " "),
-                    node: classFace(c),
-                  }))}
-                  onCommit={(v) => set("system.details.class", v)}
-                  renderValue={classFace}
-                  createHint="Type to set a custom class"
-                  newOptionLabel={(q) => `Custom: “${q}”`}
-                />
-              </label>
-            )}
           </div>
         </div>
 
@@ -411,7 +349,7 @@ export function EditModal({
               <label className="ed-field" key={k}>
                 <span className="lab">{n}</span>
                 <select
-                  className="ed-input mono"
+                  className="input mono"
                   value={sys.exploration[k]}
                   onChange={(e) =>
                     set(`system.exploration.${k}`, Number(e.target.value))

--- a/src/OscSheet/features/edit/EditModalClass.test.tsx
+++ b/src/OscSheet/features/edit/EditModalClass.test.tsx
@@ -142,3 +142,49 @@ describe("EditModal class combobox", () => {
     expect(classInput().value).toBe("cleric"); // display must follow the committed value
   });
 });
+
+const alignmentInput = () =>
+  Array.from(container.querySelectorAll<HTMLElement>(".ed-field"))
+    .find((f) => f.querySelector(".lab")?.textContent?.startsWith("Alignment"))
+    ?.querySelector("input") as HTMLInputElement;
+
+describe("EditModal alignment combobox", () => {
+  it("commits a preset B/X alignment on selection", async () => {
+    const actor = makeActor();
+    act(() =>
+      root.render(
+        <OscSheetProvider
+          initialActor={actor}
+          source={actor}
+          contextConnector={connector}
+          canEdit
+        >
+          <EditModal open onClose={() => {}} />
+        </OscSheetProvider>,
+      ),
+    );
+
+    const input = alignmentInput();
+    expect(input.value).toBe("Neutral");
+
+    act(() => input.focus());
+    const chaotic = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).find((r) => r.textContent === "Chaotic")!;
+    await act(async () => {
+      chaotic.dispatchEvent(
+        new MouseEvent("pointerdown", {
+          bubbles: true,
+          cancelable: true,
+          button: 0,
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(actor.update as ReturnType<typeof vi.fn>).toHaveBeenCalledWith({
+      "system.details.alignment": "Chaotic",
+    });
+    expect(actor.system.details.alignment).toBe("Chaotic");
+  });
+});

--- a/src/OscSheet/features/edit/HitDiceField.tsx
+++ b/src/OscSheet/features/edit/HitDiceField.tsx
@@ -1,0 +1,66 @@
+import {
+  InlineButton,
+  OverrideValue,
+  ValidatedInput,
+} from "@src/OscSheet/components/ui";
+import type { OSEActor } from "@src/OscSheet/domain/types";
+import type { CSSProperties } from "react";
+
+// A hit-die formula must be a valid Roll AND actually contain a die term.
+const validateHd = (v: string) =>
+  /d\d/i.test(v) && Roll.validate(v) ? null : "invalid dice formula";
+
+export function HitDiceField({
+  actor,
+  hdVal,
+  hdDefault,
+  hdOverridden,
+  onCommit,
+  onResetRequest,
+  style,
+}: {
+  actor: OSEActor;
+  hdVal: string;
+  hdDefault: string | null | undefined;
+  hdOverridden: boolean;
+  onCommit: (v: string) => void;
+  onResetRequest: () => void;
+  style: CSSProperties;
+}) {
+  const rollHd = () => {
+    const speaker = ChatMessage.getSpeaker({ actor });
+    void new Roll(hdVal).toMessage(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { speaker, flavor: `Hit Dice — ${hdVal}` } as any,
+    );
+  };
+
+  return (
+    <div className="ed-field" style={style}>
+      <span className="lab">Hit Dice</span>
+      <InlineButton
+        className="ed-rollbtn"
+        title={`Roll ${hdVal} hit points`}
+        onClick={rollHd}
+      >
+        <i className="fa-solid fa-dice-d20" aria-hidden="true" />
+      </InlineButton>
+      <ValidatedInput
+        className="input mono"
+        value={hdVal}
+        validate={validateHd}
+        onCommit={onCommit}
+        spellCheck={false}
+        hint={
+          hdDefault != null ? (
+            <OverrideValue
+              overridden={hdOverridden}
+              defaultText={`default · ${hdDefault}`}
+              onResetRequest={onResetRequest}
+            />
+          ) : undefined
+        }
+      />
+    </div>
+  );
+}

--- a/src/OscSheet/styles/edit-modal.scss
+++ b/src/OscSheet/styles/edit-modal.scss
@@ -19,72 +19,174 @@
   }
   // Cap the form width on wide windows (it centers via the scrim's place-items);
   // .modal's width:100% still shrinks it below the cap on narrow sheets.
-  .fe-modal { container-type: inline-size; container-name: fwin; max-width: 760px; max-height: 100%; margin: 0; }
-  .fe-modal-body { display: flex; flex-direction: column; gap: 20px; }
+  .fe-modal {
+    container-type: inline-size;
+    container-name: fwin;
+    max-width: 760px;
+    max-height: 100%;
+    margin: 0;
+  }
+  .fe-modal-body {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  }
 
-  .ed-sec { display: flex; flex-direction: column; gap: 12px; }
-  .ed-sec > .section-title { margin: 0; font-size: var(--fs-2xl); }
+  .ed-sec {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .ed-sec > .section-title {
+    margin: 0;
+    font-size: var(--fs-2xl);
+  }
   // Class name in the Identity header — real serif italic (the display face is
   // small-caps with no true italic), slightly dimmed as an annotation.
-  .ed-id-class { font-family: var(--serif); font-style: italic; color: var(--text-dim); }
+  .ed-id-class {
+    font-family: var(--serif);
+    font-style: italic;
+    color: var(--text-dim);
+  }
 
-  .ed-id-top { display: flex; gap: 14px; align-items: stretch; }
-  .ed-id-top .ed-portrait { align-self: stretch; height: auto; }
-  .ed-id-grid { flex: 1 1 auto; min-width: 0; display: grid; grid-template-columns: repeat(12, minmax(0, 1fr)); gap: 14px; align-content: start; }
-  .ed-idgrid { display: grid; grid-template-columns: repeat(12, minmax(0, 1fr)); gap: 14px; align-items: start; }
-  .ed-id-grid .ed-field, .ed-idgrid .ed-field { min-width: 0; }
-  .ed-id-grid .lab, .ed-idgrid .lab { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; letter-spacing: 0.06em; }
-  .ed-idgrid .ed-locked { font-size: var(--fs-sm); padding: 9px 11px; width: 100%; }
+  .ed-portrait {
+    width: 100%;
+    height: auto;
+    grid-column: 1 / span 3;
+    grid-row: 1 / span 2;
+  }
+  .ed-id-grid {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: grid;
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    gap: 14px;
+    align-content: start;
+  }
+  .ed-idgrid {
+    display: grid;
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    gap: 14px;
+    align-items: start;
+  }
+  .ed-id-grid .ed-field,
+  .ed-idgrid .ed-field {
+    min-width: 0;
+  }
+  .ed-id-grid .lab,
+  .ed-idgrid .lab {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    letter-spacing: 0.06em;
+  }
+  .ed-idgrid .ed-locked {
+    font-size: var(--fs-sm);
+    padding: 9px 11px;
+    width: 100%;
+  }
 
-  .ed-field { display: flex; flex-direction: column; gap: 5px; min-width: 0; position: relative; }
+  .ed-field {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    min-width: 0;
+    position: relative;
+  }
   .ed-field > .lab {
-    font-family: var(--sans); font-weight: 600;
-    font-size: var(--fs-3xs); letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim);
+    font-family: var(--sans);
+    font-weight: 600;
+    font-size: var(--fs-3xs);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--text-dim);
   }
-  .ed-field .hint { font-family: var(--mono); font-size: var(--fs-3xs); color: var(--text-mute); line-height: 1.4; }
-
-  .ed-input {
-    background: var(--surface); border: 1px solid var(--border); color: var(--text);
-    font-family: var(--sans); font-size: var(--fs-sm);
-    padding: 9px 11px; border-radius: var(--r-sm); width: 100%; min-width: 0;
-    outline: none; box-sizing: border-box; transition: border-color .12s, background .12s;
-    -moz-appearance: textfield;
+  .ed-field .hint {
+    font-family: var(--mono);
+    font-size: var(--fs-3xs);
+    color: var(--text-mute);
+    line-height: 1.4;
   }
-  .ed-input::-webkit-outer-spin-button, .ed-input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
-  .ed-input:focus { border-color: var(--teal); background: var(--bg); }
-  .ed-input.is-error, .ed-input.is-error:focus { border-color: var(--crimson); }
-  .ed-input.mono { font-family: var(--mono); }
-  select.ed-input { cursor: pointer; }
 
   .ed-locked {
-    display: inline-flex; align-items: center; gap: 7px;
-    background: var(--bg-2); border: 1px dashed var(--border); border-radius: var(--r-sm);
-    padding: 8px 11px; color: var(--text-dim);
-    font-family: var(--display); font-size: var(--fs-md); letter-spacing: 0.02em;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    background: var(--bg-2);
+    border: 1px dashed var(--border);
+    border-radius: var(--r-sm);
+    padding: 8px 11px;
+    color: var(--text-dim);
+    font-family: var(--display);
+    font-size: var(--fs-md);
+    letter-spacing: 0.02em;
   }
 
   // HD inline roll button — corner placement + d20 sizing (the InlineButton
   // primitive owns only the look; placement is this consumer's job).
-  .ed-field .ed-rollbtn { position: absolute; top: -2px; right: 0; width: 18px; height: 18px; line-height: 0; z-index: 3; }
-  .ed-field .ed-rollbtn .fa-dice-d20 { font-size: var(--fs-md); }
+  .ed-field .ed-rollbtn {
+    position: absolute;
+    top: -2px;
+    right: 0;
+    width: 18px;
+    height: 18px;
+    line-height: 0;
+    z-index: 3;
+  }
+  .ed-field .ed-rollbtn .fa-dice-d20 {
+    font-size: var(--fs-md);
+  }
 
-  .ed-cells { display: grid; gap: 8px; }
-  .ed-cells.ed-abil { grid-template-columns: repeat(6, minmax(0, 1fr)); }
-  .ed-cells.ed-save { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+  .ed-cells {
+    display: grid;
+    gap: 8px;
+  }
+  .ed-cells.ed-abil {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+  .ed-cells.ed-save {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
 
-  .ed-skills { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px 14px; }
-  .ed-skills .ed-field > .lab { text-transform: none; letter-spacing: 0.02em; font-family: var(--serif); font-style: italic; font-size: var(--fs-xs); color: var(--text-dim); font-weight: 400; }
+  .ed-skills {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px 14px;
+  }
+  .ed-skills .ed-field > .lab {
+    text-transform: none;
+    letter-spacing: 0.02em;
+    font-family: var(--serif);
+    font-style: italic;
+    font-size: var(--fs-xs);
+    color: var(--text-dim);
+    font-weight: 400;
+  }
 
-  // Identity grids are 4-up via per-field grid-column spans (set inline in JSX);
-  // collapse to 2-up on narrow modals so labels/inputs aren't crushed. The
-  // !important beats the inline grid-column so fields auto-flow into 2 columns.
+  // Narrow modal: keep the 12-col grid but override the wide inline spans.
+  // Fields go half-width (span 6); comboboxes take the full row (span 12);
+  // the portrait shrinks to a small square (span 3, single row).
   @container fwin (max-width: 560px) {
-    .ed-id-grid, .ed-idgrid { grid-template-columns: 1fr 1fr; }
-    .ed-id-grid > .ed-field, .ed-idgrid > .ed-field { grid-column: auto !important; }
+    .ed-id-grid > .ed-field,
+    .ed-idgrid > .ed-field {
+      grid-column: span 6 !important;
+    }
+    .ed-id-grid > .ed-field:has(.combobox),
+    .ed-idgrid > .ed-field:has(.combobox) {
+      grid-column: span 12 !important;
+    }
+    .ed-portrait {
+      grid-column: span 3 !important;
+      grid-row: span 1 !important;
+    }
   }
 
   @container fwin (max-width: 520px) {
-    .ed-cells.ed-abil { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-    .ed-skills { grid-template-columns: 1fr; }
+    .ed-cells.ed-abil {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+    .ed-skills {
+      grid-template-columns: 1fr;
+    }
   }
 }


### PR DESCRIPTION
The Edit modal's Alignment field is now a create-or-select Combobox: the three B/X alignments (Lawful/Neutral/Chaotic) are preset options, and any other value — AD&D 9-way (Chaotic Evil, etc.) or homebrew — can be typed and committed verbatim. Fixes #104.