### PR TITLE
Point the brass alias at the gold accent instead of teal

### DIFF
--- a/src/OscSheet/styles/vellum/tokens.scss
+++ b/src/OscSheet/styles/vellum/tokens.scss
@@ -95,8 +95,10 @@
   --on-accent:     var(--ink);
 
   /* ─── Legacy aliases (so existing components keep working) ─────────── */
-  --brass:         var(--teal);
-  --brass-dim:     var(--teal-dim);
+  /* Brass is the warm gold accent (XP, treasure), NOT teal — teal is the primary/retainer
+     accent. Aliasing it to teal also froze it across themes: --teal is theme-constant. */
+  --brass:         var(--accent-alt);
+  --brass-dim:     var(--accent-alt-dim);
   --oxblood:       var(--crimson);
   --oxblood-2:     var(--crimson);
   --sage:          var(--forest);


### PR DESCRIPTION
`--brass`/`--brass-dim` were aliased to `--teal`, so everything using them rendered teal — the XP bar gradient, the active tab underline and tab counts. Brass is the warm gold accent for XP and treasure; teal is the primary/retainer accent, and the design system documents it that way.

Aliasing to teal also froze the value across themes: `--teal` is deliberately theme-constant while `--accent-alt` flips (`#c89e54` → `#8a6418`). This is a visible change to shipped colours — the XP bar and active tab underline go from teal to gold.
