### PR TITLE
fix(inventory): equipped-item popover no longer clipped at the sheet's left edge

### DIFF
--- a/src/OscSheet/components/ui/HoverPop.test.tsx
+++ b/src/OscSheet/components/ui/HoverPop.test.tsx
@@ -67,7 +67,7 @@ describe("HoverPop", () => {
     hover(trigger, "pointerenter");
     expect(pop.style.position).toBe("fixed");
     expect(pop.style.visibility).toBe("");
-    expect(pop.style.top).toBe("106px"); // trigger bottom + 6 gap
+    expect(pop.style.top).toBe("111px"); // trigger bottom + 11 gap (clears the arrow)
     expect(pop.style.left).toBe("200px"); // align="start" → trigger's left edge
 
     hover(trigger, "pointerleave");
@@ -156,17 +156,18 @@ function Tray() {
 }
 
 describe("both hover cards share HoverPop", () => {
-  // Same mechanism; only the equipped card draws an arrow, so only it needs a bigger gap.
-  it("places both cards off their trigger, the arrowed one clear of it", () => {
+  it("places both cards identically and gives both the shared shell", () => {
     act(() => root.render(<Tray />));
     const equipPop = container.querySelector<HTMLElement>(".osc-equip-tt-pop")!;
     const tile = equipPop.parentElement!;
     expect(tile.className).toContain("osc-equip-tcard");
     expect(equipPop.style.position).toBe("fixed");
+    expect(equipPop.className).toContain("osc-hoverpop");
 
     stubRect(tile, { left: 300, width: 50, bottom: 240 });
     hover(tile, "pointerenter");
     expect(equipPop.style.top).toBe("251px"); // 240 + 11
+    expect(equipPop.hasAttribute("data-open")).toBe(true);
 
     act(() =>
       root.render(
@@ -179,7 +180,8 @@ describe("both hover cards share HoverPop", () => {
     const trigger = movePop.parentElement!;
     stubRect(trigger, { left: 300, width: 50, bottom: 240 });
     hover(trigger, "pointerenter");
-    expect(movePop.style.top).toBe("246px"); // no arrow → default 6
+    expect(movePop.style.top).toBe("251px");
     expect(movePop.style.position).toBe(equipPop.style.position);
+    expect(movePop.className).toContain("osc-hoverpop");
   });
 });

--- a/src/OscSheet/components/ui/HoverPop.test.tsx
+++ b/src/OscSheet/components/ui/HoverPop.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+// The popover must escape its clipping ancestor: an ancestor with `overflow-y: auto`
+// computes `overflow-x` as a clip box, so an absolutely-positioned card is cut off at
+// the sheet's edge (the equipped-item card lost its whole left half). Both hover
+// cards therefore go through HoverPop → `position: fixed`, JS-anchored, clamped to the
+// viewport. These tests pin the strategy, not the pixels.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { HoverPop } from "@ui/HoverPop";
+import { EquippedTray } from "@features/inventory/EquippedTray";
+import { useDragReorder } from "@features/inventory/useDragReorder";
+import { MoveTooltip } from "@ui/MovePop";
+import type { InventoryItemVM } from "@domain/vm-types";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+/** jsdom has no layout: stub the trigger's rect so placement has real numbers. */
+function stubRect(el: Element, r: { left: number; width: number; bottom: number }) {
+  vi.spyOn(el, "getBoundingClientRect").mockReturnValue({
+    ...r,
+    top: r.bottom - 50,
+    right: r.left + r.width,
+    height: 50,
+    x: r.left,
+    y: r.bottom - 50,
+    toJSON: () => "",
+  } as DOMRect);
+}
+
+const hover = (el: Element, type: "pointerenter" | "pointerleave") =>
+  act(() => {
+    el.dispatchEvent(new Event(type, { bubbles: false }));
+  });
+
+describe("HoverPop", () => {
+  it("is fixed, not absolute, so no overflow ancestor can clip it", () => {
+    act(() =>
+      root.render(
+        <span className="trigger">
+          <HoverPop className="pop">body</HoverPop>
+        </span>,
+      ),
+    );
+    const trigger = container.querySelector(".trigger")!;
+    const pop = container.querySelector<HTMLElement>(".pop")!;
+
+    // closed: laid out but invisible (measurable, so placement is a single pass)
+    expect(pop.style.position).toBe("fixed");
+    expect(pop.style.visibility).toBe("hidden");
+
+    stubRect(trigger, { left: 200, width: 50, bottom: 100 });
+    hover(trigger, "pointerenter");
+    expect(pop.style.position).toBe("fixed");
+    expect(pop.style.visibility).toBe("");
+    expect(pop.style.top).toBe("106px"); // trigger bottom + 6 gap
+    expect(pop.style.left).toBe("200px"); // align="start" → trigger's left edge
+
+    hover(trigger, "pointerleave");
+    expect(pop.style.visibility).toBe("hidden");
+  });
+
+  it("clamps a centred card to the sheet instead of letting it overhang", () => {
+    act(() =>
+      root.render(
+        <span className="trigger">
+          <HoverPop className="pop" align="center">
+            body
+          </HoverPop>
+        </span>,
+      ),
+    );
+    const trigger = container.querySelector(".trigger")!;
+    const pop = container.querySelector<HTMLElement>(".pop")!;
+    // a 200px card centred under the first tile of the equipped tray would start at
+    // -75px; clamped it starts at the 8px viewport margin, arrow still on the tile.
+    vi.spyOn(pop, "offsetWidth", "get").mockReturnValue(200);
+    stubRect(trigger, { left: 0, width: 50, bottom: 120 });
+
+    hover(trigger, "pointerenter");
+    expect(pop.style.left).toBe("8px");
+    expect(pop.style.getPropertyValue("--anchor-x")).toBe("17px");
+  });
+
+  it("clamps inside the sheet window when there is one, not the viewport", () => {
+    act(() =>
+      root.render(
+        <div className="osc-sheet-app">
+          <span className="trigger">
+            <HoverPop className="pop" align="center">
+              body
+            </HoverPop>
+          </span>
+        </div>,
+      ),
+    );
+    const app = container.querySelector(".osc-sheet-app")!;
+    const trigger = container.querySelector(".trigger")!;
+    const pop = container.querySelector<HTMLElement>(".pop")!;
+    vi.spyOn(pop, "offsetWidth", "get").mockReturnValue(200);
+    stubRect(app, { left: 400, width: 500, bottom: 600 });
+    stubRect(trigger, { left: 420, width: 50, bottom: 120 });
+
+    hover(trigger, "pointerenter");
+    expect(pop.style.left).toBe("408px"); // sheet's left edge + 8, not 345
+  });
+});
+
+const item: InventoryItemVM = {
+  id: "sword",
+  name: "Sword",
+  img: "",
+  category: "Weapon",
+  categoryRank: 0,
+  damage: "1d8",
+  tags: [],
+  monogram: "S",
+  weight: 60,
+  cost: 10,
+  armorClass: null,
+  sort: 100,
+  equippedSort: 100,
+  equipped: true,
+  quantity: null,
+  isContainer: false,
+  children: [],
+};
+
+function Tray() {
+  const dnd = useDragReorder();
+  return (
+    <EquippedTray
+      items={[item]}
+      dnd={dnd}
+      itemDragData={() => undefined}
+      onOpen={() => {}}
+      onContext={() => {}}
+      equipDropActive={false}
+      onEquipDrop={() => {}}
+    />
+  );
+}
+
+describe("both hover cards share HoverPop", () => {
+  it("the equipped-item card is placed the same way as the movement card", () => {
+    act(() => root.render(<Tray />));
+    const equipPop = container.querySelector<HTMLElement>(".osc-equip-tt-pop")!;
+    const tile = equipPop.parentElement!;
+    expect(tile.className).toContain("osc-equip-tcard");
+    expect(equipPop.style.position).toBe("fixed");
+
+    stubRect(tile, { left: 300, width: 50, bottom: 240 });
+    hover(tile, "pointerenter");
+    expect(equipPop.style.top).toBe("246px");
+
+    act(() =>
+      root.render(
+        <span className="trigger">
+          <MoveTooltip bands={{ encounter: 40, explore: 120, travel: 24 }} />
+        </span>,
+      ),
+    );
+    const movePop = container.querySelector<HTMLElement>(".osc-move-pop")!;
+    const trigger = movePop.parentElement!;
+    stubRect(trigger, { left: 300, width: 50, bottom: 240 });
+    hover(trigger, "pointerenter");
+    expect(movePop.style.top).toBe("246px");
+    expect(movePop.style.position).toBe(equipPop.style.position);
+  });
+});

--- a/src/OscSheet/components/ui/HoverPop.test.tsx
+++ b/src/OscSheet/components/ui/HoverPop.test.tsx
@@ -156,9 +156,7 @@ function Tray() {
 }
 
 describe("both hover cards share HoverPop", () => {
-  // Same mechanism, one deliberate difference: only the equipped card draws an arrow,
-  // and that arrow pokes above the card's top edge, so it needs a bigger gap or its tip
-  // sits on the tile. The movement card has no arrow and keeps the default.
+  // Same mechanism; only the equipped card draws an arrow, so only it needs a bigger gap.
   it("places both cards off their trigger, the arrowed one clear of it", () => {
     act(() => root.render(<Tray />));
     const equipPop = container.querySelector<HTMLElement>(".osc-equip-tt-pop")!;
@@ -168,8 +166,7 @@ describe("both hover cards share HoverPop", () => {
 
     stubRect(tile, { left: 300, width: 50, bottom: 240 });
     hover(tile, "pointerenter");
-    // 240 + 11: the arrow reaches ~7px up, leaving ~4px of air under the tile
-    expect(equipPop.style.top).toBe("251px");
+    expect(equipPop.style.top).toBe("251px"); // 240 + 11
 
     act(() =>
       root.render(

--- a/src/OscSheet/components/ui/HoverPop.test.tsx
+++ b/src/OscSheet/components/ui/HoverPop.test.tsx
@@ -156,7 +156,10 @@ function Tray() {
 }
 
 describe("both hover cards share HoverPop", () => {
-  it("the equipped-item card is placed the same way as the movement card", () => {
+  // Same mechanism, one deliberate difference: only the equipped card draws an arrow,
+  // and that arrow pokes above the card's top edge, so it needs a bigger gap or its tip
+  // sits on the tile. The movement card has no arrow and keeps the default.
+  it("places both cards off their trigger, the arrowed one clear of it", () => {
     act(() => root.render(<Tray />));
     const equipPop = container.querySelector<HTMLElement>(".osc-equip-tt-pop")!;
     const tile = equipPop.parentElement!;
@@ -165,7 +168,8 @@ describe("both hover cards share HoverPop", () => {
 
     stubRect(tile, { left: 300, width: 50, bottom: 240 });
     hover(tile, "pointerenter");
-    expect(equipPop.style.top).toBe("246px");
+    // 240 + 11: the arrow reaches ~7px up, leaving ~4px of air under the tile
+    expect(equipPop.style.top).toBe("251px");
 
     act(() =>
       root.render(
@@ -178,7 +182,7 @@ describe("both hover cards share HoverPop", () => {
     const trigger = movePop.parentElement!;
     stubRect(trigger, { left: 300, width: 50, bottom: 240 });
     hover(trigger, "pointerenter");
-    expect(movePop.style.top).toBe("246px");
+    expect(movePop.style.top).toBe("246px"); // no arrow → default 6
     expect(movePop.style.position).toBe(equipPop.style.position);
   });
 });

--- a/src/OscSheet/components/ui/HoverPop.tsx
+++ b/src/OscSheet/components/ui/HoverPop.tsx
@@ -18,7 +18,7 @@ import {
   type ReactNode,
 } from "react";
 
-const GAP = 6; // trigger bottom → card top
+const GAP = 6; // trigger bottom → card top, for a card with no arrow
 const EDGE = 8; // smallest gap the card keeps from the sheet's (or viewport's) edge
 
 const HIDDEN: CSSProperties = {
@@ -34,12 +34,16 @@ export function HoverPop({
   className,
   align = "start",
   role = "tooltip",
+  gap = GAP,
   children,
 }: {
   className?: string;
   /** `start` = card's left edge on the trigger's; `center` = centred under it. */
   align?: HoverPopAlign;
   role?: string;
+  /** Trigger bottom → card top. A card whose ::before arrow pokes ABOVE its top edge
+      must pass `GAP + arrow height`, or the arrow's tip lands on the trigger. */
+  gap?: number;
   children: ReactNode;
 }) {
   const ref = useRef<HTMLSpanElement>(null);
@@ -61,7 +65,7 @@ export function HoverPop({
       const left = Math.min(Math.max(wanted, min), Math.max(min, right - w - EDGE));
       setStyle({
         position: "fixed",
-        top: r.bottom + GAP,
+        top: r.bottom + gap,
         left,
         // keeps an arrow under the trigger's centre even when the card is clamped
         "--anchor-x": `${r.left + r.width / 2 - left}px`,
@@ -92,7 +96,7 @@ export function HoverPop({
       window.removeEventListener("scroll", reposition, true);
       window.removeEventListener("resize", reposition);
     };
-  }, [align]);
+  }, [align, gap]);
 
   return (
     <span className={className} role={role} ref={ref} style={style}>

--- a/src/OscSheet/components/ui/HoverPop.tsx
+++ b/src/OscSheet/components/ui/HoverPop.tsx
@@ -41,8 +41,7 @@ export function HoverPop({
   /** `start` = card's left edge on the trigger's; `center` = centred under it. */
   align?: HoverPopAlign;
   role?: string;
-  /** Trigger bottom → card top. A card whose ::before arrow pokes ABOVE its top edge
-      must pass `GAP + arrow height`, or the arrow's tip lands on the trigger. */
+  /** Trigger bottom → card top. Add the arrow's height if the card draws one. */
   gap?: number;
   children: ReactNode;
 }) {

--- a/src/OscSheet/components/ui/HoverPop.tsx
+++ b/src/OscSheet/components/ui/HoverPop.tsx
@@ -1,0 +1,102 @@
+// The one hover-popover shell: shown while its TRIGGER (this element's parent) is
+// hovered/focused, pinned with `position: fixed` in JS off the trigger's rect.
+//
+// Fixed is load-bearing, not a style choice: an ancestor with `overflow-y: auto`
+// computes `overflow-x` as a clip box too, and a normally-positioned absolute child
+// can never escape it — that clipped the equipped-item card at the sheet body's left
+// edge. Fixed (no transformed ancestor — verified for the sheet shell; `container-type`
+// on the sheet body does NOT capture fixed descendants) renders in full instead.
+//
+// Closed = `visibility: hidden`, not `display: none`, so the card is measurable before
+// it is shown — that measurement is what lets `align="center"` and the viewport clamp
+// place it in one pass.
+import {
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+
+const GAP = 6; // trigger bottom → card top
+const EDGE = 8; // smallest gap the card keeps from the sheet's (or viewport's) edge
+
+const HIDDEN: CSSProperties = {
+  position: "fixed",
+  top: 0,
+  left: 0,
+  visibility: "hidden",
+};
+
+export type HoverPopAlign = "start" | "center";
+
+export function HoverPop({
+  className,
+  align = "start",
+  role = "tooltip",
+  children,
+}: {
+  className?: string;
+  /** `start` = card's left edge on the trigger's; `center` = centred under it. */
+  align?: HoverPopAlign;
+  role?: string;
+  children: ReactNode;
+}) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const [style, setStyle] = useState<CSSProperties>(HIDDEN);
+
+  useEffect(() => {
+    const pop = ref.current;
+    const trigger = pop?.parentElement;
+    if (!pop || !trigger) return;
+    let open = false;
+    const place = () => {
+      const r = trigger.getBoundingClientRect();
+      const w = pop.offsetWidth;
+      const wanted = align === "center" ? r.left + r.width / 2 - w / 2 : r.left;
+      // stay inside the sheet window (fixed can leave it — it just isn't clipped)
+      const host = trigger.closest(".osc-sheet-app")?.getBoundingClientRect();
+      const min = (host?.width ? host.left : 0) + EDGE;
+      const right = host?.width ? host.right : window.innerWidth;
+      const left = Math.min(Math.max(wanted, min), Math.max(min, right - w - EDGE));
+      setStyle({
+        position: "fixed",
+        top: r.bottom + GAP,
+        left,
+        // keeps an arrow under the trigger's centre even when the card is clamped
+        "--anchor-x": `${r.left + r.width / 2 - left}px`,
+      } as CSSProperties);
+    };
+    const show = () => {
+      open = true;
+      place();
+    };
+    const hide = () => {
+      open = false;
+      setStyle(HIDDEN);
+    };
+    const reposition = () => {
+      if (open) place();
+    };
+    trigger.addEventListener("pointerenter", show);
+    trigger.addEventListener("pointerleave", hide);
+    trigger.addEventListener("focusin", show);
+    trigger.addEventListener("focusout", hide);
+    window.addEventListener("scroll", reposition, true);
+    window.addEventListener("resize", reposition);
+    return () => {
+      trigger.removeEventListener("pointerenter", show);
+      trigger.removeEventListener("pointerleave", hide);
+      trigger.removeEventListener("focusin", show);
+      trigger.removeEventListener("focusout", hide);
+      window.removeEventListener("scroll", reposition, true);
+      window.removeEventListener("resize", reposition);
+    };
+  }, [align]);
+
+  return (
+    <span className={className} role={role} ref={ref} style={style}>
+      {children}
+    </span>
+  );
+}

--- a/src/OscSheet/components/ui/HoverPop.tsx
+++ b/src/OscSheet/components/ui/HoverPop.tsx
@@ -17,8 +17,11 @@ import {
   type CSSProperties,
   type ReactNode,
 } from "react";
+import { cx } from "./cx";
 
-const GAP = 6; // trigger bottom → card top, for a card with no arrow
+// trigger bottom → card top. 11 not 6: the arrow reaches ~7px above the card, so this
+// leaves ~4px of air under the trigger.
+const GAP = 11;
 const EDGE = 8; // smallest gap the card keeps from the sheet's (or viewport's) edge
 
 const HIDDEN: CSSProperties = {
@@ -34,15 +37,12 @@ export function HoverPop({
   className,
   align = "start",
   role = "tooltip",
-  gap = GAP,
   children,
 }: {
   className?: string;
   /** `start` = card's left edge on the trigger's; `center` = centred under it. */
   align?: HoverPopAlign;
   role?: string;
-  /** Trigger bottom → card top. Add the arrow's height if the card draws one. */
-  gap?: number;
   children: ReactNode;
 }) {
   const ref = useRef<HTMLSpanElement>(null);
@@ -64,7 +64,7 @@ export function HoverPop({
       const left = Math.min(Math.max(wanted, min), Math.max(min, right - w - EDGE));
       setStyle({
         position: "fixed",
-        top: r.bottom + gap,
+        top: r.bottom + GAP,
         left,
         // keeps an arrow under the trigger's centre even when the card is clamped
         "--anchor-x": `${r.left + r.width / 2 - left}px`,
@@ -95,10 +95,16 @@ export function HoverPop({
       window.removeEventListener("scroll", reposition, true);
       window.removeEventListener("resize", reposition);
     };
-  }, [align, gap]);
+  }, [align]);
 
   return (
-    <span className={className} role={role} ref={ref} style={style}>
+    <span
+      className={cx("osc-hoverpop", className)}
+      role={role}
+      ref={ref}
+      style={style}
+      data-open={style.visibility === "hidden" ? undefined : ""}
+    >
       {children}
     </span>
   );

--- a/src/OscSheet/components/ui/MovePop.tsx
+++ b/src/OscSheet/components/ui/MovePop.tsx
@@ -3,14 +3,13 @@
 // call sites render it, neither re-composes the rows, so the two hovers can never
 // drift apart again. The tier→colour helper lives in @domain/format (encTierClass).
 //
-// The popover is `position: fixed`, positioned in JS off its trigger's rect. Fixed
-// (with no transformed ancestor — verified for the sheet shell) is NOT clipped by an
-// ancestor's `overflow: auto/hidden`, so the popover renders in full even when it
-// lives inside a self-scrolling container like the capped character rail.
-import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
+// Placement/visibility is HoverPop's job (fixed + JS-anchored, so no ancestor's
+// `overflow: auto` can clip it); this file only supplies the rows.
+import { type ReactNode } from "react";
 import type { EncumbranceTier, MoveBands } from "@domain/vm-types";
 import { encTierClass } from "@domain/format";
 import { cx } from "@ui/cx";
+import { HoverPop } from "@ui/HoverPop";
 
 /** A rate line: label + a right-aligned value (number + unit). The value shares the
     single right-aligned column with the status rows, so every value ends flush at the
@@ -36,54 +35,6 @@ function PopRow({ k, v, vClass }: { k: ReactNode; v: ReactNode; vClass?: string 
   );
 }
 
-// Hidden until the trigger (this element's parent) is hovered/focused; then pinned
-// with `position: fixed` just under the trigger. Repositions on scroll/resize so it
-// stays glued while open. Returns the ref for the popover element + its inline style.
-function useTriggerAnchoredFixed(): {
-  ref: React.RefObject<HTMLSpanElement | null>;
-  style: CSSProperties;
-} {
-  const ref = useRef<HTMLSpanElement>(null);
-  const [style, setStyle] = useState<CSSProperties>({ display: "none" });
-
-  useEffect(() => {
-    const trigger = ref.current?.parentElement;
-    if (!trigger) return;
-    let open = false;
-    const place = () => {
-      const r = trigger.getBoundingClientRect();
-      setStyle({ position: "fixed", top: r.bottom + 6, left: r.left });
-    };
-    const show = () => {
-      open = true;
-      place();
-    };
-    const hide = () => {
-      open = false;
-      setStyle({ display: "none" });
-    };
-    const reposition = () => {
-      if (open) place();
-    };
-    trigger.addEventListener("pointerenter", show);
-    trigger.addEventListener("pointerleave", hide);
-    trigger.addEventListener("focusin", show);
-    trigger.addEventListener("focusout", hide);
-    window.addEventListener("scroll", reposition, true);
-    window.addEventListener("resize", reposition);
-    return () => {
-      trigger.removeEventListener("pointerenter", show);
-      trigger.removeEventListener("pointerleave", hide);
-      trigger.removeEventListener("focusin", show);
-      trigger.removeEventListener("focusout", hide);
-      window.removeEventListener("scroll", reposition, true);
-      window.removeEventListener("resize", reposition);
-    };
-  }, []);
-
-  return { ref, style };
-}
-
 /**
  * The one and only movement popover body: the three OSE rates (full labels, each in
  * its own unit) plus the encumbrance tier that explains them. Rendered verbatim by
@@ -104,9 +55,8 @@ export function MoveTooltip({
       armor slows movement without colouring the encumbrance bar. */
   armor?: string;
 }) {
-  const { ref, style } = useTriggerAnchoredFixed();
   return (
-    <span className="osc-move-pop" role="tooltip" ref={ref} style={style}>
+    <HoverPop className="osc-move-pop">
       <span className="hd">Movement</span>
       {armor && <PopRow k="Armor" v={armor} />}
       {tier !== undefined && status && (
@@ -118,7 +68,7 @@ export function MoveTooltip({
       <RateRow k="Encounter" n={bands.encounter} u="ft" />
       <RateRow k="Explore" n={bands.explore} u="ft" />
       <RateRow k="Travel" n={bands.travel} u="mi" />
-    </span>
+    </HoverPop>
   );
 }
 

--- a/src/OscSheet/features/inventory/EquippedTray.tsx
+++ b/src/OscSheet/features/inventory/EquippedTray.tsx
@@ -141,8 +141,10 @@ export function EquippedTray({
             type="button"
             className="osc-equip-tt"
             onClick={() => onOpen(item.id)}
+            // No `title`: the HoverPop below already names the item, and the browser's
+            // own grey tooltip drew over it in a different visual language. aria-label
+            // keeps the accessible name.
             aria-label={item.name}
-            title={item.name}
           >
             <Monogram
               img={item.img}

--- a/src/OscSheet/features/inventory/EquippedTray.tsx
+++ b/src/OscSheet/features/inventory/EquippedTray.tsx
@@ -141,9 +141,6 @@ export function EquippedTray({
             type="button"
             className="osc-equip-tt"
             onClick={() => onOpen(item.id)}
-            // No `title`: the HoverPop below already names the item, and the browser's
-            // own grey tooltip drew over it in a different visual language. aria-label
-            // keeps the accessible name.
             aria-label={item.name}
           >
             <Monogram
@@ -152,8 +149,7 @@ export function EquippedTray({
               className={item.img ? "" : "osc-equip-tt-ic"}
             />
           </button>
-          {/* gap 11, not the default 6: this card's arrow (9px square rotated 45° at
-              top:-5px) reaches ~7px above the card, so 11 leaves ~4px under the tile. */}
+          {/* gap 11: the arrow reaches ~7px above the card */}
           <HoverPop className="osc-equip-tt-pop" align="center" gap={11}>
             <span className="osc-equip-tt-pop-nm">{item.name}</span>
             <span className="osc-equip-tt-pop-type">{item.category}</span>

--- a/src/OscSheet/features/inventory/EquippedTray.tsx
+++ b/src/OscSheet/features/inventory/EquippedTray.tsx
@@ -1,10 +1,13 @@
 // Equipped tray — dashed-bordered row of large ink-stamp tiles, one per
 // equipped item, each with a hover popover. Click a tile to unequip.
+// The popover is a HoverPop (fixed + JS-anchored): centred under its tile, it would
+// otherwise be clipped by the sheet body's overflow at the sheet's left edge.
 import { useState } from "react";
 import type { InventoryItemVM } from "@domain/vm-types";
 import { weightLabel, EQUIPPED } from "@features/inventory/groups";
 import type { Dnd, ItemDragData, OnContext } from "@features/inventory/types";
 import { useOscSheetContext } from "@app/context";
+import { HoverPop } from "@ui/HoverPop";
 import { Monogram } from "@ui/Monogram";
 import { cx } from "@ui/cx";
 
@@ -147,7 +150,7 @@ export function EquippedTray({
               className={item.img ? "" : "osc-equip-tt-ic"}
             />
           </button>
-          <span className="osc-equip-tt-pop" role="tooltip">
+          <HoverPop className="osc-equip-tt-pop" align="center">
             <span className="osc-equip-tt-pop-nm">{item.name}</span>
             <span className="osc-equip-tt-pop-type">{item.category}</span>
             <span className="osc-equip-tt-pop-stats">
@@ -173,7 +176,7 @@ export function EquippedTray({
                 ))}
               </span>
             )}
-          </span>
+          </HoverPop>
         </div>
         );
       })}

--- a/src/OscSheet/features/inventory/EquippedTray.tsx
+++ b/src/OscSheet/features/inventory/EquippedTray.tsx
@@ -149,8 +149,7 @@ export function EquippedTray({
               className={item.img ? "" : "osc-equip-tt-ic"}
             />
           </button>
-          {/* gap 11: the arrow reaches ~7px above the card */}
-          <HoverPop className="osc-equip-tt-pop" align="center" gap={11}>
+          <HoverPop className="osc-equip-tt-pop" align="center">
             <span className="osc-equip-tt-pop-nm">{item.name}</span>
             <span className="osc-equip-tt-pop-type">{item.category}</span>
             <span className="osc-equip-tt-pop-stats">

--- a/src/OscSheet/features/inventory/EquippedTray.tsx
+++ b/src/OscSheet/features/inventory/EquippedTray.tsx
@@ -150,7 +150,9 @@ export function EquippedTray({
               className={item.img ? "" : "osc-equip-tt-ic"}
             />
           </button>
-          <HoverPop className="osc-equip-tt-pop" align="center">
+          {/* gap 11, not the default 6: this card's arrow (9px square rotated 45° at
+              top:-5px) reaches ~7px above the card, so 11 leaves ~4px under the tile. */}
+          <HoverPop className="osc-equip-tt-pop" align="center" gap={11}>
             <span className="osc-equip-tt-pop-nm">{item.name}</span>
             <span className="osc-equip-tt-pop-type">{item.category}</span>
             <span className="osc-equip-tt-pop-stats">

--- a/src/OscSheet/features/inventory/useDragReorder.ts
+++ b/src/OscSheet/features/inventory/useDragReorder.ts
@@ -125,6 +125,16 @@ export function useDragReorder(
     return {
       draggable: true,
       onDragStart: (e) => {
+        // Selecting text in a row's input fires dragstart on the input, which bubbles
+        // here. That drag never reaches our onDragEnd, so the row stayed faded.
+        if (
+          (e.target as HTMLElement | null)?.closest(
+            "input, textarea, select, [contenteditable='true']",
+          )
+        ) {
+          e.preventDefault();
+          return;
+        }
         setDrag({ group, idx });
         e.dataTransfer.effectAllowed = "move";
         const payload = o.dragPayload?.() ?? `${group}:${idx}`;

--- a/src/OscSheet/styles/actions.scss
+++ b/src/OscSheet/styles/actions.scss
@@ -381,7 +381,6 @@
   // don't inherit the anchor's tier tint — only a `.vv.enc-t*` row opts back in
   --enc-c: initial;
 
-  z-index: var(--z-tooltip);
   min-width: 150px;
   // 2-col grid: label | value. The label column grows (1fr) to eat the slack; every value
   // (rates AND status) lives in the same right-aligned column, so they all end flush at the
@@ -390,12 +389,6 @@
   grid-template-columns: minmax(max-content, 1fr) max-content;
   column-gap: var(--spacer-3);
   row-gap: 3px;
-  padding: var(--spacer-2) var(--spacer-2);
-  background: var(--bg-2, #1f1c17);
-  border: 1px solid var(--gold-soft);
-  border-radius: var(--r-lg, 10px);
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
-  pointer-events: none; // display-only; never intercept clicks on content below
 }
 // small section-label header atop the popover, divided from the rate rows
 .osc-move-pop .hd {

--- a/src/OscSheet/styles/actions.scss
+++ b/src/OscSheet/styles/actions.scss
@@ -374,10 +374,9 @@
   text-underline-offset: 2px;
 }
 // Shared by the header MOVE tile and the inventory encumbrance line (see MovePop.tsx).
-// Positioned in JS as `position: fixed` (inline style) so it escapes any overflow-
-// clipping ancestor — the character rail self-scrolls, and fixed with no transformed
-// ancestor is not clipped by it. `display:none` (inline) when closed. z-index keeps it
-// above sheet content (carets, sticky heads) when the layers happen to overlap.
+// Placed by HoverPop: `position: fixed` (inline) so it escapes any overflow-clipping
+// ancestor — the character rail self-scrolls — and `visibility: hidden` when closed.
+// z-index keeps it above sheet content (carets, sticky heads) when layers overlap.
 .osc-move-pop {
   // don't inherit the anchor's tier tint — only a `.vv.enc-t*` row opts back in
   --enc-c: initial;
@@ -386,7 +385,7 @@
   min-width: 150px;
   // 2-col grid: label | value. The label column grows (1fr) to eat the slack; every value
   // (rates AND status) lives in the same right-aligned column, so they all end flush at the
-  // table's right edge. Inline `display:none` hides it when closed (overrides grid).
+  // table's right edge.
   display: grid;
   grid-template-columns: minmax(max-content, 1fr) max-content;
   column-gap: var(--spacer-3);

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -635,6 +635,12 @@
 .osc-coin-row:active {
   cursor: grabbing;
 }
+// cursor inherits and our inputs are `all: unset`, so the row's grabbing fist leaked
+// into them on mousedown. Needs the :active parent to out-specify the rule above.
+.osc-inv-row:active :is(input, textarea),
+.osc-coin-row:active :is(input, textarea) {
+  cursor: text;
+}
 // While a drag is in flight the source row is no longer under the pointer, so
 // :active drops — flag the sheet root for the drag's lifetime and force the
 // grabbing cursor everywhere until drop/end.

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -1178,12 +1178,6 @@
   display: inline-flex;
   align-items: center;
   gap: 3px;
-  // Optical alignment: the chip's own 1px border + 6px padding inset its TEXT, so a
-  // box-flush chip reads as indented against the labels above. Pull the leading chip
-  // out by that inset so the words line up, not the boxes.
-  &:first-child {
-    margin-left: -7px;
-  }
   font-family: var(--sans);
   font-size: var(--fs-3xs, 10px);
   color: var(--text-dim, #b5ad97);

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -1073,10 +1073,6 @@
   border: 1.5px solid var(--teal);
   border-radius: var(--r-sm, 4px);
   overflow: hidden;
-  transition: transform 0.12s;
-  &:hover {
-    transform: translateY(-1px);
-  }
   img {
     width: 100%;
     height: 100%;
@@ -1182,6 +1178,12 @@
   display: inline-flex;
   align-items: center;
   gap: 3px;
+  // Optical alignment: the chip's own 1px border + 6px padding inset its TEXT, so a
+  // box-flush chip reads as indented against the labels above. Pull the leading chip
+  // out by that inset so the words line up, not the boxes.
+  &:first-child {
+    margin-left: -7px;
+  }
   font-family: var(--sans);
   font-size: var(--fs-3xs, 10px);
   color: var(--text-dim, #b5ad97);

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -1042,6 +1042,10 @@
 .osc-equip-tcard.dragging > * {
   opacity: 0.4;
 }
+// A fixed child inside the drag-image snapshot paints against the viewport, not the tile.
+.osc-equip-tcard.dragging .osc-hoverpop {
+  display: none;
+}
 // horizontal insertion line on the leading/trailing edge of the hovered tile (teal)
 .osc-equip-tcard.drop-before::before,
 .osc-equip-tcard.drop-after::after {
@@ -1085,45 +1089,13 @@
   line-height: 1;
 }
 
-// hover popover with item detail. Position comes from HoverPop (inline `position:
-// fixed` + JS-anchored) — absolute here got clipped by the sheet body's overflow.
+// Item detail — appearance and placement are .osc-hoverpop / HoverPop; content only here.
 .osc-equip-tt-pop {
-  transform: translateY(4px);
-  z-index: var(--z-tooltip);
   min-width: 132px;
   max-width: 200px;
   display: flex;
   flex-direction: column;
   gap: 3px;
-  padding: var(--spacer-2) var(--spacer-3);
-  border-radius: var(--r-md, 6px);
-  background: var(--surface-2, #2c2823);
-  border: 1px solid var(--border, #3a342c);
-  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.32);
-  opacity: 0;
-  pointer-events: none;
-  transition:
-    opacity 0.12s,
-    transform 0.12s;
-  // --anchor-x = the tile's centre relative to the card's left edge, so the arrow
-  // keeps pointing at its tile even when HoverPop clamps the card to the viewport.
-  &::before {
-    content: "";
-    position: absolute;
-    left: var(--anchor-x, 50%);
-    top: -5px;
-    transform: translateX(-50%) rotate(45deg);
-    width: 9px;
-    height: 9px;
-    background: var(--surface-2, #2c2823);
-    border-left: 1px solid var(--border, #3a342c);
-    border-top: 1px solid var(--border, #3a342c);
-  }
-}
-.osc-equip-tcard:hover .osc-equip-tt-pop,
-.osc-equip-tcard:focus-within .osc-equip-tt-pop {
-  opacity: 1;
-  transform: translateY(0);
 }
 .osc-equip-tt-pop-nm {
   font-family: var(--display);

--- a/src/OscSheet/styles/inventory.scss
+++ b/src/OscSheet/styles/inventory.scss
@@ -1089,13 +1089,11 @@
   line-height: 1;
 }
 
-// hover popover with item detail
+// hover popover with item detail. Position comes from HoverPop (inline `position:
+// fixed` + JS-anchored) — absolute here got clipped by the sheet body's overflow.
 .osc-equip-tt-pop {
-  position: absolute;
-  left: 50%;
-  top: calc(100% + 8px);
-  transform: translate(-50%, 4px);
-  z-index: 12;
+  transform: translateY(4px);
+  z-index: var(--z-tooltip);
   min-width: 132px;
   max-width: 200px;
   display: flex;
@@ -1111,10 +1109,12 @@
   transition:
     opacity 0.12s,
     transform 0.12s;
+  // --anchor-x = the tile's centre relative to the card's left edge, so the arrow
+  // keeps pointing at its tile even when HoverPop clamps the card to the viewport.
   &::before {
     content: "";
     position: absolute;
-    left: 50%;
+    left: var(--anchor-x, 50%);
     top: -5px;
     transform: translateX(-50%) rotate(45deg);
     width: 9px;
@@ -1124,9 +1124,10 @@
     border-top: 1px solid var(--border, #3a342c);
   }
 }
-.osc-equip-tcard:hover .osc-equip-tt-pop {
+.osc-equip-tcard:hover .osc-equip-tt-pop,
+.osc-equip-tcard:focus-within .osc-equip-tt-pop {
   opacity: 1;
-  transform: translate(-50%, 0);
+  transform: translateY(0);
 }
 .osc-equip-tt-pop-nm {
   font-family: var(--display);

--- a/src/OscSheet/styles/styles.scss
+++ b/src/OscSheet/styles/styles.scss
@@ -215,6 +215,44 @@
   --z-tooltip: 30; // hover popovers — above sticky heads and carets
 }
 
+// --- hover popovers -------------------------------------------------------
+// One shell for every HoverPop: appearance, stacking, arrow, fade. Callers add only
+// their own content layout and width. --anchor-x comes from HoverPop, so the arrow
+// keeps pointing at the trigger even when the card is clamped to the sheet.
+.osc-hoverpop {
+  z-index: var(--z-tooltip);
+  padding: var(--spacer-2) var(--spacer-3);
+  border: 1px solid var(--border, #3a342c);
+  border-radius: var(--r-md, 6px);
+  background: var(--surface-2, #2c2823);
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.32);
+  opacity: 0;
+  transform: translateY(4px);
+  pointer-events: none;
+  // Closing is immediate; opening waits, so brushing past a tile doesn't flash a card.
+  transition:
+    opacity 0.12s,
+    transform 0.12s;
+
+  &[data-open] {
+    opacity: 1;
+    transform: translateY(0);
+    transition-delay: 0.15s;
+  }
+  &::before {
+    content: "";
+    position: absolute;
+    left: var(--anchor-x, 50%);
+    top: -5px;
+    width: 9px;
+    height: 9px;
+    transform: translateX(-50%) rotate(45deg);
+    background: var(--surface-2, #2c2823);
+    border-left: 1px solid var(--border, #3a342c);
+    border-top: 1px solid var(--border, #3a342c);
+  }
+}
+
 // --- encumbrance tier colours ---------------------------------------------
 // One tier → one colour, everywhere: the inventory rates line, the tier string in
 // both hover popovers, and the load bar's gradient stops. Vellum tokens only —


### PR DESCRIPTION
## What was wrong

Tooltip popups are clipping under parent containers. Fix and consolidate styles/component.
