### PR TITLE
Narrow item-based slot exclusion to coins and gems

### DIFF
--- a/src/OscSheet/components/ui/HoverPop.test.tsx
+++ b/src/OscSheet/components/ui/HoverPop.test.tsx
@@ -137,7 +137,7 @@ const item: InventoryItemVM = {
   equippedSort: 100,
   equipped: true,
   quantity: null,
-  treasure: false,
+  treasure: false, coinsOrGems: false,
   isContainer: false,
   children: [],
 };

--- a/src/OscSheet/domain/types.ts
+++ b/src/OscSheet/domain/types.ts
@@ -164,6 +164,10 @@ export type OseItem = Omit<Item, "type"> & {
     itemslots?: number;
     /** `item` type only — ceil(itemslots × quantity). Absent on weapon/armor/container. */
     cumulativeItemslots?: number;
+    /** System-derived: treasure the system buckets at 100 to a slot, matched on a
+     *  coin/gem tag or a coin name. Read it off the item — the match list is the
+     *  system's to own, and it is localised. */
+    isCoinsOrGems?: boolean;
   };
   rollWeapon: (options: { skipDialog: boolean }) => void;
   update: (updateData: {

--- a/src/OscSheet/domain/vm-types.ts
+++ b/src/OscSheet/domain/vm-types.ts
@@ -137,8 +137,11 @@ export interface InventoryItemVM {
   equipped: boolean | null;
   /** null unless the item is a stack (qty > 1) or charged (max set). */
   quantity: { value: number; max: number } | null;
-  /** `system.treasure` — coins/gems/valuables, counted per section rather than per row. */
+  /** `system.treasure` — coins, gems and other valuables; shown in the Treasure section. */
   treasure: boolean;
+  /** The narrower subset the system buckets at 100 to a slot (`system.isCoinsOrGems`), so
+   *  it carries no per-row slot figure. Other valuables count their slots normally. */
+  coinsOrGems: boolean;
   isContainer: boolean;
   children: InventoryItemVM[]; // [] unless container; nested by containerId
 }
@@ -188,6 +191,12 @@ export interface CoinVM {
   value: number;
   /** gp value of one coin of this denom (system.cost, std fallback) — for the wealth total. */
   gpEach: number;
+  /** System-derived: bucketed at 100 to a slot. Our coin naming is broader than the
+   *  system's, so a coin row is not automatically one of these. */
+  coinsOrGems: boolean;
+  /** Per-unit item slots, for the rows that aren't bucketed — the count has to follow
+   *  the live (draft) qty, so it can't be pre-multiplied. */
+  itemslots: number;
 }
 
 /** A non-coin treasure item (gem, jewellery, …) surfaced in the Treasure section.
@@ -206,6 +215,10 @@ export interface TreasureVM {
   cost: number;
   /** Summed gp value: qty × cost. */
   value: number;
+  /** System-derived: bucketed at 100 to a slot (a gem), rather than counted per row. */
+  coinsOrGems: boolean;
+  /** Carried item slots — 0 when bucketed. */
+  slots: number;
 }
 
 /** Fields shared by every row of the unified Treasure table (coins + valuables). */
@@ -222,6 +235,9 @@ interface WealthRowShared {
   weight: number;
   /** Row gp value. */
   value: number;
+  /** `system.isCoinsOrGems` — the rows the system buckets at 100 to a slot. The rest
+   *  (a gold idol, a silver crown) take ordinary item slots, per row. */
+  coinsOrGems: boolean;
 }
 
 /** An editable coin denomination row. */
@@ -231,11 +247,16 @@ export interface CoinWealthRow extends WealthRowShared {
   denom: string;
   /** gp value of one coin — the row value recomputes live as the qty is edited. */
   gpEach: number;
+  /** Per-unit item slots. Kept per-unit (not folded with qty) because an un-bucketed
+   *  coin row's slot count has to follow the qty being typed. */
+  itemslots: number;
 }
 
 /** A read-only non-coin treasure row (gem, jewellery, …). */
 export interface TreasureWealthRow extends WealthRowShared {
   kind: "treasure";
+  /** Carried item slots (qty already folded in); 0 when the row is bucketed. */
+  slots: number;
 }
 
 /** A single row of the Treasure table: coins and valuables in one list, rendered

--- a/src/OscSheet/features/inventory/InventoryView.stories.tsx
+++ b/src/OscSheet/features/inventory/InventoryView.stories.tsx
@@ -20,7 +20,7 @@ const item = (o: Partial<InventoryItemVM> & { id: string; name: string }): Inven
   equippedSort: 0,
   equipped: null,
   quantity: null,
-  treasure: false,
+  treasure: false, coinsOrGems: false,
   isContainer: false,
   children: [],
   ...o,
@@ -52,9 +52,11 @@ const encumbrance: EncumbranceVM = { enabled: true, variant: "basic", value: 380
 const coin = (denom: string, qty: number, gpEach: number): WealthRow => ({
   kind: "coin", denom, id: denom.toLowerCase(), name: `${denom} coins`, img: "",
   monogram: denom, gpEach, qty, weight: qty, value: qty * gpEach,
+  coinsOrGems: true, itemslots: 0,
 });
 const valuable = (id: string, name: string, monogram: string, qty: number, weight: number, cost: number): WealthRow => ({
   kind: "treasure", id, name, img: "", monogram, qty, weight, value: qty * cost,
+  coinsOrGems: false, slots: 1,
 });
 
 // Coins (canonical order) then read-only valuables — the merged Treasure table.

--- a/src/OscSheet/features/inventory/WealthRow.tsx
+++ b/src/OscSheet/features/inventory/WealthRow.tsx
@@ -14,7 +14,7 @@ export function WealthRow({
   canEdit,
   dnd,
   itemDragData,
-  perRowLoad = true,
+  load,
   inputValue,
   onOpen,
   onContext,
@@ -30,9 +30,9 @@ export function WealthRow({
   /** Foundry item drag-data for this row (coins/valuables are real items) so a drag
    *  carries `{type:"Item",uuid,…}` — droppable onto the hotbar and Item Piles. */
   itemDragData: ItemDragData;
-  /** False under item-based encumbrance: treasure is counted per section, so the row's
-   *  load cell has no honest number to show. */
-  perRowLoad?: boolean;
+  /** Pre-formatted load cell — cn, slots, or an em-dash for the rows the section buckets.
+   *  The unit is variant-dependent and lives in the column header, so the parent formats it. */
+  load: string;
   /** Controlled coin-input value (draft-aware); coin rows only. */
   inputValue?: string;
   onOpen: (id: string) => void;
@@ -100,9 +100,7 @@ export function WealthRow({
       ) : (
         <span className="osc-coin-qty-ro">{fmtCoin(row.qty)}</span>
       )}
-      <span className="osc-coin-wt">
-        {perRowLoad ? fmtCoin(row.weight) : "—"}
-      </span>
+      <span className="osc-coin-wt">{load}</span>
       <span className="osc-coin-val">{fmtCoin(row.value)}</span>
     </div>
   );

--- a/src/OscSheet/features/inventory/WealthSection.tsx
+++ b/src/OscSheet/features/inventory/WealthSection.tsx
@@ -33,7 +33,7 @@ export function WealthSection({
 }: {
   /** Unified row list: coins (canonical order) then non-coin valuables. */
   wealth: WealthRowVM[];
-  /** Active encumbrance variant — item-based counts treasure per section, not per row. */
+  /** Active encumbrance variant — item-based buckets coins/gems per section, not per row. */
   variant?: string;
   onSetCoin: (id: string, value: number) => void;
   /** Foundry item drag-data per row id — lets treasure rows drop onto the hotbar / Item Piles. */
@@ -112,13 +112,30 @@ export function WealthSection({
   const liveValue = (r: WealthRowVM) => (r.kind === "coin" ? draftQty(r) * r.gpEach : r.value);
   const totalGp = wealth.reduce((s, r) => s + liveValue(r), 0);
   const weight = wealth.reduce((s, r) => s + liveWeight(r), 0);
-  // Item-based encumbrance buckets treasure globally: 100 coins/gems to one slot. No
-  // per-row figure exists, so only the section total is real (rows show a dash).
   const itemBased = variant === "itembased";
-  const slots = Math.ceil(
-    wealth.reduce((s, r) => s + (r.kind === "coin" ? draftQty(r) : r.qty), 0) / 100,
-  );
+  // Draft-aware qty: only coins are editable, so only they can be mid-edit.
+  const liveQty = (r: WealthRowVM) => (r.kind === "coin" ? draftQty(r) : r.qty);
+  // Item-based encumbrance buckets coins and gems globally — 100 to one slot, ceiled once
+  // over the lot, so they have no per-row figure. Every OTHER valuable is an ordinary item
+  // and takes its own slots, which is why the section total is a sum of the two rules.
+  const rowSlots = (r: WealthRowVM) =>
+    r.coinsOrGems
+      ? 0
+      : r.kind === "coin"
+        ? Math.ceil(liveQty(r) * r.itemslots)
+        : r.slots;
+  const bucketed = wealth.reduce((s, r) => s + (r.coinsOrGems ? liveQty(r) : 0), 0);
+  const slots =
+    Math.ceil(bucketed / 100) + wealth.reduce((s, r) => s + rowSlots(r), 0);
   const load = itemBased ? `${slots} slots` : `${fmtCoin(weight)} cn`;
+  // The row's load cell: cn normally, slots under item-based — a dash only for the rows
+  // the section buckets, which genuinely have no per-row figure.
+  const rowLoad = (r: WealthRowVM) =>
+    !itemBased
+      ? fmtCoin(liveWeight(r))
+      : r.coinsOrGems
+        ? "—"
+        : String(rowSlots(r));
   const dots = wealth
     .filter((r): r is CoinWealthRow => r.kind === "coin" && draftQty(r) > 0)
     .map((r) => r.denom);
@@ -199,7 +216,7 @@ export function WealthSection({
                 canEdit={canEdit}
                 dnd={dnd}
                 itemDragData={itemDragData}
-                perRowLoad={!itemBased}
+                load={rowLoad(row)}
                 inputValue={draft[row.denom] ?? String(row.qty)}
                 onOpen={onOpen}
                 onContext={onContext}
@@ -215,7 +232,7 @@ export function WealthSection({
                 canEdit={canEdit}
                 dnd={dnd}
                 itemDragData={itemDragData}
-                perRowLoad={!itemBased}
+                load={rowLoad(row)}
                 onOpen={onOpen}
                 onContext={onContext}
               />

--- a/src/OscSheet/features/inventory/dragHandle.test.tsx
+++ b/src/OscSheet/features/inventory/dragHandle.test.tsx
@@ -19,12 +19,13 @@ import type { OscSheetContextValue } from "@domain/types";
 const coin: CoinWealthRow = {
   kind: "coin", id: "gp", denom: "GP", gpEach: 1, name: "Gold Pieces",
   img: "", monogram: "GP", qty: 5, weight: 5, value: 5,
+  coinsOrGems: true, itemslots: 0,
 };
 
 const mkItem = (id: string): InventoryItemVM => ({
   id, name: id, img: "", category: "Gear", categoryRank: 2, damage: "", tags: [],
   monogram: id[0]!, weight: 1, slots: 1, cost: 0, armorClass: null, sort: 100, equippedSort: 100,
-  equipped: false, quantity: null, treasure: false, isContainer: false, children: [],
+  equipped: false, quantity: null, treasure: false, coinsOrGems: false, isContainer: false, children: [],
 });
 
 const noop = () => {};
@@ -62,7 +63,7 @@ function WealthHarness({ itemDragData }: { itemDragData: (id: string) => string 
   const dnd = useDragReorder({ enabled: true, onReorder: noop });
   return (
     <WealthRow
-      row={coin} index={0} canEdit dnd={dnd} itemDragData={itemDragData}
+      row={coin} index={0} canEdit dnd={dnd} itemDragData={itemDragData} load="5"
       inputValue="5" onOpen={noop} onContext={noop}
       onQtyChange={noop} onQtyCommit={noop} onQtyCommitClose={noop}
     />

--- a/src/OscSheet/features/inventory/dragNest.test.tsx
+++ b/src/OscSheet/features/inventory/dragNest.test.tsx
@@ -31,7 +31,7 @@ const item = (id: string, over: Partial<InventoryItemVM> = {}): InventoryItemVM 
   equippedSort: 100,
   equipped: false,
   quantity: null,
-  treasure: false,
+  treasure: false, coinsOrGems: false,
   isContainer: false,
   children: [],
   ...over,

--- a/src/OscSheet/features/inventory/encumbranceVariants.test.ts
+++ b/src/OscSheet/features/inventory/encumbranceVariants.test.ts
@@ -8,14 +8,14 @@ import {
   loadHeading,
   sectionCountLabel,
 } from "@features/inventory/groups";
-import { selectInventory } from "@features/inventory/inventory";
+import { selectInventory, selectWealth } from "@features/inventory/inventory";
 import type { InventoryItemVM } from "@domain/vm-types";
 import type { OseItem } from "@domain/types";
 
 const mkVM = (o: Partial<InventoryItemVM> = {}): InventoryItemVM => ({
   id: "x", name: "X", img: "", category: "Gear", categoryRank: 2, damage: "",
   tags: [], monogram: "XX", weight: 0, slots: 0, cost: 0, armorClass: null,
-  sort: 0, equippedSort: 0, equipped: null, quantity: null, treasure: false,
+  sort: 0, equippedSort: 0, equipped: null, quantity: null, treasure: false, coinsOrGems: false,
   isContainer: false, children: [], ...o,
 });
 
@@ -24,14 +24,20 @@ const mkVM = (o: Partial<InventoryItemVM> = {}): InventoryItemVM => ({
 const sword = mkVM({ id: "sword", name: "Sword", weight: 60, slots: 1 });
 const arrows = mkVM({ id: "arrows", name: "Arrows", weight: 10, slots: 17 });
 const unset = mkVM({ id: "unset", name: "Unset gear", weight: 0, slots: 0 });
-// treasure gets slots: 0 from slotsOf — it's bucketed globally by the Treasure section.
-const coins = mkVM({ id: "gp", name: "GP", weight: 900, slots: 0, treasure: true });
+// coins/gems get slots: 0 from slotsOf — bucketed globally by the Treasure section.
+const coins = mkVM({
+  id: "gp", name: "GP", weight: 900, slots: 0, treasure: true, coinsOrGems: true,
+});
+// A valuable the system does NOT bucket: treasure, but ordinary slots all the same.
+const idol = mkVM({
+  id: "idol", name: "Golden idol", weight: 200, slots: 3, treasure: true,
+});
 const pack = mkVM({
   id: "pack", name: "Backpack", weight: 20, slots: 1, isContainer: true,
   children: [mkVM({ id: "rope", name: "Rope", weight: 50, slots: 2 })],
 });
 
-const inventory = [sword, arrows, unset, coins, pack];
+const inventory = [sword, arrows, unset, coins, idol, pack];
 
 /** Every variant the system's enum carries, plus the no-encumbrance case. */
 const CN_VARIANTS = [undefined, "", "basic", "detailed", "complete"] as const;
@@ -63,15 +69,28 @@ describe("slot derivation", () => {
     expect(vm.items.find((i) => i.name === "Backpack")!.slots).toBe(0);
   });
 
-  it("gives treasure no slots — it is bucketed globally, 100 to a slot", () => {
-    const vm = selectInventory([
-      mkItem("item", "Gem", {
-        treasure: true, itemslots: 1, quantity: { value: 900, max: 0 },
+  // Treasure is filtered out of the main list into the Treasure section, so its slot
+  // figure surfaces on the wealth rows rather than on an inventory row.
+  it("gives coins/gems no slots — they are bucketed globally, 100 to a slot", () => {
+    const [row] = selectWealth([
+      mkItem("item", "Gems", {
+        treasure: true, isCoinsOrGems: true, itemslots: 1,
+        quantity: { value: 900, max: 0 },
       }),
     ]);
-    // Counting it per-row would make section totals disagree with their rows, and
-    // ceil(qty × itemslots) is the wrong rule for treasure anyway.
-    for (const it of vm.items) expect(it.slots).toBe(0);
+    // ceil(qty × itemslots) is the wrong rule for these — the section buckets them.
+    expect(row.coinsOrGems).toBe(true);
+    expect(row.kind === "treasure" && row.slots).toBe(0);
+  });
+
+  it("gives a non-bucketed valuable ordinary slots", () => {
+    const [row] = selectWealth([
+      mkItem("item", "Golden idol", {
+        treasure: true, itemslots: 2, quantity: { value: 3, max: 0 },
+      }),
+    ]);
+    expect(row.coinsOrGems).toBe(false);
+    expect(row.kind === "treasure" && row.slots).toBe(6);
   });
 });
 
@@ -90,9 +109,14 @@ describe("row figures across every variant", () => {
     for (const v of CN_VARIANTS) expect(loadText(countedLoad(unset, v))).toBe("—");
   });
 
-  it("treasure has no per-row slot figure, but does have a weight", () => {
+  it("coins/gems have no per-row slot figure, but do have a weight", () => {
     expect(loadText(countedLoad(coins, "itembased"))).toBe("—");
     for (const v of CN_VARIANTS) expect(loadText(countedLoad(coins, v))).toBe("900 cn");
+  });
+
+  it("a valuable the system does not bucket keeps a real slot figure", () => {
+    expect(loadText(countedLoad(idol, "itembased"))).toBe("3");
+    for (const v of CN_VARIANTS) expect(loadText(countedLoad(idol, v))).toBe("200 cn");
   });
 });
 
@@ -104,15 +128,15 @@ describe("column heading follows the same variant", () => {
 });
 
 describe("section totals across every variant", () => {
-  // 6 rows once the container's child is flattened.
-  it("sums slots under itembased, excluding treasure", () => {
-    // 1 + 17 + 0 + 1 + 2 = 21; the coin row contributes nothing per-row.
-    expect(sectionCountLabel(inventory, "itembased")).toBe("6 items · 21 slots");
+  // 7 rows once the container's child is flattened.
+  it("sums slots under itembased, excluding only the bucketed coins/gems", () => {
+    // 1 + 17 + 0 + 3 + 1 + 2 = 24; the coin row contributes nothing per-row.
+    expect(sectionCountLabel(inventory, "itembased")).toBe("7 items · 24 slots");
   });
 
   it("sums cn for every other variant", () => {
     for (const v of CN_VARIANTS) {
-      expect(sectionCountLabel(inventory, v)).toBe("6 items · 1040 cn");
+      expect(sectionCountLabel(inventory, v)).toBe("7 items · 1240 cn");
     }
   });
 

--- a/src/OscSheet/features/inventory/groups.test.ts
+++ b/src/OscSheet/features/inventory/groups.test.ts
@@ -12,7 +12,7 @@ import type { InventoryItemVM } from "@domain/vm-types";
 const mkVM = (o: Partial<InventoryItemVM> = {}): InventoryItemVM => ({
   id: "x", name: "X", img: "", category: "Gear", categoryRank: 2, damage: "",
   tags: [], monogram: "XX", weight: 0, slots: 0, cost: 0, armorClass: null,
-  sort: 0, equippedSort: 0, equipped: null, quantity: null, treasure: false,
+  sort: 0, equippedSort: 0, equipped: null, quantity: null, treasure: false, coinsOrGems: false,
   isContainer: false, children: [], ...o,
 });
 
@@ -28,8 +28,14 @@ describe("countedLoad", () => {
     expect(loadText(countedLoad(mkVM({ slots: 0, weight: 50 }), "itembased"))).toBe("0");
   });
 
-  it("itembased: treasure has no honest per-row figure (counted per section)", () => {
-    expect(loadText(countedLoad(mkVM({ treasure: true, slots: 2 }), "itembased"))).toBe("—");
+  it("itembased: coins/gems have no honest per-row figure (counted per section)", () => {
+    expect(
+      loadText(countedLoad(mkVM({ treasure: true, coinsOrGems: true, slots: 0 }), "itembased")),
+    ).toBe("—");
+  });
+
+  it("itembased: other valuables are ordinary items and keep their slot figure", () => {
+    expect(loadText(countedLoad(mkVM({ treasure: true, slots: 2 }), "itembased"))).toBe("2");
   });
 
   it("other variants keep the cn behaviour, dash for weightless included", () => {

--- a/src/OscSheet/features/inventory/groups.ts
+++ b/src/OscSheet/features/inventory/groups.ts
@@ -19,15 +19,16 @@ export interface CountedLoad {
 
 /** The load cell for one row. Under item-based encumbrance this is the item's slots —
  *  a literal 0 (an unset GM value the sheet should surface, not hide behind a dash);
- *  treasure has no per-row figure at all (it's counted per section, 100 to a slot).
- *  Every other variant keeps the cn behaviour, dash included. */
+ *  coins and gems have no per-row figure at all (they're counted per section, 100 to a
+ *  slot). Every other variant keeps the cn behaviour, dash included. */
 export function countedLoad(
   item: InventoryItemVM,
   variant?: string,
 ): CountedLoad {
   if (variant !== "itembased") return weightLoad(item.weight);
-  // Treasure carries no per-row slot figure (see slotsOf) — the section totals it.
-  if (item.treasure) return { value: "—", unit: "" };
+  // Coins/gems carry no per-row slot figure (see slotsOf) — the section totals them.
+  // Other valuables take ordinary slots, so they show a real number.
+  if (item.coinsOrGems) return { value: "—", unit: "" };
   return { value: String(item.slots), unit: "" };
 }
 

--- a/src/OscSheet/features/inventory/inventory.test.ts
+++ b/src/OscSheet/features/inventory/inventory.test.ts
@@ -202,7 +202,7 @@ describe("sortInventory", () => {
   const mkVM = (overrides: Partial<import("@domain/vm-types").InventoryItemVM>): import("@domain/vm-types").InventoryItemVM => ({
     id: "x", name: "X", img: "", category: "Gear", categoryRank: 2,
     damage: "", tags: [], monogram: "XX", weight: 0, slots: 0, cost: 0, armorClass: null, sort: 0, equippedSort: 0,
-    equipped: null, quantity: null, treasure: false, isContainer: false, children: [],
+    equipped: null, quantity: null, treasure: false, coinsOrGems: false, isContainer: false, children: [],
     ...overrides,
   });
 
@@ -273,7 +273,7 @@ describe("sortEquipped", () => {
   const mkVM = (id: string, name: string, equippedSort: number): import("@domain/vm-types").InventoryItemVM => ({
     id, name, img: "", category: "Gear", categoryRank: 2, damage: "", tags: [],
     monogram: "XX", weight: 0, slots: 0, cost: 0, armorClass: null, sort: 0, equippedSort, equipped: true, quantity: null,
-    treasure: false, isContainer: false, children: [],
+    treasure: false, coinsOrGems: false, isContainer: false, children: [],
   });
 
   it("orders by equippedSort, ties broken by name", () => {

--- a/src/OscSheet/features/inventory/inventory.ts
+++ b/src/OscSheet/features/inventory/inventory.ts
@@ -7,6 +7,7 @@ import type {
 } from "@domain/vm-types";
 import { FLAGS, readFlag } from "@domain/flags";
 import { monogram } from "./monogram";
+import { bucketsAsCoinsOrGems, slotsOf } from "./slots";
 
 /** Manual order position: our own flag, falling back to Foundry's sort for un-migrated items. */
 function orderOf(item: OseItem): number {
@@ -84,21 +85,6 @@ function armorClassOf(item: OseItem): { label: string; value: number } | null {
     : { label: "AC", value: s.ac?.value ?? 0 };
 }
 
-/** Carried item slots, mirroring the system's item-based encumbrance model: `item` and
- *  `container` fold in quantity, `weapon`/`armor` count their slots once whatever the qty. */
-function slotsOf(item: OseItem): number {
-  const s = item.system;
-  const slots = s.itemslots ?? 0;
-  // Treasure is bucketed globally (100 to a slot, ceiled once over the lot), so it has no
-  // honest per-row figure — the Treasure section totals it instead. Counting it here too
-  // would make every section total disagree with the rows above it.
-  if (s.treasure) return 0;
-  if (item.type === "weapon" || item.type === "armor") return slots;
-  // Containers ship quantity 0, so the system counts them as 0 slots. Coercing that to 1
-  // would read better but would stop our totals matching the system's own figure.
-  return s.cumulativeItemslots ?? Math.ceil(slots * (s.quantity?.value ?? 1));
-}
-
 function toVM(
   item: OseItem,
   children: InventoryItemVM[] = [],
@@ -130,6 +116,7 @@ function toVM(
     equipped: "equipped" in s ? !!s.equipped : null,
     quantity: hasQty ? { value: q.value, max: q.max || q.value } : null,
     treasure: !!s.treasure,
+    coinsOrGems: bucketsAsCoinsOrGems(item),
     isContainer: item.type === "container",
     children,
   };

--- a/src/OscSheet/features/inventory/itemSlots.test.tsx
+++ b/src/OscSheet/features/inventory/itemSlots.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
-// Item-Based Encumbrance display: the load column reads in item slots, and treasure —
-// which the system counts globally at 100 to a slot — shows a section total only.
+// Item-Based Encumbrance display: the load column reads in item slots, and coins/gems —
+// which the system counts globally at 100 to a slot — show a section total only. Other
+// valuables are ordinary items and keep a real per-row figure.
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
@@ -15,6 +16,19 @@ import type { WealthRow } from "@domain/vm-types";
 const coin = (denom: string, qty: number): WealthRow => ({
   kind: "coin", id: denom.toLowerCase(), denom, gpEach: 1, name: `${denom} coins`,
   img: "", monogram: denom, qty, weight: qty, value: qty,
+  coinsOrGems: true, itemslots: 0,
+});
+
+/** A gem: not a coin row for us, but the system buckets it with coins all the same. */
+const gem = (qty: number): WealthRow => ({
+  kind: "treasure", id: "gem", name: "Gems", img: "", monogram: "GE",
+  qty, weight: qty, value: qty * 10, coinsOrGems: true, slots: 0,
+});
+
+/** A valuable the system does NOT bucket — ordinary slots, ordinary per-row figure. */
+const valuable = (qty: number, slots: number): WealthRow => ({
+  kind: "treasure", id: "idol", name: "Golden idol", img: "", monogram: "GI",
+  qty, weight: 100, value: 500, coinsOrGems: false, slots,
 });
 
 const ctx = { canEdit: true } as OscSheetContextValue;
@@ -49,7 +63,7 @@ describe("load column header", () => {
   });
 });
 
-describe("treasure under itembased", () => {
+describe("coins, gems and other valuables under itembased", () => {
   // 250 coins → 3 slots (ceil), and no per-row figure to show.
   const wealth = [coin("GP", 150), coin("SP", 100)];
 
@@ -72,5 +86,22 @@ describe("treasure under itembased", () => {
     const cells = [...container.querySelectorAll(".osc-coin-wt")].map((n) => n.textContent?.trim());
     expect(cells).toEqual(["150", "100"]);
     expect(container.querySelector(".osc-coin-total .tw")?.textContent).toBe("250");
+  });
+
+  it("ceils the coin bucket once over the whole set, not per row", () => {
+    // 50 + 40 = 90 coins → one slot. Ceiling each row would wrongly give two.
+    render(<WealthSection wealth={[coin("GP", 50), coin("SP", 40)]} variant="itembased" onSetCoin={noop} itemDragData={() => undefined} onOpen={noop} onContext={noop} />);
+    expect(container.querySelector(".osc-whead .wt")?.textContent).toBe("1 slots");
+  });
+
+  it("buckets gems with the coins and counts other valuables normally", () => {
+    // 60 coins + 50 gems = 110 bucketed → 2 slots, plus the idol's own 3.
+    const wealth = [coin("GP", 60), gem(50), valuable(3, 3)];
+    render(<WealthSection wealth={wealth} variant="itembased" onSetCoin={noop} itemDragData={() => undefined} onOpen={noop} onContext={noop} />);
+    expect(container.querySelector(".osc-whead .wt")?.textContent).toBe("5 slots");
+    openTable();
+    const cells = [...container.querySelectorAll(".osc-coin-wt")].map((n) => n.textContent?.trim());
+    expect(cells).toEqual(["—", "—", "3"]);
+    expect(container.querySelector(".osc-coin-total .tw")?.textContent).toBe("5");
   });
 });

--- a/src/OscSheet/features/inventory/rows/SortableRow.test.tsx
+++ b/src/OscSheet/features/inventory/rows/SortableRow.test.tsx
@@ -17,7 +17,7 @@ const mkItem = (o: Partial<InventoryItemVM> = {}): InventoryItemVM => ({
   id: "arrows", name: "Arrows", img: "", category: "Weapon", categoryRank: 0,
   damage: "", tags: [], monogram: "AR", weight: 5, slots: 1, cost: 0, armorClass: null,
   sort: 0, equippedSort: 0, equipped: null, quantity: { value: 3, max: 5 },
-  treasure: false, isContainer: false, children: [], ...o,
+  treasure: false, coinsOrGems: false, isContainer: false, children: [], ...o,
 });
 
 let container: HTMLDivElement;

--- a/src/OscSheet/features/inventory/rows/UsesRow.test.tsx
+++ b/src/OscSheet/features/inventory/rows/UsesRow.test.tsx
@@ -18,7 +18,7 @@ const mkItem = (o: Partial<InventoryItemVM> = {}): InventoryItemVM => ({
   id: "arrows", name: "Arrows", img: "", category: "Weapon", categoryRank: 0,
   damage: "", tags: [], monogram: "AR", weight: 5, slots: 1, cost: 0, armorClass: null,
   sort: 0, equippedSort: 0, equipped: null, quantity: { value: 3, max: 5 },
-  treasure: false, isContainer: false, children: [], ...o,
+  treasure: false, coinsOrGems: false, isContainer: false, children: [], ...o,
 });
 
 let container: HTMLDivElement;

--- a/src/OscSheet/features/inventory/slots.ts
+++ b/src/OscSheet/features/inventory/slots.ts
@@ -1,0 +1,24 @@
+// Item-Based Encumbrance slot counting, shared by the inventory list and the Treasure
+// section (which is why it lives here rather than in either of them).
+import type { OseItem } from "@domain/types";
+
+/** Whether the system buckets this item globally at 100 to a slot instead of counting it
+ *  per row. Only `item`-typed treasure qualifies, and only when the system's own derived
+ *  `isCoinsOrGems` says so — other valuables (a gold idol, a silver crown) count normally. */
+export function bucketsAsCoinsOrGems(item: OseItem): boolean {
+  return item.type === "item" && !!item.system?.isCoinsOrGems;
+}
+
+/** Carried item slots, mirroring the system's item-based encumbrance model: `item` and
+ *  `container` fold in quantity, `weapon`/`armor` count their slots once whatever the qty. */
+export function slotsOf(item: OseItem): number {
+  const s = item.system;
+  const slots = s.itemslots ?? 0;
+  // Coins/gems are bucketed globally (100 to a slot, ceiled once over the lot), so they
+  // have no honest per-row figure — the Treasure section totals them instead.
+  if (bucketsAsCoinsOrGems(item)) return 0;
+  if (item.type === "weapon" || item.type === "armor") return slots;
+  // Containers ship quantity 0, so the system counts them as 0 slots. Coercing that to 1
+  // would read better but would stop our totals matching the system's own figure.
+  return s.cumulativeItemslots ?? Math.ceil(slots * (s.quantity?.value ?? 1));
+}

--- a/src/OscSheet/features/inventory/treasure.ts
+++ b/src/OscSheet/features/inventory/treasure.ts
@@ -7,6 +7,7 @@ import type {
   SortDir,
 } from "@domain/vm-types";
 import { monogram } from "./monogram";
+import { bucketsAsCoinsOrGems, slotsOf } from "./slots";
 
 const COIN_DENOMS = ["pp", "gp", "ep", "sp", "cp"] as const;
 
@@ -74,6 +75,8 @@ export function selectCoins(items: OseItem[]): CoinVM[] {
         img: (it.img as string) ?? "",
         value: it.system.quantity?.value ?? 0,
         gpEach: cost > 0 ? cost : (GP_PER_COIN[d] ?? 0),
+        coinsOrGems: bucketsAsCoinsOrGems(it),
+        itemslots: it.system.itemslots ?? 0,
       },
     ];
   });
@@ -112,6 +115,8 @@ export function selectTreasure(items: OseItem[]): TreasureVM[] {
         weight: s.cumulativeWeight ?? s.weight ?? 0,
         cost,
         value: qty * cost,
+        coinsOrGems: bucketsAsCoinsOrGems(it),
+        slots: slotsOf(it),
       };
     })
     .sort((a, b) => a.name.localeCompare(b.name));
@@ -137,6 +142,8 @@ export function selectWealth(items: OseItem[]): WealthRow[] {
     qty: c.value,
     weight: c.value, // coins are 1 cn each
     value: c.value * c.gpEach,
+    coinsOrGems: c.coinsOrGems,
+    itemslots: c.itemslots,
   }));
   const valuables: WealthRow[] = selectTreasure(items).map((t) => ({
     kind: "treasure",
@@ -147,6 +154,8 @@ export function selectWealth(items: OseItem[]): WealthRow[] {
     qty: t.qty,
     weight: t.weight,
     value: t.value,
+    coinsOrGems: t.coinsOrGems,
+    slots: t.slots,
   }));
   return [...coins, ...valuables];
 }

--- a/src/applications/osc-sheet.js
+++ b/src/applications/osc-sheet.js
@@ -87,6 +87,12 @@ class OscSheet extends ReactActorSheetV2 {
     });
   }
 
+  // Local builds append the branch + sha they were built FROM, so a stale dist is
+  // obvious in the titlebar. Empty in CI, so released builds keep a clean title.
+  get title() {
+    return __BUILD_STAMP__ ? `${super.title} — ${__BUILD_STAMP__}` : super.title;
+  }
+
   async _onRender(context, options) {
     await super._onRender(context, options);
     const theme = resolveTheme(game.settings.get(MODULE_ID, "theme"));

--- a/src/applications/osc-sheet.js
+++ b/src/applications/osc-sheet.js
@@ -87,7 +87,7 @@ class OscSheet extends ReactActorSheetV2 {
     });
   }
 
-  // Local builds append the branch + sha they were built FROM, so a stale dist is
+  // Local builds append the branch they were built FROM, so a stale dist is
   // obvious in the titlebar. Empty in CI, so released builds keep a clean title.
   get title() {
     return __BUILD_STAMP__ ? `${super.title} — ${__BUILD_STAMP__}` : super.title;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,3 +3,5 @@
 
 // Build-time-injected module id (vite `define`); beta builds override it.
 declare const __MODULE_ID__: string;
+/** Branch + sha the build came from; "" in CI. */
+declare const __BUILD_STAMP__: string;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,5 +3,5 @@
 
 // Build-time-injected module id (vite `define`); beta builds override it.
 declare const __MODULE_ID__: string;
-/** Branch + sha the build came from; "" in CI. */
+/** Branch the build came from ("*" = dirty); "" in CI. */
 declare const __BUILD_STAMP__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,15 +6,17 @@ import fs from "node:fs";
 import path from "path";
 import { execSync } from "node:child_process";
 
-/** Branch + short sha of the build, so a sheet's titlebar says which build is loaded —
- *  not what's checked out now. Those differ exactly when you forget to rebuild. Empty
- *  in CI, so released builds keep a clean title. */
+/** Branch the build came from, so a sheet's titlebar says which build is loaded — not
+ *  what's checked out now. Those differ exactly when you forget to rebuild. A trailing
+ *  `*` means the build included uncommitted changes. Empty in CI, so releases are clean. */
 function buildStamp(): string {
   if (process.env.CI) return "";
   try {
-    const git = (cmd: string) => execSync(`git ${cmd}`, { stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
-    const dirty = git("status --porcelain") ? "*" : "";
-    return `${git("rev-parse --abbrev-ref HEAD")} @ ${git("rev-parse --short HEAD")}${dirty}`;
+    const git = (cmd: string) =>
+      execSync(`git ${cmd}`, { stdio: ["ignore", "pipe", "ignore"] })
+        .toString()
+        .trim();
+    return `${git("rev-parse --abbrev-ref HEAD")}${git("status --porcelain") ? "*" : ""}`;
   } catch {
     return "";
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,21 @@ import foundryReact from "foundry-vtt-react/vite";
 import svgr from "vite-plugin-svgr";
 import fs from "node:fs";
 import path from "path";
+import { execSync } from "node:child_process";
+
+/** Branch + short sha of the build, so a sheet's titlebar says which build is loaded —
+ *  not what's checked out now. Those differ exactly when you forget to rebuild. Empty
+ *  in CI, so released builds keep a clean title. */
+function buildStamp(): string {
+  if (process.env.CI) return "";
+  try {
+    const git = (cmd: string) => execSync(`git ${cmd}`, { stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
+    const dirty = git("status --porcelain") ? "*" : "";
+    return `${git("rev-parse --abbrev-ref HEAD")} @ ${git("rev-parse --short HEAD")}${dirty}`;
+  } catch {
+    return "";
+  }
+}
 
 // foundryReact() owns the Foundry-specific config (base, root, server.proxy,
 // build input/output) — derived from module.json. Only app-specific config lives here.
@@ -16,6 +31,7 @@ const config: UserConfig = {
     __SENTRY_DEBUG__: false,
     // Baked module id — beta builds set MODULE_ID to isolate flags/settings/socket.
     __MODULE_ID__: JSON.stringify(process.env.MODULE_ID ?? "osc-character-sheet"),
+    __BUILD_STAMP__: JSON.stringify(buildStamp()),
   },
   resolve: {
     // Note: react/react-dom dedupe is handled by foundryReact() — no need to set it here.


### PR DESCRIPTION
Only `isCoinsOrGems` treasure is bucketed at 100 to a slot; other valuables now take ordinary item slots and show a real per-row figure.