### PR TITLE
Hide the sheet when the view gate flag is absent

### DIFF
--- a/src/OscSheet/app/OscSheetProvider.tsx
+++ b/src/OscSheet/app/OscSheetProvider.tsx
@@ -63,7 +63,7 @@ function OscSheetProvider({
         _setTimestampedActor(document);
         setItems([...(document.items.contents as OseItem[])]);
         setCanEdit(isEditable ?? document.isOwner ?? false);
-        setCanViewFullSheet(canViewFullSheet ?? !document.limited);
+        setCanViewFullSheet(canViewFullSheet ?? false);
       },
       200
     );

--- a/src/OscSheet/app/limitedView.test.tsx
+++ b/src/OscSheet/app/limitedView.test.tsx
@@ -115,16 +115,26 @@ describe("LIMITED ownership", () => {
     expect(hasFullSheet()).toBe(true);
   });
 
-  it("falls back to document.limited=true when the flag is absent", () => {
+  it("hides the sheet when the flag is absent and document.limited is true", () => {
     mount({ actorOver: { limited: true } });
     expect(hasLimitedSheet()).toBe(true);
     expect(hasFullSheet()).toBe(false);
   });
 
-  it("falls back to document.limited=false when the flag is absent", () => {
+  it("hides the sheet when the flag is absent and document.limited is false", () => {
     mount({ actorOver: { limited: false } });
-    expect(hasLimitedSheet()).toBe(false);
+    expect(hasLimitedSheet()).toBe(true);
+    expect(hasFullSheet()).toBe(false);
+  });
+
+  it("hides the sheet when a republished context omits the flag", () => {
+    mount({ canViewFullSheet: true });
     expect(hasFullSheet()).toBe(true);
+
+    act(() => publish({ document: makeActor(), isEditable: false }));
+
+    expect(hasLimitedSheet()).toBe(true);
+    expect(hasFullSheet()).toBe(false);
   });
 
   it("swaps to the limited view when ownership is downgraded mid-session", () => {

--- a/src/OscSheet/app/readOnlyClass.test.tsx
+++ b/src/OscSheet/app/readOnlyClass.test.tsx
@@ -59,6 +59,7 @@ function mount(actor: OSEActor, isEditable: boolean) {
         source={actor}
         contextConnector={connector}
         isEditable={isEditable}
+        canViewFullSheet
       />,
     ),
   );
@@ -86,7 +87,13 @@ describe("read-only presentation — ownership granted while the sheet is open",
     mount(makeActor(), false);
     expect(appRoot().classList.contains("is-readonly")).toBe(true);
 
-    act(() => publish({ document: makeActor(), isEditable: true }));
+    act(() =>
+      publish({
+        document: makeActor(),
+        isEditable: true,
+        canViewFullSheet: true,
+      }),
+    );
 
     expect(appRoot().classList.contains("is-readonly")).toBe(false);
   });
@@ -95,7 +102,13 @@ describe("read-only presentation — ownership granted while the sheet is open",
     mount(makeActor(), false);
     expect(editButton()).toBeUndefined();
 
-    act(() => publish({ document: makeActor(), isEditable: true }));
+    act(() =>
+      publish({
+        document: makeActor(),
+        isEditable: true,
+        canViewFullSheet: true,
+      }),
+    );
 
     expect(editButton()).toBeDefined();
   });
@@ -104,7 +117,13 @@ describe("read-only presentation — ownership granted while the sheet is open",
     mount(makeActor(), true);
     expect(appRoot().classList.contains("is-readonly")).toBe(false);
 
-    act(() => publish({ document: makeActor(), isEditable: false }));
+    act(() =>
+      publish({
+        document: makeActor(),
+        isEditable: false,
+        canViewFullSheet: true,
+      }),
+    );
 
     expect(appRoot().classList.contains("is-readonly")).toBe(true);
   });

--- a/src/OscSheet/index.tsx
+++ b/src/OscSheet/index.tsx
@@ -68,7 +68,7 @@ function OscSheetApp({
   // Seeds the provider's gate; it re-derives from every published context after.
   // Falls back to ownership when mounted outside a Foundry sheet (tests).
   const canEdit = isEditable ?? actor?.isOwner ?? false;
-  const canViewFull = canViewFullSheet ?? !actor?.limited;
+  const canViewFull = canViewFullSheet ?? false;
   return (
     <SheetErrorBoundary actor={actor}>
       <OscSheetProvider


### PR DESCRIPTION
When the sheet renders, it asks whether this user may see the whole character. If that answer was missing, the old code guessed by reading Foundry's `limited` flag — and a user with no permission at all is not flagged limited, so the guess came back "show them everything". A player who should see nothing would have seen another player's stats, inventory and spells: the leak the limited-access fix exists to close, reachable through that fix's own fallback.

Nothing leaks today — the flag is always set before render, so the fallback never runs. This removes the way back in. An absent answer now hides the sheet, matching the edit gate on the line above it.

`?? false` rather than the edit gate's `?? document.isOwner ?? false`: `isOwner` is a write signal, and using it here would hide the sheet from a legitimate observer.

Two places guessed that way, not one — the mount and the republish.
