### PR TITLE
Key the e2e concurrency group by event name

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,9 +30,11 @@ on:
     types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
-# One license = one server: serialize, drop superseded runs.
+# One license = one server: serialize, drop superseded runs. Keyed by event name as well
+# as PR, or the pull_request_target run cancels the pull_request run on a same-repo PR and
+# then skips itself, leaving the required check with no green status.
 concurrency:
-  group: e2e-${{ github.event.pull_request.number || github.ref }}
+  group: e2e-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Both e2e workflows shared one concurrency group, so on a same-repo PR the pull_request_target run cancelled the pull_request run and then skipped itself — leaving the required e2e check with no successful status and blocking the PR. Adding the event name to the group key keeps the one-run-per-PR serialisation within each trigger while stopping the two paths from cancelling each other.