### PR TITLE
Show favorited abilities on the Actions tab

### DIFF
--- a/src/OscSheet/domain/favorites.ts
+++ b/src/OscSheet/domain/favorites.ts
@@ -1,0 +1,12 @@
+import type { OseItem } from "@domain/types";
+import { FLAGS, readFlag, setFlag, unsetFlag } from "@domain/flags";
+
+/** Whether an item is favorited (shown on the Actions tab). */
+export function isFavorite(item: OseItem): boolean {
+  return !!readFlag<boolean>(item, FLAGS.favorite);
+}
+
+/** Toggle an item's favorite flag. */
+export function toggleFavorite(item: OseItem): Promise<unknown> {
+  return isFavorite(item) ? unsetFlag(item, FLAGS.favorite) : setFlag(item, FLAGS.favorite, true);
+}

--- a/src/OscSheet/domain/flags.ts
+++ b/src/OscSheet/domain/flags.ts
@@ -18,7 +18,7 @@ export const FLAGS = {
   /** Manual order position of an equipped item within the equipped tray —
    *  independent of `order` (its row position in the All-Items list). */
   equippedOrder: "equippedOrder",
-  /** Spell flagged to appear on the Actions tab when memorization is disabled. */
+  /** Item flagged to appear on the Actions tab (spells: only when memorization is disabled). */
   favorite: "favorite",
   /** Per-level spell points spent (actor flag) in free-casting mode: Record<level, number>. */
   spellPoints: "spellPoints",

--- a/src/OscSheet/features/abilities/FavoriteStar.tsx
+++ b/src/OscSheet/features/abilities/FavoriteStar.tsx
@@ -1,0 +1,48 @@
+import { cx } from "@ui/cx";
+import { IconButton } from "@ui/IconButton";
+import { useToast } from "@ui/toastContext";
+
+export function FavoriteStar({
+  name,
+  favorite,
+  onToggle,
+  className,
+  ...rest
+}: {
+  name: string;
+  favorite: boolean;
+  onToggle: () => void;
+  className?: string;
+  "data-testid"?: string;
+}) {
+  const toast = useToast();
+  const label = favorite ? `Unfavorite ${name}` : `Favorite ${name}`;
+
+  return (
+    <IconButton
+      on={favorite}
+      className={className}
+      {...rest}
+      aria-pressed={favorite}
+      title={label}
+      aria-label={label}
+      onClick={(e) => {
+        e.stopPropagation();
+        onToggle();
+        toast({
+          intent: "success",
+          title: favorite ? "Unfavorited" : "Favorited",
+          message: (
+            <>
+              <strong>{name}</strong>
+              {favorite ? " removed from Actions tab" : " added to Actions tab"}
+            </>
+          ),
+          icon: <i className="fa-solid fa-star" aria-hidden="true" />,
+        });
+      }}
+    >
+      <i className={cx(favorite ? "fa-solid" : "fa-regular", "fa-star")} aria-hidden="true" />
+    </IconButton>
+  );
+}

--- a/src/OscSheet/features/abilities/FeatureCard.tsx
+++ b/src/OscSheet/features/abilities/FeatureCard.tsx
@@ -4,6 +4,7 @@ import { useOscSheetContext } from "@app/context";
 import { cx } from "@ui/cx";
 import { IconButton } from "@ui/IconButton";
 import { Monogram } from "@ui/Monogram";
+import { FavoriteStar } from "@features/abilities/FavoriteStar";
 import { RichText } from "@ui/RichText";
 
 /** Enrich raw HTML once via Foundry's TextEditor (links, inline rolls, embeds). */
@@ -102,6 +103,14 @@ export function FeatureCard({ feature }: { feature: FeatureVM }) {
             </div>
           )}
         </div>
+        {canEdit && (
+          <FavoriteStar
+            className="ft-fav"
+            name={feature.name}
+            favorite={feature.favorite}
+            onToggle={feature.onToggleFavorite}
+          />
+        )}
         <IconButton
           className="ft-chev tw:text-[length:var(--fs-md)]"
           aria-expanded={open}

--- a/src/OscSheet/features/abilities/features.test.ts
+++ b/src/OscSheet/features/abilities/features.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, vi } from "vitest";
-import { selectFeatures } from "@features/abilities/features";
+import { selectFeatures, selectFavoriteAbilities } from "@features/abilities/features";
 import type { OSEActor, OseAbility } from "@domain/types";
 
 // selectFeatures composes the roll tag from CONFIG.OSE.roll_type (a Foundry global).
@@ -9,20 +9,26 @@ beforeAll(() => {
   };
 });
 
+const MODULE_ID = "osc-character-sheet";
+
 type AbilityMock = {
   _id: string;
   name: string;
   img?: string;
   roll?: () => void;
+  favorite?: boolean;
   // partial ability system — full OseItem system has many required fields the VM ignores
   system?: Partial<OseAbility["system"]>;
 };
 
-function ability(partial: AbilityMock): OseAbility {
+function ability({ favorite, ...partial }: AbilityMock): OseAbility {
   return {
     img: "icons/x.svg",
     roll: vi.fn(),
+    setFlag: vi.fn(),
+    unsetFlag: vi.fn(),
     ...partial,
+    flags: favorite ? { [MODULE_ID]: { favorite: true } } : {},
     system: { description: "", ...(partial.system ?? {}) },
   } as unknown as OseAbility;
 }
@@ -87,5 +93,50 @@ describe("selectFeatures", () => {
       ability({ _id: "a4", name: "Gamma", system: { requirements: "elf" } }),
     ]);
     expect(selectFeatures(actor).map((f) => f.name)).toEqual(["Alpha", "Gamma", "Beta", "Zeta"]);
+  });
+
+  it("reads the favorite flag off the backing item", () => {
+    const actor = actorWith([
+      ability({ _id: "a1", name: "Hide", favorite: true }),
+      ability({ _id: "a2", name: "Listen" }),
+    ]);
+    expect(selectFeatures(actor).map((f) => f.favorite)).toEqual([true, false]);
+  });
+
+  it("onToggleFavorite sets the flag when unset and unsets it when set", () => {
+    const off = ability({ _id: "a1", name: "Listen" });
+    selectFeatures(actorWith([off]))[0].onToggleFavorite();
+    expect(off.setFlag).toHaveBeenCalledWith(MODULE_ID, "favorite", true);
+    expect(off.unsetFlag).not.toHaveBeenCalled();
+
+    const on = ability({ _id: "a2", name: "Hide", favorite: true });
+    selectFeatures(actorWith([on]))[0].onToggleFavorite();
+    expect(on.unsetFlag).toHaveBeenCalledWith(MODULE_ID, "favorite");
+    expect(on.setFlag).not.toHaveBeenCalled();
+  });
+
+  it("onActivate calls the item's roll method for a passive feature too", () => {
+    const item = ability({ _id: "a1", name: "Read Magic", system: { roll: "" } });
+    const [vm] = selectFeatures(actorWith([item]));
+    expect(vm.onRoll).toBeUndefined();
+    vm.onActivate();
+    expect(item.roll).toHaveBeenCalledOnce();
+  });
+});
+
+describe("selectFavoriteAbilities", () => {
+  it("returns only favorited features, keeping the requirements-then-name sort", () => {
+    const actor = actorWith([
+      ability({ _id: "a1", name: "Zeta", favorite: true, system: {} }),
+      ability({ _id: "a2", name: "Beta", system: { requirements: "thief" } }),
+      ability({ _id: "a3", name: "Alpha", favorite: true, system: { requirements: "elf" } }),
+      ability({ _id: "a4", name: "Gamma", favorite: true, system: { requirements: "elf" } }),
+    ]);
+    expect(selectFavoriteAbilities(actor).map((f) => f.name)).toEqual(["Alpha", "Gamma", "Zeta"]);
+  });
+
+  it("returns an empty list when nothing is favorited", () => {
+    const actor = actorWith([ability({ _id: "a1", name: "Hide", system: {} })]);
+    expect(selectFavoriteAbilities(actor)).toEqual([]);
   });
 });

--- a/src/OscSheet/features/abilities/features.ts
+++ b/src/OscSheet/features/abilities/features.ts
@@ -1,5 +1,6 @@
 import type { OSEActor, OseAbility, OseRollType } from "@domain/types";
 import { showDeleteDialog } from "@domain/foundryDialogs";
+import { isFavorite, toggleFavorite } from "@domain/favorites";
 
 export interface FeatureVM {
   id: string;
@@ -15,8 +16,18 @@ export interface FeatureVM {
   rollable: boolean;
   /** Composed tag, e.g. "1d6 ≤2" or "1d6" when there's no target. undefined when passive. */
   rollTag?: string;
+  /** Bare formula, e.g. "1d6". undefined when passive. */
+  rollFormula?: string;
+  /** Comparison and target, e.g. "≤2". undefined when the ability sets no target. */
+  rollTargetTag?: string;
+  /** Flagged to appear on the Actions tab. */
+  favorite: boolean;
   /** Calls the OSE ability item's own roll method (chat, success/fail, blind). */
   onRoll?: () => void;
+  /** Same call, always present — rolls the formula, or prints the ability to chat when passive. */
+  onActivate: () => void;
+  /** Toggles the backing item's favorite flag. */
+  onToggleFavorite: () => void;
   /** Opens the backing ability item's sheet. */
   onOpen: () => void;
   /** Opens the confirm-delete dialog for the backing item. */
@@ -61,6 +72,7 @@ export function selectFeatures(actor: OSEActor): FeatureVM[] {
   const vms: FeatureVM[] = abilities.map((item) => {
     const s = item.system;
     const rollable = !!s.roll;
+    const activate = () => item.roll();
     return {
       id: item._id as string,
       name: item.name,
@@ -70,7 +82,13 @@ export function selectFeatures(actor: OSEActor): FeatureVM[] {
       requiresLabel: requiresLabel(s.requirements),
       rollable,
       rollTag: rollable ? composeTag(s.roll!, s.rollType, s.rollTarget) : undefined,
-      onRoll: rollable ? () => item.roll() : undefined,
+      rollFormula: rollable ? s.roll! : undefined,
+      rollTargetTag:
+        rollable && s.rollTarget ? `${rollSymbol(s.rollType)}${s.rollTarget}` : undefined,
+      favorite: isFavorite(item),
+      onRoll: rollable ? activate : undefined,
+      onActivate: activate,
+      onToggleFavorite: () => void toggleFavorite(item),
       onOpen: () => item.sheet.render(true),
       onDelete: () => showDeleteDialog(item),
     };
@@ -82,4 +100,9 @@ export function selectFeatures(actor: OSEActor): FeatureVM[] {
     if (!sa !== !sb) return sa ? -1 : 1;
     return sa.localeCompare(sb) || a.name.localeCompare(b.name);
   });
+}
+
+/** The abilities flagged to appear on the Actions tab, in the same order. */
+export function selectFavoriteAbilities(actor: OSEActor): FeatureVM[] {
+  return selectFeatures(actor).filter((f) => f.favorite);
 }

--- a/src/OscSheet/features/actions/ActionsView.tsx
+++ b/src/OscSheet/features/actions/ActionsView.tsx
@@ -11,6 +11,8 @@ import { postRollCard } from "@domain/chat/attackCard";
 import { buildItemMacroDragData } from "@features/inventory/dragToMacro";
 import { AbilityPlaques } from "@features/actions/AbilityPlaques";
 import { AttacksTable } from "@features/actions/AttacksTable";
+import { FavoriteAbilities } from "@features/actions/FavoriteAbilities";
+import { selectFavoriteAbilities } from "@features/abilities/features";
 import { MemorizedSpells } from "@features/actions/MemorizedSpells";
 import { SavesGrid, ExplorationGrid } from "@features/actions/SavesExploration";
 import { SectionTitle } from "@ui/SectionTitle";
@@ -55,6 +57,7 @@ export function ActionsView({ actor }: Props) {
     <>
       <AbilityPlaques abilities={selectAbilities(actor)} onRoll={onAbility} />
       <AttacksTable attacks={attacks} onRoll={onRoll} onAttack={canEdit ? onAttack : undefined} onOpen={onOpenWeapon} dragData={dragData} canAttack={canEdit} />
+      <FavoriteAbilities features={selectFavoriteAbilities(actor)} dragData={dragData} />
       <MemorizedSpells actor={actor} />
       {/* .actions-only: hidden at lg (Saves/Exploration live in the rail there). */}
       <section className="osc-section actions-only">

--- a/src/OscSheet/features/actions/FavoriteAbilities.test.tsx
+++ b/src/OscSheet/features/actions/FavoriteAbilities.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { FavoriteAbilities } from "@features/actions/FavoriteAbilities";
+import type { FeatureVM } from "@features/abilities/features";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function feature(partial: Partial<FeatureVM> = {}): FeatureVM {
+  return {
+    id: "hide",
+    name: "Hide in Shadows",
+    img: "",
+    description: "",
+    rollable: true,
+    rollTag: "1d6 ≤2",
+    rollFormula: "1d6",
+    rollTargetTag: "≤2",
+    favorite: true,
+    onRoll: vi.fn(),
+    onActivate: vi.fn(),
+    onToggleFavorite: vi.fn(),
+    onOpen: vi.fn(),
+    onDelete: vi.fn(),
+    ...partial,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+const click = (testid: string) => {
+  const el = container.querySelector<HTMLElement>(`[data-testid="${testid}"]`)!;
+  act(() => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+};
+
+describe("FavoriteAbilities", () => {
+  it("renders nothing when there are no favorites", () => {
+    act(() => root.render(<FavoriteAbilities features={[]} />));
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("shows the formula by the dice and the target beside the name", () => {
+    act(() =>
+      root.render(
+        <FavoriteAbilities
+          features={[
+            feature(),
+            feature({ id: "listen", name: "Listen", rollFormula: "1d6", rollTargetTag: "≤1" }),
+          ]}
+        />,
+      ),
+    );
+    expect(container.querySelectorAll("[data-testid^='fav-ability-']").length).toBeGreaterThan(0);
+    expect(container.querySelector('[data-testid="fav-ability-name-hide"]')!.textContent).toBe(
+      "Hide in Shadows",
+    );
+    expect(container.querySelector('[data-testid="fav-ability-target-hide"]')!.textContent).toBe(
+      "≤2",
+    );
+    expect(container.querySelector('[data-testid="fav-ability-roll-listen"]')!.textContent).toContain(
+      "1d6",
+    );
+    expect(container.querySelector('[data-testid="fav-ability-roll-listen"]')!.textContent).not.toContain(
+      "≤1",
+    );
+  });
+
+  it("labels a passive ability's button for chat", () => {
+    act(() =>
+      root.render(
+        <FavoriteAbilities
+          features={[feature({ id: "magic", name: "Read Magic", rollable: false, rollTag: undefined, rollFormula: undefined, rollTargetTag: undefined, onRoll: undefined })]}
+        />,
+      ),
+    );
+    const btn = container.querySelector('[data-testid="fav-ability-roll-magic"]')!;
+    expect(btn.textContent).toContain("chat");
+    const row = container.querySelector('[data-testid="fav-ability-magic"]')!;
+    expect(row.getAttribute("title")).toBe("Print Read Magic to chat");
+  });
+
+  it("the roll button calls onActivate for both rollable and passive abilities", () => {
+    const rollable = feature();
+    const passive = feature({
+      id: "magic",
+      name: "Read Magic",
+      rollable: false,
+      rollTag: undefined,
+      onRoll: undefined,
+    });
+    act(() => root.render(<FavoriteAbilities features={[rollable, passive]} />));
+
+    click("fav-ability-roll-hide");
+    click("fav-ability-roll-magic");
+
+    expect(rollable.onActivate).toHaveBeenCalledOnce();
+    expect(passive.onActivate).toHaveBeenCalledOnce();
+  });
+
+  it("the name opens the item sheet", () => {
+    const vm = feature();
+    act(() => root.render(<FavoriteAbilities features={[vm]} />));
+
+    click("fav-ability-name-hide");
+
+    expect(vm.onOpen).toHaveBeenCalledOnce();
+  });
+
+  it("has no favorite star", () => {
+    act(() => root.render(<FavoriteAbilities features={[feature()]} />));
+    expect(container.querySelector('[data-testid="fav-ability-star-hide"]')).toBeNull();
+  });
+});

--- a/src/OscSheet/features/actions/FavoriteAbilities.tsx
+++ b/src/OscSheet/features/actions/FavoriteAbilities.tsx
@@ -1,0 +1,103 @@
+import type { DragEvent } from "react";
+import type { FeatureVM } from "@features/abilities/features";
+import { SectionTitle } from "@ui/SectionTitle";
+import { Monogram } from "@ui/Monogram";
+import { cx } from "@ui/cx";
+import { rollable } from "@ui/rollable";
+
+type Props = {
+  features: FeatureVM[];
+  /** Foundry item drag-data for an ability, so its card drops onto the macro hotbar. */
+  dragData?: (itemId: string) => string | undefined;
+};
+
+function AbilityCard({
+  feature,
+  dragData,
+}: {
+  feature: FeatureVM;
+  dragData?: Props["dragData"];
+}) {
+  const macroDrag = dragData
+    ? {
+        draggable: true,
+        onDragStart: (e: DragEvent<HTMLElement>) => {
+          const payload = dragData(feature.id);
+          if (!payload) {
+            e.preventDefault();
+            return;
+          }
+          e.dataTransfer.effectAllowed = "all";
+          try {
+            e.dataTransfer.setData("text/plain", payload);
+          } catch {
+            /* IE guard */
+          }
+        },
+      }
+    : {};
+
+  return (
+    <div
+      className="fvtt-skill rollable osc-fav-ability"
+      data-testid={`fav-ability-${feature.id}`}
+      title={feature.rollable ? `Roll ${feature.rollTag}` : `Print ${feature.name} to chat`}
+      {...rollable(() => feature.onActivate())}
+    >
+      <Monogram
+        img={feature.img}
+        monogram={feature.name.charAt(0).toUpperCase()}
+        className="skic tw:grid tw:size-5 tw:place-items-center tw:rounded-sm tw:bg-ink tw:font-display tw:text-[length:var(--fs-2xs)] tw:text-stamp-text"
+        imgClassName="tw:object-cover"
+        data-testid={`fav-ability-img-${feature.id}`}
+        {...macroDrag}
+      />
+      <span className="skn tw:flex tw:min-w-0 tw:flex-wrap tw:items-baseline tw:gap-x-2">
+        <button
+          type="button"
+          className="tw:min-w-0 tw:cursor-pointer tw:border-0 tw:bg-transparent tw:p-0 tw:text-left tw:text-inherit tw:hover:text-gold tw:focus-visible:outline-2 tw:focus-visible:outline-offset-2 tw:focus-visible:outline-gold"
+          data-testid={`fav-ability-name-${feature.id}`}
+          title={`Open ${feature.name}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            feature.onOpen();
+          }}
+        >
+          {feature.name}
+        </button>
+        {feature.rollTargetTag && (
+          <span
+            className="tw:font-mono tw:whitespace-nowrap tw:text-text-mute"
+            data-testid={`fav-ability-target-${feature.id}`}
+          >
+            {feature.rollTargetTag}
+          </span>
+        )}
+      </span>
+      <span className="skv" data-testid={`fav-ability-roll-${feature.id}`}>
+        {feature.rollFormula ?? "chat"}
+        <i
+          className={cx("fa-solid", feature.rollable ? "fa-dice-d20" : "fa-comment")}
+          aria-hidden="true"
+        />
+      </span>
+    </div>
+  );
+}
+
+/** Favorited ability items, quick-rollable from the Actions tab. Passive abilities
+ *  (no formula) print to chat instead — `item.roll()` covers both. */
+export function FavoriteAbilities({ features, dragData }: Props) {
+  if (features.length === 0) return null;
+
+  return (
+    <section className="osc-section">
+      <SectionTitle hint="favorites — click to roll">Abilities</SectionTitle>
+      <div className="fvtt-explore">
+        {features.map((feature) => (
+          <AbilityCard key={feature.id} feature={feature} dragData={dragData} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/OscSheet/features/spells/spells.ts
+++ b/src/OscSheet/features/spells/spells.ts
@@ -2,6 +2,9 @@ import type { OSEActor, OseSpell } from "@domain/types";
 import type { SpellLevelVM } from "@domain/vm-types";
 import { MODULE_ID, FLAGS, readFlag, setFlag, unsetFlag } from "@domain/flags";
 import { selectSpellSlotDefaults } from "@domain/classRules";
+import { isFavorite } from "@domain/favorites";
+
+export { isFavorite, toggleFavorite } from "@domain/favorites";
 
 /** One part of the prepared-row meta line, e.g. { kind: "roll", text: "1d6+1" }. */
 export interface SpellMetaPart {
@@ -57,18 +60,6 @@ export async function castFree(actor: OSEActor, spell: OseSpell, max: number): P
 /** Rest in free-casting mode: clear all spent points. */
 export function resetSpellPoints(actor: OSEActor): Promise<unknown> {
   return unsetFlag(actor, FLAGS.spellPoints);
-}
-
-/** Whether a spell is favorited (shown on the Actions tab in free-casting mode). */
-export function isFavorite(spell: OseSpell): boolean {
-  return !!readFlag<boolean>(spell, FLAGS.favorite);
-}
-
-/** Toggle a spell's favorite flag. */
-export function toggleFavorite(spell: OseSpell): Promise<unknown> {
-  return isFavorite(spell)
-    ? unsetFlag(spell, FLAGS.favorite)
-    : setFlag(spell, FLAGS.favorite, true);
 }
 
 /** Favorited spells across all levels, sorted by level then name (Actions tab, free-casting). */

--- a/src/OscSheet/styles/actions.scss
+++ b/src/OscSheet/styles/actions.scss
@@ -185,6 +185,14 @@
   @include rollable-card;
 }
 
+// Favorited abilities reuse the exploration row but show name, target and
+// formula at one size. (0,3,0) is required: the base sizes are UNLAYERED, so a
+// `tw:` utility on the element would lose to them regardless of specificity.
+.fvtt-skill.osc-fav-ability .skv,
+.fvtt-skill.osc-fav-ability .skv i {
+  font-size: var(--fs-sm, 13px);
+}
+
 // --- memorized spells quick-cast ---
 // `.fvtt-castlist` and the cast control's centring/pill width are in
 // actions-features.scss (MemorizedSpells is NOT converted). The rows reuse the
@@ -434,6 +442,11 @@
 // MUST live here (after the base .osc-head / .osc-tb-* rules) to win the cascade —
 // shell.scss loads earlier, so XS overrides placed there lose at equal specificity.
 @container app (max-width: 479px) {
+  // Exploration and favorited abilities: 2-up leaves no room for the label, so
+  // both stack. They share the .fvtt-explore grid.
+  .fvtt-explore {
+    grid-template-columns: 1fr;
+  }
   // header: portrait | name | compact HP/AC on top; Init/HD/Move full-width below
   .osc-head {
     grid-template-columns: auto 1fr auto;


### PR DESCRIPTION
- Star an ability from the Abilities tab
- Starred abilities show in an Abilities section on the Actions tab
- Roll via the item's own roll method: formula rolls, passive prints to chat
- Cards reuse the exploration row layout; stack at XS
- Drag an ability to the macro hotbar
- Toast on favorite/unfavorite
- Favorite helpers moved out of the spells module so spells and abilities share one flag