### PR TITLE
Trial: e2e with 2 Playwright workers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ jobs:
       - run:
           name: Run Playwright E2E suite
           working_directory: tools/e2e
-          command: npx playwright test --forbid-only --workers=1
+          command: npx playwright test --forbid-only --workers=2
 
       - store_artifacts:
           path: tools/e2e/playwright-report


### PR DESCRIPTION
Bumps the CircleCI e2e job to `--workers=2` to see if it passes against the shared Foundry world. If it flakes, we hold at 1 (see OSC-127 for the per-test-actor isolation that makes parallelism safe).