### PR TITLE
Stop pretending the committed manifest carries a real version

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "osc-character-sheet",
   "title": "Enhanced Character Sheet for Old-School Essentials",
   "description": "An alternative character sheet for the Old-School Essentials system in Foundry VTT. Part of the Old-School Chronicle tool set.",
-  "version": "0.4.1",
+  "version": "0.0.0",
   "authors": [
     {
       "name": "Tim Sandberg",
@@ -53,5 +53,5 @@
   },
   "url": "https://github.com/tasandberg/osc-character-sheet",
   "manifest": "https://github.com/tasandberg/osc-character-sheet/releases/latest/download/module.json",
-  "download": "https://github.com/tasandberg/osc-character-sheet/releases/download/0.4.1/module.zip"
+  "download": "https://github.com/tasandberg/osc-character-sheet/releases/latest/download/module.zip"
 }


### PR DESCRIPTION
- The release workflow stamps `module.json` from the git tag, so the committed version is never read and had drifted to 0.4.1 while releases reached 1.1.3
- Sets it to 0.0.0 so a working tree reads unmistakably as not-a-release
- Repoints the stale 0.4.1 download URL at `releases/latest`, which stays valid on its own