### PR TITLE
Editable base movement + auto-calculate toggle (OSC-123)

### DIFF
--- a/src/OscSheet/app/OscSheetProvider.tsx
+++ b/src/OscSheet/app/OscSheetProvider.tsx
@@ -35,7 +35,7 @@ function OscSheetProvider({
   };
 
   async function updateActor(updateData: {
-    [key: string]: string | number;
+    [key: string]: string | number | boolean;
   }): Promise<OSEActor | void> {
     // Read-only sheets short-circuit the actor write layer: a defence-in-depth
     // backstop so any UI path that slips the per-control canEdit gating still

--- a/src/OscSheet/app/SheetShell.tsx
+++ b/src/OscSheet/app/SheetShell.tsx
@@ -73,11 +73,11 @@ export default function SheetShell() {
     ac: selectAc(aac, ac, equippedArmor, isAscending),
     initMod: scores.dex.init + (initiative?.mod ?? 0),
     hd: hp.hd,
-    move: movement.base,
+    move: Math.floor(movement.base),
     moveBands: {
-      encounter: movement.encounter,
-      explore: movement.base,
-      travel: movement.overland,
+      encounter: Math.floor(movement.encounter),
+      explore: Math.floor(movement.base),
+      travel: Math.floor(movement.overland),
     },
   };
   // One encumbrance VM for both consumers — the header MOVE hover and the inventory

--- a/src/OscSheet/domain/types.ts
+++ b/src/OscSheet/domain/types.ts
@@ -43,7 +43,7 @@ export interface OscSheetContextValue {
    *  sheet). Components hide/disable write affordances when false. */
   canEdit: boolean;
   updateActor: (updateData: {
-    [key: string]: string | number | string[];
+    [key: string]: string | number | boolean | string[];
   }) => Promise<OSEActor | void>;
   /** Apply an optimistic patch (flat dot-paths) to a doc immediately, run the real
    *  Foundry write, and reconcile/rollback async. `key` = item `_id` or "actor".
@@ -66,6 +66,9 @@ export type OSEActor = Actor & {
   system: {
     aac: CharacterAC;
     ac: CharacterAC;
+    config?: {
+      movementAuto?: boolean;
+    };
     details: {
       alignment: string;
       class: string;
@@ -135,7 +138,9 @@ export type OSEActor = Actor & {
     save: OSESave,
     options: { event?: RollEvent; fastForward?: boolean; chatMessage?: string }
   ) => void;
-  update: (updateData: { [key: string]: string | number }) => Promise<OSEActor>;
+  update: (updateData: {
+    [key: string]: string | number | boolean;
+  }) => Promise<OSEActor>;
 };
 
 export type OseItem = Omit<Item, "type"> & {

--- a/src/OscSheet/features/edit/EditModal.movement.test.tsx
+++ b/src/OscSheet/features/edit/EditModal.movement.test.tsx
@@ -1,0 +1,206 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import OscSheetProvider from "@app/OscSheetProvider";
+import { EditModal } from "./EditModal";
+import type { OSEActor } from "@domain/types";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function deepSet(obj: Record<string, unknown>, path: string, value: unknown) {
+  const parts = path.split(".");
+  let cur = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    cur[parts[i]] ??= {};
+    cur = cur[parts[i]] as Record<string, unknown>;
+  }
+  cur[parts[parts.length - 1]] = value;
+}
+
+const g = globalThis as Record<string, unknown>;
+g.foundry = { utils: { debounce: (fn: unknown) => fn } };
+g.game = { user: { isGM: true } };
+g.Roll = { validate: () => true };
+g.ChatMessage = { getSpeaker: () => ({}) };
+g.CONFIG = {
+  OSE: {
+    classes: {
+      classic: {
+        fighter: { levels: [{ xp: 0, hd: "1d8", saves: [1, 2, 3, 4, 5] }] },
+      },
+    },
+  },
+};
+
+const RAW_BASE = 120; // stored (manual) base
+const DERIVED_BASE = 90; // encumbrance-scaled getter value ≠ raw
+
+function makeActor(
+  movementAuto: boolean,
+  rawBase = RAW_BASE,
+  scaled = DERIVED_BASE,
+): OSEActor {
+  const movement = { encounter: 30, overland: 18 };
+  // Mirror OSE's getter: scaled by encumbrance when auto, raw #moveBase when manual.
+  Object.defineProperty(movement, "base", {
+    get: () => (movementAuto ? scaled : rawBase),
+    set: () => {},
+    enumerable: true,
+    configurable: true,
+  });
+
+  const actor: Record<string, unknown> = {
+    name: "Test",
+    img: "x.png",
+    system: {
+      config: { movementAuto },
+      details: {
+        class: "fighter",
+        title: "",
+        alignment: "Neutral",
+        level: 1,
+        xp: { value: 0, next: 2000 },
+      },
+      scores: {
+        str: { value: 10, mod: 0 },
+        int: { value: 10, mod: 0 },
+        wis: { value: 10, mod: 0 },
+        dex: { value: 10, mod: 0, init: 0 },
+        con: { value: 10, mod: 0 },
+        cha: { value: 10, mod: 0 },
+      },
+      hp: { value: 5, max: 5, hd: "1d8" },
+      thac0: { value: 19, bba: 0 },
+      movement,
+      saves: {
+        death: { value: 12 },
+        wand: { value: 13 },
+        paralysis: { value: 14 },
+        breath: { value: 15 },
+        spell: { value: 16 },
+      },
+      exploration: { ld: 1, od: 2, sd: 1, ft: 1 },
+      initiative: { mod: 0 },
+    },
+    _source: { system: { movement: { base: rawBase } } },
+    items: { contents: [] },
+  };
+  actor.update = vi.fn(async (data: Record<string, unknown>) => {
+    for (const [k, v] of Object.entries(data)) deepSet(actor, k, v);
+    return {
+      ...actor,
+      system: { ...(actor.system as object) },
+    } as unknown as OSEActor;
+  });
+  return actor as unknown as OSEActor;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+const connector = { onUpdate: vi.fn(), tearDown: vi.fn() } as never;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function render(actor: OSEActor) {
+  act(() =>
+    root.render(
+      <OscSheetProvider
+        initialActor={actor}
+        source={actor}
+        contextConnector={connector}
+        canEdit
+      >
+        <EditModal open onClose={() => {}} />
+      </OscSheetProvider>,
+    ),
+  );
+}
+
+const moveField = () =>
+  Array.from(container.querySelectorAll<HTMLElement>(".ed-field")).find(
+    (f) => f.querySelector(".lab")?.textContent === "Base Movement",
+  )!;
+const moveInput = () => moveField().querySelector("input[type=number]") as HTMLInputElement;
+const autoCheck = () =>
+  moveField().querySelector(".ed-movecalc input") as HTMLInputElement;
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value",
+  )!.set!;
+  setter.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+describe("EditModal base movement", () => {
+  it("auto OFF shows the editable raw base (getter returns it unscaled)", () => {
+    render(makeActor(false));
+    expect(moveInput().value).toBe(String(RAW_BASE));
+    expect(moveInput().disabled).toBe(false);
+    expect(autoCheck().checked).toBe(false);
+  });
+
+  it("auto ON shows the encumbrance-scaled getter and disables the field", () => {
+    // base 120 at the first breakpoint → 120 × 0.75 = 90
+    render(makeActor(true));
+    expect(moveInput().value).toBe(String(DERIVED_BASE));
+    expect(moveInput().disabled).toBe(true);
+    expect(autoCheck().checked).toBe(true);
+  });
+
+  it("auto ON scales the CUSTOM base (mirrors OSE — the override is used, not ignored)", () => {
+    // custom base 300 at the first breakpoint → 300 × 0.75 = 225
+    render(makeActor(true, 300, 225));
+    expect(moveInput().value).toBe("225");
+  });
+
+  it("commits system.movement.base when edited (auto off)", async () => {
+    const actor = makeActor(false);
+    render(actor);
+    act(() => moveInput().focus());
+    act(() => setInputValue(moveInput(), "150"));
+    await act(async () => {
+      moveInput().blur();
+      await Promise.resolve();
+    });
+    expect(actor.update as ReturnType<typeof vi.fn>).toHaveBeenCalledWith({
+      "system.movement.base": 150,
+    });
+  });
+
+  it("toggles system.config.movementAuto false when unchecked", async () => {
+    const actor = makeActor(true);
+    render(actor);
+    await act(async () => {
+      autoCheck().click();
+      await Promise.resolve();
+    });
+    expect(actor.update as ReturnType<typeof vi.fn>).toHaveBeenCalledWith({
+      "system.config.movementAuto": false,
+    });
+  });
+
+  it("toggles system.config.movementAuto true when checked", async () => {
+    const actor = makeActor(false);
+    render(actor);
+    await act(async () => {
+      autoCheck().click();
+      await Promise.resolve();
+    });
+    expect(actor.update as ReturnType<typeof vi.fn>).toHaveBeenCalledWith({
+      "system.config.movementAuto": true,
+    });
+  });
+});

--- a/src/OscSheet/features/edit/EditModal.tsx
+++ b/src/OscSheet/features/edit/EditModal.tsx
@@ -12,6 +12,7 @@ import {
   ValidatedInput,
   Combobox,
   Tag,
+  Check,
 } from "@src/OscSheet/components/ui";
 import { useOscSheetContext } from "@app/context";
 import {
@@ -82,7 +83,7 @@ export function EditModal({
 
   const sys = actor.system;
   const defaults = selectClassDefaults(actor);
-  const set = (key: string, value: string | number) =>
+  const set = (key: string, value: string | number | boolean) =>
     void updateActor({ [key]: value });
 
   // --- Identity / progression ---
@@ -112,6 +113,15 @@ export function EditModal({
         ? 19 - defaults.thac0
         : defaults.thac0;
   const atkOverridden = atkDefault != null && atkVal !== atkDefault;
+
+  // --- Movement ---
+  // Mirror OSE's own sheet: show system.movement.base (the derived getter —
+  // encumbrance-scaled when auto, raw when manual), disabled while auto-calculate is
+  // on. The checkbox only toggles the flag. Floored so a breakpoint fraction doesn't
+  // render as e.g. 82.5; editing (auto off) writes the raw base.
+  const movementAuto = sys.config?.movementAuto ?? true;
+  const rawMoveBase = actor._source?.system?.movement?.base ?? 120;
+  const moveShown = Math.floor(sys.movement?.base ?? rawMoveBase);
 
   const footer = (
     <Button variant="primary" onClick={onClose}>
@@ -244,7 +254,7 @@ export function EditModal({
                 />
               )}
             </label>
-            <label className="ed-field" style={{ gridColumn: "span 2" }}>
+            <label className="ed-field" style={{ gridColumn: "span 3" }}>
               <span className="lab">Current HP</span>
               <NumberInput
                 className="input mono"
@@ -264,7 +274,7 @@ export function EditModal({
               />
             </label>
 
-            <div className="ed-field" style={{ gridColumn: "span 2" }}>
+            <div className="ed-field" style={{ gridColumn: "span 3" }}>
               <span className="lab">Initiative Mod</span>
               <NumberInput
                 className="input mono"
@@ -284,7 +294,7 @@ export function EditModal({
               />
             </div>
 
-            <div className="ed-field" style={{ gridColumn: "1 / span 3" }}>
+            <div className="ed-field" style={{ gridColumn: "span 3" }}>
               <span className="lab">{atkLabel}</span>
               <NumberInput
                 className="input mono"
@@ -304,6 +314,26 @@ export function EditModal({
                   }
                 />
               )}
+            </div>
+
+            <div className="ed-field" style={{ gridColumn: "span 4" }}>
+              <span className="lab">Base Movement</span>
+              <NumberInput
+                className="input mono"
+                value={moveShown}
+                min={0}
+                disabled={movementAuto}
+                onCommit={(n) => set("system.movement.base", n)}
+              />
+              <Check
+                className="ed-movecalc"
+                checked={movementAuto}
+                onChange={(e) =>
+                  set("system.config.movementAuto", e.target.checked)
+                }
+              >
+                Auto-calculate movement
+              </Check>
             </div>
           </div>
         </div>

--- a/src/OscSheet/features/inventory/encumbrance.ts
+++ b/src/OscSheet/features/inventory/encumbrance.ts
@@ -42,9 +42,9 @@ export function selectEncumbrance(actor: OSEActor, items?: OseItem[]): Encumbran
       status: TIER_STATUS[0],
       label: "",
       moveBands: {
-        encounter: movement?.encounter ?? 0,
-        explore: movement?.base ?? 0,
-        travel: movement?.overland ?? 0,
+        encounter: Math.floor(movement?.encounter ?? 0),
+        explore: Math.floor(movement?.base ?? 0),
+        travel: Math.floor(movement?.overland ?? 0),
       },
       bands: [],
     };
@@ -83,9 +83,9 @@ export function selectEncumbrance(actor: OSEActor, items?: OseItem[]): Encumbran
     label: `${e.value} / ${e.max} ${unit}`,
     armorTier: basicArmorTier(e, sigTreasure),
     moveBands: {
-      encounter: movement?.encounter ?? 0,
-      explore: movement?.base ?? 0,
-      travel: movement?.overland ?? 0,
+      encounter: Math.floor(movement?.encounter ?? 0),
+      explore: Math.floor(movement?.base ?? 0),
+      travel: Math.floor(movement?.overland ?? 0),
     },
     bands,
     barTier: tier,

--- a/src/OscSheet/styles/edit-modal.scss
+++ b/src/OscSheet/styles/edit-modal.scss
@@ -107,6 +107,7 @@
     color: var(--text-mute);
     line-height: 1.4;
   }
+  .ed-field .ed-movecalc { margin-top: 2px; font-size: var(--fs-2xs); color: var(--text-dim); }
 
   .ed-locked {
     display: inline-flex;


### PR DESCRIPTION
Adds a **Base Movement** field to the Edit modal with an **Auto-calculate movement** checkbox, mirroring the core OSE Tweaks "Calculate Movement" lock.

- Checkbox writes `system.config.movementAuto` (default true).
- When auto is ON: field is disabled and shows the derived `movement.base` getter.
- When auto is OFF: field is editable, reads the raw `_source.system.movement.base` (fallback 120), commits `system.movement.base`.

Types: added `system.config.movementAuto` and widened `updateActor`/`update` to accept boolean.

Tests: new `EditModal.movement.test.tsx` (source-vs-derived read, disabled state, base commit, toggle both directions). Full suite green.

Fixes #102