### PR TITLE
Converge stored Forage and Hunt targets onto system data

### DIFF
--- a/src/OscSheet/domain/migrations.test.ts
+++ b/src/OscSheet/domain/migrations.test.ts
@@ -2,9 +2,24 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildActorUpdate,
+  buildExplorationConverge,
   buildFlagScopeMove,
   buildSheetClassFix,
 } from "./migrations";
+import { MODULE_ID } from "./flags";
+
+const SKILLS_PATH = `flags.${MODULE_ID}.explorationSkills`;
+const SKILLS_DELETE_PATH = `flags.${MODULE_ID}.-=explorationSkills`;
+
+function actorWith(
+  skills: Array<{ key: string; inSix: number }>,
+  exploration: Record<string, number>,
+) {
+  return {
+    flags: { [MODULE_ID]: { explorationSkills: skills } },
+    system: { exploration },
+  };
+}
 
 describe("buildFlagScopeMove", () => {
   it("moves the whole old scope blob and deletes the old scope", () => {
@@ -46,5 +61,63 @@ describe("buildActorUpdate", () => {
       "flags.core.sheetClass": "ose.OscSheet",
     });
     expect(buildActorUpdate({ core: {} })).toBeNull();
+  });
+});
+
+describe("buildExplorationConverge", () => {
+  const base = { ld: 1, od: 2, sd: 1, ft: 1 };
+
+  it("returns null when nothing is stored", () => {
+    expect(buildExplorationConverge({ system: { exploration: base } })).toBeNull();
+    expect(buildExplorationConverge({})).toBeNull();
+  });
+
+  it("leaves a stored entry the system does not model alone", () => {
+    expect(buildExplorationConverge(actorWith([{ key: "fg", inSix: 4 }], base))).toBeNull();
+  });
+
+  it("writes a modelled entry to system data and deletes the emptied flag", () => {
+    const actor = actorWith([{ key: "fg", inSix: 4 }], { ...base, fg: 1, hn: 1 });
+    expect(buildExplorationConverge(actor)).toEqual({
+      "system.exploration.fg": 4,
+      [SKILLS_DELETE_PATH]: null,
+    });
+  });
+
+  it("keeps unmodelled entries in the flag", () => {
+    const actor = actorWith(
+      [
+        { key: "fg", inSix: 4 },
+        { key: "hn", inSix: 3 },
+      ],
+      { ...base, fg: 1 },
+    );
+    expect(buildExplorationConverge(actor)).toEqual({
+      "system.exploration.fg": 4,
+      [SKILLS_PATH]: [{ key: "hn", inSix: 3 }],
+    });
+  });
+
+  it("drops rather than writes a value the schema would reject", () => {
+    const exploration = { ...base, fg: 1, hn: 1 };
+    expect(buildExplorationConverge(actorWith([{ key: "fg", inSix: 0 }], exploration))).toEqual({
+      [SKILLS_DELETE_PATH]: null,
+    });
+    expect(buildExplorationConverge(actorWith([{ key: "fg", inSix: -2 }], exploration))).toEqual({
+      [SKILLS_DELETE_PATH]: null,
+    });
+    expect(buildExplorationConverge(actorWith([{ key: "fg", inSix: 2.5 }], exploration))).toEqual({
+      [SKILLS_DELETE_PATH]: null,
+    });
+  });
+
+  it("is a no-op on the second pass", () => {
+    const actor = actorWith([{ key: "fg", inSix: 4 }], { ...base, fg: 1, hn: 1 });
+    const update = buildExplorationConverge(actor)!;
+    const converged = {
+      flags: { [MODULE_ID]: {} },
+      system: { exploration: { ...base, fg: update["system.exploration.fg"] as number, hn: 1 } },
+    };
+    expect(buildExplorationConverge(converged)).toBeNull();
   });
 });

--- a/src/OscSheet/domain/migrations.ts
+++ b/src/OscSheet/domain/migrations.ts
@@ -7,7 +7,9 @@
 // - chat-message `damageApplied` flags: old damage cards lose their apply button — fine.
 // - unlinked-token actor deltas: cosmetic sort-order loss only — fine.
 
-import { MODULE_ID } from "./flags";
+import { storedSkills, type ExplorationSkill } from "@features/actions/exploration";
+
+import { FLAGS, MODULE_ID, flagDeletePath, flagPath } from "./flags";
 
 export const OLD_MODULE_ID = "reactor-sheet";
 export const OLD_SHEET_CLASS = "ose.ReactorSheet";
@@ -44,6 +46,44 @@ export function buildActorUpdate(flags: Flags): UpdatePayload | null {
   return Object.keys(update).length ? update : null;
 }
 
+// --- exploration flag convergence (no version gate) ---------------------------
+//
+// We stored Forage/Hunt targets in an actor flag because the game system had no
+// field for them. The system now models them, but a user updates the module and
+// the system independently — so this pass is a convergence, not a stamped
+// one-shot: it probes each actor for the field and runs on every `ready` until
+// no stored entry names a modelled key.
+
+/** Minimal actor shape this pass reads. */
+interface ExplorationSource {
+  /** Raw flag blob — our stored skill list lives under the module scope. */
+  flags?: Flags;
+  /** Actor system data; `exploration` gains a key once the system models it. */
+  system?: { exploration?: Record<string, unknown> };
+}
+
+/** Move stored targets the system now models into system data, dropping them
+ *  from the flag (and the flag itself once empty). Null if nothing converges. */
+export function buildExplorationConverge(actor: ExplorationSource): UpdatePayload | null {
+  const stored = storedSkills(actor);
+  const exploration = actor.system?.exploration;
+  const remaining: ExplorationSkill[] = [];
+  const update: UpdatePayload = {};
+  for (const entry of stored) {
+    if (typeof exploration?.[entry.key] !== "number") {
+      remaining.push(entry);
+      continue;
+    }
+    if (Number.isInteger(entry.inSix) && entry.inSix > 0) {
+      update[`system.exploration.${entry.key}`] = entry.inSix;
+    }
+  }
+  if (remaining.length === stored.length) return null;
+  if (remaining.length) update[flagPath(FLAGS.explorationSkills)] = remaining;
+  else update[flagDeletePath(FLAGS.explorationSkills)] = null;
+  return update;
+}
+
 // --- client-side localStorage migration (every user, no GM gate) --------------
 
 /** localStorage keys to carry over: [old, new]. The theme entry is legacy: it
@@ -77,7 +117,7 @@ interface FlaggedDoc {
   flags?: Flags;
   update(data: UpdatePayload): Promise<unknown>;
 }
-interface ActorDoc extends FlaggedDoc {
+interface ActorDoc extends FlaggedDoc, ExplorationSource {
   items: Iterable<FlaggedDoc>;
   updateEmbeddedDocuments(type: string, updates: UpdatePayload[]): Promise<unknown>;
 }
@@ -162,5 +202,21 @@ export async function runWorldMigration(): Promise<void> {
       ?.notifications?.error(
         "OSC Character Sheet: migration from reactor-sheet failed — see console. It will retry on next reload.",
       );
+  }
+}
+
+/** Converge stored exploration targets onto system data. Call from `ready` on
+ *  every load; never throws. Unlinked token actors and compendium actors are
+ *  left alone — they still read correctly through the flag. */
+export async function runExplorationConvergence(): Promise<void> {
+  const game = getGame();
+  try {
+    if (!game.users.activeGM || game.users.activeGM !== game.user) return;
+    for (const actor of game.actors) {
+      const update = buildExplorationConverge(actor);
+      if (update) await actor.update(update);
+    }
+  } catch (err) {
+    console.error(`${MODULE_ID} | exploration convergence failed`, err);
   }
 }

--- a/src/OscSheet/features/actions/exploration.test.ts
+++ b/src/OscSheet/features/actions/exploration.test.ts
@@ -9,6 +9,7 @@ import { raistlin } from "@src/OscSheet/__fixtures__/raistlin";
 import type { OSEActor } from "@domain/types";
 
 const SKILLS_PATH = `flags.${MODULE_ID}.explorationSkills`;
+const DELETE_PATH = `flags.${MODULE_ID}.-=explorationSkills`;
 
 function withSkills(
   skills: ExplorationSkill[],
@@ -77,13 +78,25 @@ describe("exploration updates", () => {
     });
   });
 
-  it("keeps writing to the flag when the schema also models the skill", () => {
+  it("converges to system data and clears the flag once the schema models the skill", () => {
     const actor = withSkills([{ key: "fg", inSix: 2 }], {
       ...raistlin.system.exploration,
       fg: 3,
     });
     expect(setTargetUpdate(actor, "fg", 5)).toEqual({
-      [SKILLS_PATH]: [{ key: "fg", inSix: 5 }],
+      "system.exploration.fg": 5,
+      [DELETE_PATH]: null,
+    });
+  });
+
+  it("keeps unrelated stored entries when converging one", () => {
+    const actor = withSkills([
+      { key: "hn", inSix: 3 },
+      { key: "fg", inSix: 2 },
+    ], { ...raistlin.system.exploration, fg: 3 });
+    expect(setTargetUpdate(actor, "fg", 5)).toEqual({
+      "system.exploration.fg": 5,
+      [SKILLS_PATH]: [{ key: "hn", inSix: 3 }],
     });
   });
 

--- a/src/OscSheet/features/actions/exploration.test.ts
+++ b/src/OscSheet/features/actions/exploration.test.ts
@@ -31,7 +31,7 @@ describe("selectExploration", () => {
     const od = vm.find((e) => e.key === "od")!;
     expect(od.label).toBe("Open Stuck Door");
     expect(od.inSix).toBe(2);
-    expect(vm.find((e) => e.key === "fg")!.inSix).toBe(2);
+    expect(vm.find((e) => e.key === "fg")!.inSix).toBe(1);
     expect(vm.find((e) => e.key === "hn")!.inSix).toBe(1);
   });
 

--- a/src/OscSheet/features/actions/exploration.ts
+++ b/src/OscSheet/features/actions/exploration.ts
@@ -1,6 +1,6 @@
 import type { OSEActor, RollEvent } from "@domain/types";
 import type { ExplorationVM } from "@domain/vm-types";
-import { FLAGS, flagPath, readFlag } from "@domain/flags";
+import { FLAGS, flagDeletePath, flagPath, readFlag } from "@domain/flags";
 
 export interface ExplorationSkill {
   key: string;
@@ -67,12 +67,18 @@ export function setTargetUpdate(
   key: string,
   inSix: number,
 ): Record<string, unknown> {
-  if (storedTarget(actor, key) === undefined && systemTarget(actor, key) !== undefined) {
-    return { [`system.exploration.${key}`]: inSix };
+  if (systemTarget(actor, key) === undefined) {
+    return {
+      [flagPath(FLAGS.explorationSkills)]: patchSkills(storedSkills(actor), key, inSix),
+    };
   }
-  return {
-    [flagPath(FLAGS.explorationSkills)]: patchSkills(storedSkills(actor), key, inSix),
-  };
+  const stored = storedSkills(actor);
+  const remaining = stored.filter((s) => s.key !== key);
+  const update: Record<string, unknown> = { [`system.exploration.${key}`]: inSix };
+  if (remaining.length === stored.length) return update;
+  if (remaining.length) update[flagPath(FLAGS.explorationSkills)] = remaining;
+  else update[flagDeletePath(FLAGS.explorationSkills)] = null;
+  return update;
 }
 
 export function rollExploration(actor: OSEActor, key: string, event?: RollEvent): void {

--- a/src/OscSheet/features/actions/exploration.ts
+++ b/src/OscSheet/features/actions/exploration.ts
@@ -19,7 +19,7 @@ const KNOWN_SKILLS: SkillMeta[] = [
   { key: "od", label: "Open Stuck Door", icon: "fas fa-door-closed", inSix: 2 },
   { key: "sd", label: "Find Secret Door", icon: "fas fa-magnifying-glass", inSix: 1 },
   { key: "ft", label: "Find Trap", icon: "fas fa-radar", inSix: 1 },
-  { key: "fg", label: "Forage", icon: "fas fa-mushroom", inSix: 2 },
+  { key: "fg", label: "Forage", icon: "fas fa-mushroom", inSix: 1 },
   { key: "hn", label: "Hunt", icon: "fas fa-bow-arrow", inSix: 1 },
 ];
 
@@ -32,7 +32,7 @@ function systemTarget(actor: OSEActor, key: string): number | undefined {
   return typeof value === "number" ? value : undefined;
 }
 
-export function storedSkills(actor: OSEActor): ExplorationSkill[] {
+export function storedSkills(actor: { flags?: unknown }): ExplorationSkill[] {
   return readFlag<ExplorationSkill[]>(actor, FLAGS.explorationSkills) ?? [];
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { MODULE_ID } from "@domain/flags";
 import {
   migrateLocalStorage,
   registerMigrationSetting,
+  runExplorationConvergence,
   runWorldMigration,
 } from "@domain/migrations";
 import logger from "@src/util/logger";
@@ -29,6 +30,7 @@ export function initialize() {
     logger("Initializing React application");
     migrateLocalStorage(); // every user; independent of the GM world pass
     await runWorldMigration();
+    await runExplorationConvergence(); // after the rename pass — it reads new-scope flags
     await installAdvancedClasses();
     registerSendItemSocket(); // GM relay for cross-owner "Send Item" transfers
 


### PR DESCRIPTION
- OSE now models `fg`/`hn`, so stored flag values move into `system.exploration.*` and the flag is deleted
- Runs on every ready, GM-gated, with no version stamp — the module can be updated long before the system, so a one-shot would burn itself out before OSE lands
- Detects the fields per actor rather than by system version, and re-running is a no-op
- Flag value wins on conflict; at first run the system can only hold the schema initial
- Non-integer or non-positive stored values are dropped rather than written, since the field rejects them
- Corrects our Forage fallback from 2 to 1 to match the initial upstream merged
- Flag-reading stays: `module.json` sets no minimum system version, so old-system users still need it