### PR TITLE
Pin the vellum dependency to an exact version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "release": "node tools/release.mjs"
   },
   "dependencies": {
-    "@old-school-chronicle/vellum": "^0.1.0",
+    "@old-school-chronicle/vellum": "0.1.0",
     "@sentry/browser": "^10.63.0",
     "clsx": "^2.1.1",
     "foundry-vtt-react": "^0.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@old-school-chronicle/vellum':
-        specifier: ^0.1.0
+        specifier: 0.1.0
         version: 0.1.0
       '@sentry/browser':
         specifier: ^10.63.0


### PR DESCRIPTION
Pins `@old-school-chronicle/vellum` to an exact `0.1.0` instead of `^0.1.0`.

The tokens package is the styling source of truth for this repo, so a caret range means a token change can arrive through a routine install rather than a deliberate bump. A design-system update should be a visible commit here, not lockfile drift.
