### PR TITLE
Include the weapon bonus in the hit and damage quick rolls

### DIFF
--- a/src/OscSheet/__fixtures__/raistlin.ts
+++ b/src/OscSheet/__fixtures__/raistlin.ts
@@ -50,8 +50,8 @@ export const raistlin = {
       {
         name: "Dagger",
         img: "",
-        bonus: 0,
         system: {
+          bonus: 0,
           damage: "1d4",
           qualities: [{ label: "Thrown", value: "thrown", icon: "fa-bullseye-pointer" }],
           description: "",
@@ -63,8 +63,8 @@ export const raistlin = {
       {
         name: "Quarterstaff",
         img: "",
-        bonus: 0,
         system: {
+          bonus: 0,
           damage: "1d6",
           qualities: [
             { label: "Two-handed", value: "twohanded", icon: "fa-hand-fist" },

--- a/src/OscSheet/domain/attackMath.test.ts
+++ b/src/OscSheet/domain/attackMath.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import { computeAttack, type AttackInput, type AttackSettings } from "@domain/attackMath";
+
+const settings = (over: Partial<AttackSettings> = {}): AttackSettings => ({
+  ascendingAC: false,
+  ignoreAttackBonusOnDamageRoll: false,
+  ...over,
+});
+
+const input = (over: Partial<AttackInput> = {}): AttackInput => ({
+  kind: "melee",
+  die: "1d8",
+  weaponBonus: 0,
+  strMod: 0,
+  dexMod: 0,
+  thac0: { bba: 0, mod: { melee: 0, missile: 0 } },
+  ignoreBonusDamage: false,
+  ...over,
+});
+
+describe("computeAttack", () => {
+  it("a plain weapon with no modifiers is just the dice", () => {
+    const { hit, dmg } = computeAttack(input(), settings());
+    expect(hit.formula).toBe("1d20");
+    expect(hit.display).toBe("+0");
+    expect(hit.tip).toBe("1d20");
+    expect(hit.terms).toEqual([{ label: "die", value: "1d20" }]);
+    expect(dmg.formula).toBe("1d8");
+    expect(dmg.display).toBe("1d8+0");
+    expect(dmg.terms).toEqual([{ label: "die", value: "1d8" }]);
+  });
+
+  it("falls back to 1d6 when the weapon has no damage die", () => {
+    expect(computeAttack(input({ die: "" }), settings()).dmg.formula).toBe("1d6");
+  });
+
+  it("melee takes str on hit and damage; missile takes dex on hit only", () => {
+    const melee = computeAttack(input({ strMod: 2, dexMod: 3 }), settings());
+    expect(melee.hit.formula).toBe("1d20+2");
+    expect(melee.hit.terms).toContainEqual({ label: "str", value: 2 });
+    expect(melee.dmg.formula).toBe("1d8+2");
+
+    const missile = computeAttack(
+      input({ kind: "missile", strMod: 2, dexMod: 3 }),
+      settings(),
+    );
+    expect(missile.hit.formula).toBe("1d20+3");
+    expect(missile.hit.terms).toContainEqual({ label: "dex", value: 3 });
+    expect(missile.dmg.formula).toBe("1d8");
+  });
+
+  it("adds the weapon bonus to hit and damage", () => {
+    const { hit, dmg } = computeAttack(input({ weaponBonus: 1 }), settings());
+    expect(hit.formula).toBe("1d20+1");
+    expect(hit.label).toBe("1d20 +1(weapon)");
+    expect(hit.tip).toBe("1d20 + 1 (weapon)");
+    expect(dmg.formula).toBe("1d8+1");
+    expect(dmg.display).toBe("1d8+1");
+    expect(dmg.terms).toContainEqual({ label: "weapon", value: 1 });
+  });
+
+  it("adds the weapon bonus to missile damage too — only the ability mod is melee-only", () => {
+    const { hit, dmg } = computeAttack(
+      input({ kind: "missile", weaponBonus: 2 }),
+      settings(),
+    );
+    expect(hit.formula).toBe("1d20+2");
+    expect(dmg.formula).toBe("1d8+2");
+  });
+
+  it("drops the damage bonus when the world setting opts out", () => {
+    const { hit, dmg } = computeAttack(
+      input({ weaponBonus: 1 }),
+      settings({ ignoreAttackBonusOnDamageRoll: true }),
+    );
+    expect(hit.formula).toBe("1d20+1");
+    expect(dmg.formula).toBe("1d8");
+    expect(dmg.terms).not.toContainEqual({ label: "weapon", value: 1 });
+  });
+
+  it("drops the damage bonus when the per-actor Tweaks flag opts out", () => {
+    const { hit, dmg } = computeAttack(
+      input({ weaponBonus: 1, ignoreBonusDamage: true }),
+      settings(),
+    );
+    expect(hit.formula).toBe("1d20+1");
+    expect(dmg.formula).toBe("1d8");
+  });
+
+  it("drops the damage bonus when both opt-outs are on", () => {
+    const { dmg } = computeAttack(
+      input({ weaponBonus: 1, ignoreBonusDamage: true }),
+      settings({ ignoreAttackBonusOnDamageRoll: true }),
+    );
+    expect(dmg.formula).toBe("1d8");
+  });
+
+  it("applies the Tweaks attack mod per range, folding melee's into damage", () => {
+    const melee = computeAttack(
+      input({ thac0: { bba: 0, mod: { melee: 1, missile: 2 } } }),
+      settings(),
+    );
+    expect(melee.hit.formula).toBe("1d20+1");
+    expect(melee.dmg.formula).toBe("1d8+1");
+
+    const missile = computeAttack(
+      input({ kind: "missile", thac0: { bba: 0, mod: { melee: 1, missile: 2 } } }),
+      settings(),
+    );
+    expect(missile.hit.formula).toBe("1d20+2");
+    expect(missile.dmg.formula).toBe("1d8");
+  });
+
+  it("adds the base attack bonus only under ascending AC", () => {
+    const thac0 = { bba: 2, mod: { melee: 0, missile: 0 } };
+    expect(computeAttack(input({ thac0 }), settings()).hit.formula).toBe("1d20");
+    const ascending = computeAttack(input({ thac0 }), settings({ ascendingAC: true }));
+    expect(ascending.hit.formula).toBe("1d20+2");
+    expect(ascending.hit.terms).toContainEqual({ label: "bba", value: 2 });
+    expect(ascending.dmg.formula).toBe("1d8");
+  });
+
+  it("tolerates a missing thac0 block", () => {
+    const { hit } = computeAttack(
+      input({ thac0: undefined }),
+      settings({ ascendingAC: true }),
+    );
+    expect(hit.formula).toBe("1d20");
+  });
+
+  it("composes every term at once, and keeps display in step with the formula", () => {
+    const { hit, dmg } = computeAttack(
+      input({
+        strMod: 1,
+        weaponBonus: 2,
+        thac0: { bba: 3, mod: { melee: 1, missile: 0 } },
+      }),
+      settings({ ascendingAC: true }),
+    );
+    expect(hit.formula).toBe("1d20+3+1+1+2");
+    expect(hit.total).toBe(7);
+    expect(hit.display).toBe("+7");
+    expect(hit.tip).toBe("1d20 + 3 (bba) + 1 (str) + 1 (tweaks) + 2 (weapon)");
+    expect(dmg.formula).toBe("1d8+2+1+1");
+    expect(dmg.display).toBe("1d8+4");
+  });
+
+  it("renders negative modifiers", () => {
+    const { hit, dmg } = computeAttack(input({ strMod: -2 }), settings());
+    expect(hit.formula).toBe("1d20-2");
+    expect(hit.label).toBe("1d20 -2(str)");
+    expect(hit.tip).toBe("1d20 − 2 (str)");
+    expect(dmg.display).toBe("1d8-2");
+  });
+});

--- a/src/OscSheet/domain/attackMath.test.ts
+++ b/src/OscSheet/domain/attackMath.test.ts
@@ -116,7 +116,7 @@ describe("computeAttack", () => {
     expect(computeAttack(input({ thac0 }), settings()).hit.formula).toBe("1d20");
     const ascending = computeAttack(input({ thac0 }), settings({ ascendingAC: true }));
     expect(ascending.hit.formula).toBe("1d20+2");
-    expect(ascending.hit.terms).toContainEqual({ label: "bba", value: 2 });
+    expect(ascending.hit.terms).toContainEqual({ label: "ab", value: 2 });
     expect(ascending.dmg.formula).toBe("1d8");
   });
 
@@ -140,7 +140,7 @@ describe("computeAttack", () => {
     expect(hit.formula).toBe("1d20+3+1+1+2");
     expect(hit.total).toBe(7);
     expect(hit.display).toBe("+7");
-    expect(hit.tip).toBe("1d20 + 3 (bba) + 1 (str) + 1 (tweaks) + 2 (weapon)");
+    expect(hit.tip).toBe("1d20 + 3 (ab) + 1 (str) + 1 (tweaks) + 2 (weapon)");
     expect(dmg.formula).toBe("1d8+2+1+1");
     expect(dmg.display).toBe("1d8+4");
   });

--- a/src/OscSheet/domain/attackMath.ts
+++ b/src/OscSheet/domain/attackMath.ts
@@ -1,0 +1,108 @@
+import type { AttackKind } from "@domain/types";
+
+/** World settings the maths depends on — read by the caller, never by this module. */
+export interface AttackSettings {
+  /** `ascendingAC`: the actor's base attack bonus joins the to-hit roll. */
+  ascendingAC: boolean;
+  /** `ignoreAttackBonusOnDamageRoll`: the weapon bonus is dropped from damage. */
+  ignoreAttackBonusOnDamageRoll: boolean;
+}
+
+/** Everything one attack mode of one weapon contributes, already resolved to numbers. */
+export interface AttackInput {
+  kind: AttackKind;
+  /** Weapon `system.damage`; empty falls back to OSE's `1d6`. */
+  die: string;
+  /** Weapon `system.bonus` — magic/quality plus, applies to hit and (usually) damage. */
+  weaponBonus: number;
+  strMod: number;
+  dexMod: number;
+  /** Actor `system.thac0`: `bba` the ascending-AC base attack bonus, `mod` the Tweaks bonuses. */
+  thac0?: { bba?: number; mod?: { melee?: number; missile?: number } };
+  /** Per-actor Tweaks flag `system.config.ignoreBonusDamage`. */
+  ignoreBonusDamage: boolean;
+}
+
+/** One contributing part of a roll. */
+export interface AttackTerm {
+  /** `"die"`, or the name of the modifier: `str` / `dex` / `weapon` / `tweaks` / `bba`. */
+  label: string;
+  /** The dice expression for the die term, a signed integer for every other. */
+  value: string | number;
+}
+
+/** A composed roll: the formula rolled, the strings shown, and the arithmetic behind them. */
+export interface AttackPart {
+  /** Foundry roll formula, e.g. `1d20+1+1`. */
+  formula: string;
+  /** Pill label, e.g. `1d20 +1(dex) +1(weapon)`. */
+  label: string;
+  /** Button text: the signed total for hit, die + signed total for damage. */
+  display: string;
+  /** Arithmetic line for the popover, e.g. `1d20 + 1 (dex) + 1 (weapon)`. */
+  tip: string;
+  /** Every part, die first; zero modifiers are omitted. */
+  terms: AttackTerm[];
+  /** Sum of the numeric terms. */
+  total: number;
+}
+
+export interface AttackMath {
+  hit: AttackPart;
+  dmg: AttackPart;
+}
+
+type Mod = { label: string; value: number };
+
+const signed = (n: number) => (n >= 0 ? `+${n}` : `${n}`);
+
+function compose(die: string, mods: Mod[]): Omit<AttackPart, "display"> {
+  const kept = mods.filter((m) => m.value !== 0);
+  return {
+    formula: `${die}${kept.map((m) => signed(m.value)).join("")}`,
+    label: `${die}${kept.map((m) => ` ${signed(m.value)}(${m.label})`).join("")}`,
+    tip: `${die}${kept
+      .map((m) => ` ${m.value > 0 ? "+" : "−"} ${Math.abs(m.value)} (${m.label})`)
+      .join("")}`,
+    terms: [{ label: "die", value: die }, ...kept],
+    total: kept.reduce((sum, m) => sum + m.value, 0),
+  };
+}
+
+/** Hit and damage for one attack mode, mirroring OseActor#rollAttack so the sheet's
+ *  quick buttons and OSE's composite attack can never disagree. Pure: settings in, no globals. */
+export function computeAttack(input: AttackInput, settings: AttackSettings): AttackMath {
+  const ranged = input.kind === "missile";
+  const bba = settings.ascendingAC ? (input.thac0?.bba ?? 0) : 0;
+  const tweak = (ranged ? input.thac0?.mod?.missile : input.thac0?.mod?.melee) ?? 0;
+  const ability: Mod = ranged
+    ? { label: "dex", value: input.dexMod }
+    : { label: "str", value: input.strMod };
+  const bonus = input.weaponBonus || 0;
+  const die = input.die || "1d6";
+
+  const hit = compose("1d20", [
+    { label: "bba", value: bba },
+    ability,
+    { label: "tweaks", value: tweak },
+    { label: "weapon", value: bonus },
+  ]);
+
+  const dmgBonus =
+    settings.ignoreAttackBonusOnDamageRoll || input.ignoreBonusDamage ? 0 : bonus;
+  const dmg = compose(
+    die,
+    ranged
+      ? [{ label: "weapon", value: dmgBonus }]
+      : [
+          { label: "weapon", value: dmgBonus },
+          { label: "str", value: input.strMod },
+          { label: "tweaks", value: tweak },
+        ],
+  );
+
+  return {
+    hit: { ...hit, display: signed(hit.total) },
+    dmg: { ...dmg, display: `${die}${signed(dmg.total)}` },
+  };
+}

--- a/src/OscSheet/domain/attackMath.ts
+++ b/src/OscSheet/domain/attackMath.ts
@@ -25,7 +25,7 @@ export interface AttackInput {
 
 /** One contributing part of a roll. */
 export interface AttackTerm {
-  /** `"die"`, or the name of the modifier: `str` / `dex` / `weapon` / `tweaks` / `bba`. */
+  /** `"die"`, or the name of the modifier: `str` / `dex` / `weapon` / `tweaks` / `ab`. */
   label: string;
   /** The dice expression for the die term, a signed integer for every other. */
   value: string | number;
@@ -82,7 +82,7 @@ export function computeAttack(input: AttackInput, settings: AttackSettings): Att
   const die = input.die || "1d6";
 
   const hit = compose("1d20", [
-    { label: "bba", value: bba },
+    { label: "ab", value: bba },
     ability,
     { label: "tweaks", value: tweak },
     { label: "weapon", value: bonus },

--- a/src/OscSheet/domain/types.ts
+++ b/src/OscSheet/domain/types.ts
@@ -66,6 +66,8 @@ export type OSEActor = Actor & {
     ac: CharacterAC;
     config?: {
       movementAuto?: boolean;
+      /** Tweaks: drop the weapon bonus from this actor's damage rolls. */
+      ignoreBonusDamage?: boolean;
     };
     details: {
       alignment: string;
@@ -109,8 +111,9 @@ export type OSEActor = Actor & {
     };
     saves: Record<OSESave, { value: number }>;
     initiative: { value: number; mod: number };
-    /** To-hit: `value` = THAC0 (descending), `bba` = base attack bonus (ascending). */
-    thac0: { value: number; bba: number };
+    /** To-hit: `value` = THAC0 (descending), `bba` = base attack bonus (ascending),
+     *  `mod` = the Tweaks per-range attack bonuses. */
+    thac0: { value: number; bba: number; mod?: { melee?: number; missile?: number } };
     updatedAt?: string;
     weapons: OseWeapon[];
   };
@@ -182,8 +185,9 @@ export type OseWeapon = OseItem & {
     equipped: boolean;
     /** Save the target may roll against this weapon's attack. */
     save?: string;
+    /** Magic/quality plus, applied to the to-hit roll and (unless opted out) damage. */
+    bonus?: number;
   };
-  bonus: number;
 };
 
 /** Roll-comparison key, sourced from the OSE system's CONFIG (`roll_type`). */

--- a/src/OscSheet/domain/vm-types.ts
+++ b/src/OscSheet/domain/vm-types.ts
@@ -53,13 +53,13 @@ export interface RollSpec {
 export interface AttackMode {
   kind: AttackKind;
   kindLabel: string;
-  /** To-hit roll (1d20 + ability mod). */
+  /** To-hit roll (1d20 + ability mod + weapon bonus + Tweaks/BBA — see `computeAttack`). */
   hit: RollSpec;
   /** Button text — always-signed mono, e.g. "+2" / "+0". */
   hitDisplay: string;
   /** Full hit formula with named mods for the popover, e.g. "1d20 + 1 (dex)". */
   hitTip: string;
-  /** Damage roll (weapon die + ability mod). */
+  /** Damage roll (weapon die + melee str mod + weapon bonus unless opted out). */
   dmg: RollSpec;
   /** Button text — always-signed mono, e.g. "1d6+0" / "1d10+2". */
   dmgDisplay: string;

--- a/src/OscSheet/features/actions/AttacksTable.tsx
+++ b/src/OscSheet/features/actions/AttacksTable.tsx
@@ -172,7 +172,7 @@ function WeaponRow({
         data-testid={`weapon-hit-${a.itemId}`}
         disabled={!onRoll}
         onClick={() => onRoll?.(mode.hit)}
-        title={`Roll to hit · ${mode.hitTip}`}
+        aria-label={`Roll to hit · ${mode.hitTip}`}
       >
         <span className="sl">Hit</span>
         <span className="wv">
@@ -183,7 +183,7 @@ function WeaponRow({
           {mode.hitDisplay}
         </span>
         <span className="tag-pop" role="tooltip">
-          {mode.hitTip}
+          {`Roll to hit · ${mode.hitTip}`}
         </span>
       </button>
       <button
@@ -191,12 +191,12 @@ function WeaponRow({
         className="wstat dmg"
         disabled={!onRoll}
         onClick={() => onRoll?.(mode.dmg)}
-        title={`Roll damage · ${mode.dmgTip}`}
+        aria-label={`Roll damage · ${mode.dmgTip}`}
       >
         <span className="sl">Dmg</span>
         <span className="wv">{mode.dmgDisplay}</span>
         <span className="tag-pop" role="tooltip">
-          {mode.dmgTip}
+          {`Roll damage · ${mode.dmgTip}`}
         </span>
       </button>
 

--- a/src/OscSheet/features/actions/AttacksTable.tsx
+++ b/src/OscSheet/features/actions/AttacksTable.tsx
@@ -6,7 +6,6 @@ import { Tag } from "@ui/Tag";
 import { cx } from "@ui/cx";
 import { Monogram } from "@ui/Monogram";
 import { Button } from "@src/OscSheet/components/ui";
-import { HoverPop } from "@ui/HoverPop";
 
 type Props = {
   attacks: AttackVM[];
@@ -183,7 +182,9 @@ function WeaponRow({
           />
           {mode.hitDisplay}
         </span>
-        <HoverPop>{`Roll to hit · ${mode.hitTip}`}</HoverPop>
+        <span className="tag-pop" role="tooltip">
+          {`Roll to hit · ${mode.hitTip}`}
+        </span>
       </button>
       <button
         type="button"
@@ -194,7 +195,9 @@ function WeaponRow({
       >
         <span className="sl">Dmg</span>
         <span className="wv">{mode.dmgDisplay}</span>
-        <HoverPop>{`Roll damage · ${mode.dmgTip}`}</HoverPop>
+        <span className="tag-pop" role="tooltip">
+          {`Roll damage · ${mode.dmgTip}`}
+        </span>
       </button>
 
       {/* Always rendered; read-only (non-owner) shows it disabled — the composite

--- a/src/OscSheet/features/actions/AttacksTable.tsx
+++ b/src/OscSheet/features/actions/AttacksTable.tsx
@@ -6,6 +6,7 @@ import { Tag } from "@ui/Tag";
 import { cx } from "@ui/cx";
 import { Monogram } from "@ui/Monogram";
 import { Button } from "@src/OscSheet/components/ui";
+import { HoverPop } from "@ui/HoverPop";
 
 type Props = {
   attacks: AttackVM[];
@@ -182,9 +183,7 @@ function WeaponRow({
           />
           {mode.hitDisplay}
         </span>
-        <span className="tag-pop" role="tooltip">
-          {`Roll to hit · ${mode.hitTip}`}
-        </span>
+        <HoverPop>{`Roll to hit · ${mode.hitTip}`}</HoverPop>
       </button>
       <button
         type="button"
@@ -195,9 +194,7 @@ function WeaponRow({
       >
         <span className="sl">Dmg</span>
         <span className="wv">{mode.dmgDisplay}</span>
-        <span className="tag-pop" role="tooltip">
-          {`Roll damage · ${mode.dmgTip}`}
-        </span>
+        <HoverPop>{`Roll damage · ${mode.dmgTip}`}</HoverPop>
       </button>
 
       {/* Always rendered; read-only (non-owner) shows it disabled — the composite

--- a/src/OscSheet/features/actions/attacks.test.ts
+++ b/src/OscSheet/features/actions/attacks.test.ts
@@ -1,6 +1,23 @@
 import { describe, it, expect } from "vitest";
 import { selectAttacks } from "@features/actions/attacks";
+import type { OSEActor } from "@domain/types";
 import { raistlin } from "@src/OscSheet/__fixtures__/raistlin";
+
+const withMagicDagger = (over: { ignoreBonusDamage?: boolean } = {}) =>
+  ({
+    ...raistlin,
+    system: {
+      ...raistlin.system,
+      config: { ignoreBonusDamage: over.ignoreBonusDamage },
+      thac0: { value: 19, bba: 1, mod: { melee: 0, missile: 0 } },
+      weapons: [
+        {
+          ...raistlin.system.weapons[0],
+          system: { ...raistlin.system.weapons[0].system, bonus: 1 },
+        },
+      ],
+    },
+  }) as unknown as OSEActor;
 
 describe("selectAttacks", () => {
   const vm = selectAttacks(raistlin);
@@ -33,5 +50,33 @@ describe("selectAttacks", () => {
     ]);
     // single-mode (melee-only) weapon
     expect(staff.modes.map((m) => m.kind)).toEqual(["melee"]);
+  });
+
+  it("a magic weapon's bonus lands on the roll, the display and the tip alike", () => {
+    const melee = selectAttacks(withMagicDagger(), {
+      ascendingAC: false,
+      ignoreAttackBonusOnDamageRoll: false,
+    })[0].modes[0];
+    expect(melee.hit.formula).toBe("1d20+1");
+    expect(melee.hitDisplay).toBe("+1");
+    expect(melee.hitTip).toBe("1d20 + 1 (weapon)");
+    expect(melee.dmg.formula).toBe("1d4+1");
+    expect(melee.dmgDisplay).toBe("1d4+1");
+    expect(melee.dmgTip).toBe("1d4 + 1 (weapon)");
+  });
+
+  it("respects the damage opt-outs and the ascending-AC base attack bonus", () => {
+    const worldOptOut = selectAttacks(withMagicDagger(), {
+      ascendingAC: true,
+      ignoreAttackBonusOnDamageRoll: true,
+    })[0].modes[0];
+    expect(worldOptOut.hit.formula).toBe("1d20+1+1");
+    expect(worldOptOut.dmg.formula).toBe("1d4");
+
+    const actorOptOut = selectAttacks(withMagicDagger({ ignoreBonusDamage: true }), {
+      ascendingAC: false,
+      ignoreAttackBonusOnDamageRoll: false,
+    })[0].modes[0];
+    expect(actorOptOut.dmg.formula).toBe("1d4");
   });
 });

--- a/src/OscSheet/features/actions/attacks.ts
+++ b/src/OscSheet/features/actions/attacks.ts
@@ -1,20 +1,30 @@
+import { computeAttack, type AttackSettings } from "@domain/attackMath";
 import type { OSEActor } from "@domain/types";
 import type { AttackVM, AttackMode, RollSpec } from "@domain/vm-types";
 
-/** Term to append to a formula for a mod, e.g. +1 / -2 / "" for 0. */
-const term = (mod: number) => (mod === 0 ? "" : mod > 0 ? `+${mod}` : `${mod}`);
-/** Suffix shown on the pill, e.g. " +1(str)" / "" for 0. */
-const suffix = (mod: number, abil: string) => (mod === 0 ? "" : ` ${mod > 0 ? `+${mod}` : `${mod}`}(${abil})`);
-/** Always-signed term for the button display, e.g. "+0" / "+2" / "-1". */
-const signed = (mod: number) => (mod >= 0 ? `+${mod}` : `${mod}`);
-/** Full-formula popover line, e.g. "1d20 + 1 (dex)" / "1d6" for 0. */
-const tip = (base: string, mod: number, abil: string) =>
-  mod === 0 ? base : `${base} ${mod > 0 ? "+" : "−"} ${Math.abs(mod)} (${abil})`;
+/** OSE's world settings for attack maths. Safe in non-Foundry tests (both default off). */
+export function readAttackSettings(): AttackSettings {
+  const read = (key: string) => {
+    try {
+      const settings = game.settings as { get(ns: string, key: string): unknown };
+      return !!settings.get(game.system.id, key);
+    } catch {
+      return false;
+    }
+  };
+  return {
+    ascendingAC: read("ascendingAC"),
+    ignoreAttackBonusOnDamageRoll: read("ignoreAttackBonusOnDamageRoll"),
+  };
+}
 
 /** Equipped weapons → one row each. A melee+missile weapon carries both modes
  *  (melee first) so the row can toggle between them. */
-export function selectAttacks(actor: OSEActor): AttackVM[] {
-  const { weapons, scores } = actor.system;
+export function selectAttacks(
+  actor: OSEActor,
+  settings: AttackSettings = readAttackSettings(),
+): AttackVM[] {
+  const { weapons, scores, thac0, config } = actor.system;
   const out: AttackVM[] = [];
   for (const w of weapons) {
     if (!w.system.equipped) continue;
@@ -26,24 +36,30 @@ export function selectAttacks(actor: OSEActor): AttackVM[] {
       seen.add(q.label);
       qualities.push({ label: q.label, icon: q.icon ?? "" });
     }
-    const die = w.system.damage;
     const make = (kind: "melee" | "missile"): AttackMode => {
-      const ranged = kind === "missile";
-      // to-hit: str for melee, dex for missile. damage: str for melee, none for missile.
-      const hitMod = ranged ? scores.dex.mod : scores.str.mod;
-      const hitAbil = ranged ? "dex" : "str";
-      const dmgMod = ranged ? 0 : scores.str.mod;
-      const tail = ranged ? " (ranged)" : "";
+      const math = computeAttack(
+        {
+          kind,
+          die: w.system.damage,
+          weaponBonus: w.system.bonus ?? 0,
+          strMod: scores.str.mod,
+          dexMod: scores.dex.mod,
+          thac0,
+          ignoreBonusDamage: !!config?.ignoreBonusDamage,
+        },
+        settings,
+      );
+      const tail = kind === "missile" ? " (ranged)" : "";
       const hit: RollSpec = {
-        label: `1d20${suffix(hitMod, hitAbil)}`,
-        formula: `1d20${term(hitMod)}`,
+        label: math.hit.label,
+        formula: math.hit.formula,
         flavor: `${actor.name} attacks with ${w.name}${tail}`,
         kind: "hit",
         weapon: w.name as string,
       };
       const dmg: RollSpec = {
-        label: `${die}${suffix(dmgMod, "str")}`,
-        formula: `${die}${term(dmgMod)}`,
+        label: math.dmg.label,
+        formula: math.dmg.formula,
         flavor: `${actor.name} deals damage with ${w.name}${tail}`,
         kind: "damage",
         weapon: w.name as string,
@@ -53,11 +69,11 @@ export function selectAttacks(actor: OSEActor): AttackVM[] {
         kindLabel: kind === "melee" ? "Melee" : "Missile",
         hit,
         // Hit shows just the always-signed modifier (the d20 is implied by the icon).
-        hitDisplay: signed(hitMod),
-        hitTip: tip("1d20", hitMod, hitAbil),
+        hitDisplay: math.hit.display,
+        hitTip: math.hit.tip,
         dmg,
-        dmgDisplay: `${die}${signed(dmgMod)}`,
-        dmgTip: tip(die, dmgMod, "str"),
+        dmgDisplay: math.dmg.display,
+        dmgTip: math.dmg.tip,
       };
     };
     const modes: AttackMode[] = [];

--- a/src/OscSheet/styles/actions-features.scss
+++ b/src/OscSheet/styles/actions-features.scss
@@ -247,6 +247,9 @@
   &:hover:not(:disabled) {
     color: var(--text, #e5dec8);
   }
+  &.dmg:hover:not(:disabled) {
+    color: var(--crimson, #c75044);
+  }
   &:focus-visible {
     outline: 2px solid var(--gold);
     outline-offset: 1px;

--- a/src/OscSheet/styles/actions-features.scss
+++ b/src/OscSheet/styles/actions-features.scss
@@ -247,9 +247,6 @@
   &:hover:not(:disabled) {
     color: var(--text, #e5dec8);
   }
-  &.dmg:hover:not(:disabled) {
-    color: var(--crimson, #c75044);
-  }
   &:focus-visible {
     outline: 2px solid var(--gold);
     outline-offset: 1px;


### PR DESCRIPTION
- Hit and damage now come from one shared `attackMath` utility instead of ability modifiers alone
- Adds the weapon bonus, the Tweaks melee/missile mods, and the base attack bonus under ascending AC
- Damage keeps the weapon bonus out when either the world setting or the per-actor Tweaks flag says to
- Display, tooltip and rolled formula all read from the same computed terms, so they can't disagree
- The utility is pure and takes its settings as an argument, so every term is unit-tested without Foundry
- Corrects `OseWeapon.bonus` to sit under `system`, and adds the missing `thac0.mod` and `config.ignoreBonusDamage` actor types
- Tooltips lose their duplicate native `title` in favour of an `aria-label`, and damage loses its crimson hover