### PR TITLE
ci: revert e2e to 1 worker until OSC-127

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ jobs:
       - run:
           name: Run Playwright E2E suite
           working_directory: tools/e2e
-          command: npx playwright test --forbid-only --workers=2
+          command: npx playwright test --forbid-only --workers=1
 
       - store_artifacts:
           path: tools/e2e/playwright-report


### PR DESCRIPTION
The #113 2-worker trial flakes — parallel specs share one seeded actor ("E2E Fighter") and hit detached-DOM re-render races (readonly, save specs). Per-test actor fixtures (OSC-127, parked) are the prerequisite for parallel workers; revert to serial until that lands.

Root-caused from the osc-124 e2e failure (pipeline 21): 10 passed, 1 flaky (save), 1 failed (readonly) — none code-related.

https://claude.ai/code/session_01Hz4TsRDweBe2ur47Ku9s3V