### PR TITLE
Unify the section-title rule and delete the dead actions.scss override

### DIFF
--- a/src/OscSheet/styles/actions.scss
+++ b/src/OscSheet/styles/actions.scss
@@ -146,41 +146,6 @@
 // (StatPlaque variant="ability"). The grid container is in actions-features.scss
 // — AbilityPlaques.tsx is NOT converted. XS flattens the plaques (block below).
 
-// --- section title override (prototype: 2px border-bottom, not 3px thick) ---
-// STAYS SCSS, and cannot move. This is a blanket override of the vellum
-// `.section-title` base at (0,1,0), so vellum's own `.section-title.sub` and
-// `.section-title.bare` (both (0,2,0), and both earlier in source) still win the
-// properties they re-declare — that is what keeps the inventory's "Equipped" /
-// "All Items" heads small-caps sans and a modal title rule-less.
-//
-// As utilities on SectionTitle.tsx it would land at (0,2,0) imported LAST, tie
-// with those two variants and beat them, silently restyling every sub-head and
-// every modal title in the sheet. The variants live in the shared vellum
-// stylesheet, so the fix isn't here — it lands when the sheet consumes the
-// published package and this override can go away entirely.
-.section-title {
-  font-family: var(--display);
-  font-size: var(--fs-xl, 18px);
-  font-weight: 400;
-  letter-spacing: 0.02em;
-  color: var(--text);
-  margin: 0 0 var(--spacer-2);
-  padding-bottom: var(--spacer-1);
-  border-bottom: 2px solid var(--border);
-  display: flex;
-  align-items: baseline;
-  gap: var(--spacer-2);
-  flex-wrap: nowrap;
-  line-height: unset;
-}
-.section-title .hint {
-  font-family: "IM Fell English", Georgia, serif;
-  font-style: italic;
-  font-size: var(--fs-xs, 12px);
-  color: var(--text-mute);
-  letter-spacing: 0;
-}
-
 // --- saves/exploration tab nav (rail, large view) ---
 // Nav + tabs are in actions-features.scss; SavesExploration.tsx is NOT converted.
 

--- a/src/OscSheet/styles/vellum/components.css
+++ b/src/OscSheet/styles/vellum/components.css
@@ -841,8 +841,8 @@
    The SectionHeader component's layout (was `.osc-feat-head` in features.scss):
    a full-width flex row with a bottom rule, the SectionTitle flexed to fill and
    its own rule/margins neutralised. `.section-header .section-title` scopes to
-   (0,3,0), outranking both the vellum `.section-title` base (0,2,0) and the
-   actions.scss override (0,1,0), so the title reset wins as before. */
+   (0,3,0), outranking the `.section-title` base at (0,2,0), so the title reset
+   wins as before. */
 .section-header {
   display: flex;
   align-items: center;

--- a/src/OscSheet/styles/vellum/sheet-base.scss
+++ b/src/OscSheet/styles/vellum/sheet-base.scss
@@ -66,21 +66,30 @@ body {
 .stamp.md  { font-size: var(--fs-md); padding: 7px 11px 5px; }
 .stamp.sm  { font-size: var(--fs-2xs); padding: 5px 8px 3px; letter-spacing: 0.1em; }
 
-/* Section title — Title Case in IM Fell SC with a thick rule underneath
-   (the "Vellum" treatment). IM Fell SC renders small caps naturally so we
-   do NOT uppercase. */
+/* Section title — Title Case in IM Fell SC with a rule underneath (the
+   "Vellum" treatment). IM Fell SC renders small caps naturally so we do NOT
+   uppercase.
+
+   The single base rule. An `actions.scss` copy used to shadow this one and
+   never applied: unscoped, it sat at (0,1,0) against this rule's (0,2,0). Its
+   values — the prototype's — are the ones kept here, so the sheet finally
+   renders what that override intended. `--section-rule` aliases `--border` in
+   both themes, which is why the two agree on the rule despite naming different
+   tokens. The `.bare` / `.sub` variants below stay at (0,3,0) and still win. */
 .section-title {
   font-family: var(--display);
-  font-size: var(--fs-2xl);
+  font-size: var(--fs-xl);
+  font-weight: 400;
   letter-spacing: 0.02em;
   color: var(--text);
   display: flex;
   align-items: baseline;
-  gap: 12px;
-  padding-bottom: 6px;
+  flex-wrap: nowrap;
+  gap: var(--spacer-2);
+  padding-bottom: var(--spacer-1);
   border-bottom: 2px solid var(--section-rule);
-  margin: var(--spacer-6) 0 var(--spacer-3) 0;
-  line-height: 1.1;
+  margin: 0 0 var(--spacer-2);
+  line-height: unset;
   text-transform: none;
 }
 .section-title .hint {


### PR DESCRIPTION
The sheet had two `.section-title` rules. The one in `actions.scss` carried the prototype's values and a comment calling it a blanket override of the other. It never was — `actions.scss` sits outside `styles/vellum/`, so the scoper never reached it and it landed at (0,1,0) against the scoped rule's (0,2,0). It has always lost, and the sheet has been rendering the un-overridden base.

Its values were the intended ones, so they fold into the single scoped rule and the copy goes: `--fs-xl` rather than `--fs-2xl`, no top margin, tighter gap and padding, inherited line-height. `--section-rule` aliases `--border` in both themes, which is why the two agreed on the 2px rule despite naming different tokens.

Section titles across all five tabs get smaller and sit closer to their content. That is a deliberate change, and the correction the dead override was written to make. `.bare`, `.sub` and the inventory, edit-modal and SectionHeader overrides all sit at (0,3,0) and are untouched.

Based on #127; landing this first keeps the `@old-school-chronicle/ui` migration's diff quiet, since the package ships the same rule.